### PR TITLE
Refactor match/map pipeline boundaries and align hardening docs

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -41,7 +41,7 @@ class MapController:
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        soup = scraper._fetch_soup(map_url)
+                        soup = scraper.fetch_soup(map_url)
                         player_obj = self.parser.parse_map(soup, map_url, map_id)
 
                         if player_obj:

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -58,7 +58,7 @@ class MatchController:
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        soup = scraper._fetch_soup(match_url)
+                        soup = scraper.fetch_soup(match_url)
                         match, map_links, demo_links = self.parser.parse_match(
                             soup, match_url
                         )

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -4,8 +4,6 @@ import datetime as dt
 import re
 
 from cs2_analytics.models.player import Player
-from cs2_analytics.queues import map_queue
-from cs2_analytics.storage.player_storage import store_players
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -13,31 +11,6 @@ logger = get_logger(__name__)
 
 class MapParser:
     """Extracts player stats from a map stats page."""
-
-    def run(self, map_soups: list[tuple[object, int | str, str]]) -> list[Player]:
-        """
-        Runs parsing logic for a list of soup objects and stores players.
-
-        Args:
-            map_soups (list): List of tuples (soup, map_id, map_url)
-
-        Returns:
-            List[Player]: All parsed player objects
-        """
-        all_players = []
-
-        for soup, map_id, map_url in map_soups:
-            try:
-                players = self.parse_map(soup, map_url, map_id)
-                store_players(players)
-                map_queue.mark_as_parsed(str(map_id))
-                logger.info("✅ Stored %s players for map %s", len(players), map_id)
-                all_players.extend(players)
-            except Exception as e:
-                map_queue.mark_as_failed(str(map_id), str(e)[:500])
-                logger.error("❌ Failed to parse map %s: %s", map_id, e)
-
-        return all_players
 
     def __init__(self):
         """Initializes the parser."""

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -1,11 +1,10 @@
-"""Scrapes HLTV map stats pages from the queue and returns soup for parsing."""
+"""Fetches raw map HTML for downstream parsing."""
 
 import time
 
 from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
-from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -13,46 +12,19 @@ logger = get_logger(__name__)
 
 class MapScraper:
     """
-    Fetches map pages from `map_scrape_queue`, returning soup objects for parsing.
+    Fetches map pages and returns soup objects for parsing.
 
-    This scraper does NOT handle parsing or saving to the database.
-    Use it with `MapParser` after fetching soups.
+    This scraper does NOT handle queue orchestration, parsing, or persistence.
     """
 
     def __init__(self) -> None:
         self.driver = Driver(uc=True, headless=True)
-        self.map_queue = MapScrapeQueue()
 
     def __enter__(self) -> "MapScraper":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
-
-    def run(self, limit: int = 25) -> list[tuple[BeautifulSoup, str, str]]:
-        """
-        Fetches queued map pages and returns soups for parsing.
-
-        Args:
-            limit (int): Maximum number of queued map pages to scrape.
-
-        Returns:
-            List of tuples: (soup, map_id, map_url)
-        """
-        queued = self.map_queue.fetch(limit=limit)
-        results = []
-
-        for map_id, map_url in queued:
-            try:
-                logger.info("🌍 Fetching map page: %s", map_url)
-                soup = self.fetch_soup(map_url)
-                results.append((soup, map_id, map_url))
-                time.sleep(1.0)
-            except Exception as e:
-                logger.error("❌ Failed to fetch map %s: %s", map_url, e)
-                self.map_queue.mark_as_failed(map_id, str(e)[:500])
-
-        return results
 
     def fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a map page and returns its parsed HTML."""
@@ -67,4 +39,4 @@ class MapScraper:
     def close(self) -> None:
         """Closes the Selenium driver."""
         self.driver.quit()
-        logger.info("🚪 Selenium driver closed.")
+        logger.info("Selenium driver closed.")

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -45,7 +45,7 @@ class MapScraper:
         for map_id, map_url in queued:
             try:
                 logger.info("🌍 Fetching map page: %s", map_url)
-                soup = self._fetch_soup(map_url)
+                soup = self.fetch_soup(map_url)
                 results.append((soup, map_id, map_url))
                 time.sleep(1.0)
             except Exception as e:
@@ -53,6 +53,10 @@ class MapScraper:
                 self.map_queue.mark_as_failed(map_id, str(e)[:500])
 
         return results
+
+    def fetch_soup(self, url: str) -> BeautifulSoup:
+        """Loads a map page and returns its parsed HTML."""
+        return self._fetch_soup(url)
 
     def _fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a map page and returns its parsed HTML."""

--- a/cs2_analytics/scrapers/match_scraper.py
+++ b/cs2_analytics/scrapers/match_scraper.py
@@ -1,11 +1,4 @@
-"""Fetches and returns raw match HTML for queued match URLs.
-
-Args:
-    limit (int): Number of matches to fetch.
-
-Returns:
-    List of (soup, match_id, match_url) for downstream parsing.
-"""
+"""Fetches raw match HTML for downstream parsing."""
 
 import time
 
@@ -19,9 +12,9 @@ logger = get_logger(__name__)
 
 class MatchScraper:
     """
-    Scrapes match pages from match_scrape_queue and returns raw soup for later parsing.
+    Scrapes match pages and returns raw soup for later parsing.
 
-    This class does NOT handle parsing or database insertion.
+    This class does NOT handle queue orchestration, parsing, or database insertion.
     """
 
     def __init__(self):
@@ -32,28 +25,6 @@ class MatchScraper:
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
-
-    def run(self, limit: int = 25) -> list[tuple[BeautifulSoup, str, str]]:
-        """
-        Fetches match pages and returns raw soup content.
-
-        Returns:
-            List of (soup, match_id, match_url) tuples for downstream parsing.
-        """
-        matches = match_queue.fetch(limit=limit)
-        result = []
-
-        for match_id, match_url in matches:
-            try:
-                logger.info("🔄 Fetching match %s", match_url)
-                soup = self.fetch_soup(match_url)
-                result.append((soup, match_id, match_url))
-                time.sleep(1.0)
-            except Exception as e:
-                logger.error("❌ Failed to fetch %s: %s", match_url, e)
-                match_queue.mark_failed(match_id, str(e)[:500])
-
-        return result
 
     def fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a match page and returns its parsed HTML."""
@@ -67,4 +38,4 @@ class MatchScraper:
     def close(self) -> None:
         """Closes the Selenium driver."""
         self.driver.quit()
-        logger.info("🚪 Selenium driver closed.")
+        logger.info("Selenium driver closed.")

--- a/cs2_analytics/scrapers/match_scraper.py
+++ b/cs2_analytics/scrapers/match_scraper.py
@@ -12,11 +12,9 @@ import time
 from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
-from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
-match_queue = MatchScrapeQueue()
 
 
 class MatchScraper:
@@ -48,7 +46,7 @@ class MatchScraper:
         for match_id, match_url in matches:
             try:
                 logger.info("🔄 Fetching match %s", match_url)
-                soup = self._fetch_soup(match_url)
+                soup = self.fetch_soup(match_url)
                 result.append((soup, match_id, match_url))
                 time.sleep(1.0)
             except Exception as e:
@@ -56,6 +54,10 @@ class MatchScraper:
                 match_queue.mark_failed(match_id, str(e)[:500])
 
         return result
+
+    def fetch_soup(self, url: str) -> BeautifulSoup:
+        """Loads a match page and returns its parsed HTML."""
+        return self._fetch_soup(url)
 
     def _fetch_soup(self, url: str) -> BeautifulSoup:
         self.driver.get(url)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -17,12 +17,16 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [x] Retry/backoff and scraper session recovery in controllers
 - [x] Map parser hidden-vs-visible metric regression fix + tests
 - [x] Storage ownership centralized for match/player writes
+- [x] Controller/parser/scraper responsibilities aligned for active match/map flow
 
 ### Remaining hardening priorities
 
 - [ ] Decide failure policy when retries are exhausted (continue stage vs fail run)
+- [ ] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [ ] Improve observability around retry exhaustion and run-level outcomes
 - [ ] Add targeted tests for controller retry and recovery behavior
+- [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
+- [ ] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
 
 ---

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -5,19 +5,25 @@
 - Fetch remote content only
 - No parsing
 - No domain-table writes
-- Queue failure/status updates are allowed when needed
+- No queue status transitions in the active controller-driven flow
 
 ## Parsers
 
 - Extract structured data only
 - No orchestration logic
-- No queue state transitions in normal flow
+- No queue state transitions
+- No storage writes
+
+## Controllers
+
+- Coordinate workflow
+- Handle queue interaction and queue status transitions
+- Call scrapers, parsers, and storage modules
 
 ## Pipelines
 
-- Coordinate workflow
-- Handle queue interaction
-- Call scrapers and parsers
+- Coordinate stage order
+- Invoke controllers rather than reaching into scraper/parser internals
 
 ## Storage
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -14,7 +14,7 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 
 ## Current Work
 
-- Closing review feedback on queue status transitions and cleanup behavior
+- Queue-status and responsibility cleanup is complete for the active match/map flow
 - Stabilizing retry/backoff and session-recovery paths
 - Keeping match/player persistence centralized in storage modules
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -12,11 +12,17 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Queues stay PostgreSQL-backed
 - Demo-related work remains deferred until ingestion hardening is stable
 
+## Recently Completed
+
+- Queue-status and responsibility cleanup for the active match/map flow
+- Match/player persistence remains centralized in storage modules
+
 ## Current Work
 
-- Queue-status and responsibility cleanup is complete for the active match/map flow
 - Stabilizing retry/backoff and session-recovery paths
-- Keeping match/player persistence centralized in storage modules
+- Deciding failure handling when retries are exhausted
+- Improving observability around retry exhaustion and run-level outcomes
+- Adding targeted tests for controller retry and recovery behavior
 
 ## Rules
 

--- a/tests/parsers/test_map_parser_manual.py
+++ b/tests/parsers/test_map_parser_manual.py
@@ -5,31 +5,31 @@ from cs2_analytics.storage.player_storage import store_players
 
 
 def main():
-    print("🧪 Starting manual test for MapParser...")
+    print("Starting manual test for MapParser...")
 
-    with MapScraper() as scraper:
-        map_soups = scraper.run(limit=1)
-
-    if not map_soups:
-        print("⚠️ No map pages in queue.")
+    queued_maps = map_queue.fetch(limit=1)
+    if not queued_maps:
+        print("No map pages in queue.")
         return
 
     parser = MapParser()
     total_players = []
 
-    for soup, map_id, map_url in map_soups:
-        players = parser.parse_map(soup, map_url, match_id=2381532)  # use real match_id
-        if players:
-            store_players(players)  # ✅ <--- THIS STORES THE DATA
-            map_queue.mark_parsed(map_id)
-            print(f"✅ Parsed {len(players)} players from {map_url}")
-            total_players.extend(players)
-        else:
-            map_queue.mark_failed(map_id, "Map parser returned empty")
-            print(f"❌ Failed to parse {map_url}")
+    with MapScraper() as scraper:
+        for map_id, map_url in queued_maps:
+            soup = scraper.fetch_soup(map_url)
+            players = parser.parse_map(soup, map_url, map_id)
+            if players:
+                store_players(players)
+                map_queue.mark_as_parsed(map_id)
+                print(f"Parsed {len(players)} players from {map_url}")
+                total_players.extend(players)
+            else:
+                map_queue.mark_as_failed(map_id, "Map parser returned empty")
+                print(f"Failed to parse {map_url}")
 
     if total_players:
-        print(f"🔍 Example Player: {total_players[0]}")
+        print(f"Example Player: {total_players[0]}")
 
 
 if __name__ == "__main__":

--- a/tests/parsers/test_map_parser_manual.py
+++ b/tests/parsers/test_map_parser_manual.py
@@ -1,3 +1,8 @@
+"""Manually tests MapParser from queued map pages.
+
+This helper bypasses controllers intentionally and is only for manual debugging.
+"""
+
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.queues import map_queue
 from cs2_analytics.scrapers.map_scraper import MapScraper

--- a/tests/scrapers/test_map_scraper_manual.py
+++ b/tests/scrapers/test_map_scraper_manual.py
@@ -1,26 +1,24 @@
-"""
-Manually tests the MapScraper by scraping map pages from the queue
-and printing confirmation of retrieved HTML content.
-"""
+"""Manually tests MapScraper by fetching queued map pages."""
 
+from cs2_analytics.queues import map_queue
 from cs2_analytics.scrapers.map_scraper import MapScraper
 
 
 def main():
     """Main test function for MapScraper."""
-    print("🧪 Starting MapScraper manual test...")
+    print("Starting MapScraper manual test...")
 
-    with MapScraper() as scraper:
-        scraped = scraper.run(limit=3)
-
-    if not scraped:
-        print("⚠️ No queued map links found. You may need to run MatchParser first.")
+    queued_maps = map_queue.fetch(limit=3)
+    if not queued_maps:
+        print("No queued map links found. You may need to run MatchParser first.")
         return
 
-    for soup, map_id, map_url in scraped:
-        print(f"✅ Scraped map {map_id} from {map_url} — Soup length: {len(soup.text)}")
+    with MapScraper() as scraper:
+        for map_id, map_url in queued_maps:
+            soup = scraper.fetch_soup(map_url)
+            print(f"Scraped map {map_id} from {map_url}. Soup length: {len(soup.text)}")
 
-    print(f"🏁 Finished scraping {len(scraped)} map(s).")
+    print(f"Finished scraping {len(queued_maps)} map(s).")
 
 
 if __name__ == "__main__":

--- a/tests/scrapers/test_map_scraper_manual.py
+++ b/tests/scrapers/test_map_scraper_manual.py
@@ -1,4 +1,7 @@
-"""Manually tests MapScraper by fetching queued map pages."""
+"""Manually tests MapScraper by fetching queued map pages.
+
+This helper bypasses controllers intentionally and is only for manual debugging.
+"""
 
 from cs2_analytics.queues import map_queue
 from cs2_analytics.scrapers.map_scraper import MapScraper

--- a/tests/scrapers/test_match_scraper.py
+++ b/tests/scrapers/test_match_scraper.py
@@ -9,7 +9,7 @@ test_match_url = "https://www.hltv.org/matches/2380400/just-swing-vs-gods-reign-
 # Bo1 map URL = https://www.hltv.org/matches/2380400/just-swing-vs-gods-reign-esl-challenger-league-season-49-asia-pacific
 
 scraper = MatchScraper()
-match_data = scraper.fetch_match_data(test_match_url)
+match_data = scraper.fetch_soup(test_match_url)
 scraper.close()
 
 # ✅ Print results

--- a/tests/scrapers/test_match_scraper_manual.py
+++ b/tests/scrapers/test_match_scraper_manual.py
@@ -1,6 +1,4 @@
-"""
-Manually tests the refactored MatchScraper by pulling soups from the queue.
-"""
+"""Manually tests MatchScraper + MatchParser integration from queued matches."""
 
 from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.queues import match_queue
@@ -10,31 +8,32 @@ from cs2_analytics.storage.match_storage import store_matches
 
 def main():
     """Main test for MatchScraper + MatchParser integration."""
-    print("🚀 Testing MatchScraper + MatchParser integration...")
+    print("Testing MatchScraper + MatchParser integration...")
 
-    with MatchScraper() as scraper:
-        match_soups = scraper.run(limit=3)
-
-    if not match_soups:
-        print("⚠️ No queued matches found. Run the results scraper first.")
+    queued_matches = match_queue.fetch(limit=3)
+    if not queued_matches:
+        print("No queued matches found. Run the results scraper first.")
         return
 
     parser = MatchParser()
     parsed_matches = []
 
-    for soup, match_id, match_url in match_soups:
-        print(f"🔍 Parsing {match_url}")
-        match = parser.parse_match(soup, match_url)
-        if match:
-            parsed_matches.append(match)
-            store_matches([match])
-            match_queue.mark_parsed(match_id)
-            print(f"✅ Stored match {match_id}")
-        else:
-            match_queue.mark_failed(match_id, "Parser returned None")
-            print(f"❌ Failed to parse match {match_id}")
+    with MatchScraper() as scraper:
+        for match_id, match_url in queued_matches:
+            print(f"Parsing {match_url}")
+            soup = scraper.fetch_soup(match_url)
+            match_obj, _, _ = parser.parse_match(soup, match_url)
 
-    print(f"🏁 Completed. Parsed: {len(parsed_matches)} matches.")
+            if match_obj:
+                parsed_matches.append(match_obj)
+                store_matches([match_obj])
+                match_queue.mark_as_parsed(match_id)
+                print(f"Stored match {match_id}")
+            else:
+                match_queue.mark_as_failed(match_id, "Parser returned None")
+                print(f"Failed to parse match {match_id}")
+
+    print(f"Completed. Parsed: {len(parsed_matches)} matches.")
 
 
 if __name__ == "__main__":

--- a/tests/scrapers/test_match_scraper_manual.py
+++ b/tests/scrapers/test_match_scraper_manual.py
@@ -1,4 +1,7 @@
-"""Manually tests MatchScraper + MatchParser integration from queued matches."""
+"""Manually tests MatchScraper + MatchParser integration from queued matches.
+
+This helper bypasses controllers intentionally and is only for manual debugging.
+"""
 
 from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.queues import match_queue


### PR DESCRIPTION
### **Summary**
This PR tightens responsibility boundaries across the active ingestion flow and updates project docs to match the current architecture.

### **What changed**
- Removed parser-side orchestration from `MapParser`
  - no storage writes
  - no queue status transitions
- Moved match/map scraper usage onto public `fetch_soup()` methods
- Removed legacy queue-driven `run()` entrypoints from the active match/map scrapers
- Updated manual helper scripts to work with the new scraper shape
- Added clear notes that manual helper scripts intentionally bypass controllers
- Updated hardening docs to reflect the current ownership model and recent progress

### **Architectural intent**
This keeps the active match/map pipeline aligned to the project conventions:
- scrapers fetch content only
- parsers extract structured data only
- controllers own orchestration, queue transitions, retries, and persistence handoff

### **Docs updated**
- `docs/conventions.md`
- `docs/current_focus.md`
- `docs/backlog.md`

### **Validation**
- Full pipeline ran successfully
- Tests passed:
  - `.\.venv\Scripts\python.exe -m pytest`

### **Follow-up work**
This PR does not change the broader error-handling model yet. Follow-up hardening items remain:
- standardize scraper/parser/storage error handling
- decide retry exhaustion failure policy
- improve observability
- add targeted controller retry/recovery tests
- centralize shared controller retry/session-recovery logic