### PR TITLE
Hardening/error handling observability

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -1,6 +1,9 @@
+"""Controller for scraping and storing map-level player data."""
+
 import time
 from contextlib import suppress
 
+from cs2_analytics.exceptions import RetryableScrapeError
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
 from cs2_analytics.scrapers.map_scraper import MapScraper
@@ -11,16 +14,18 @@ logger = get_logger("map_controller")
 
 
 class MapController:
+    """Orchestrates map scraping, parsing, and player storage."""
+
     def __init__(self) -> None:
         self.scraper = MapScraper()
         self.parser = MapParser()
         self.queue = MapScrapeQueue()
 
     def run(self, batch_size: int = 25) -> None:
-        logger.info("🕹️ Running MapController with batch size: %d", batch_size)
+        logger.info("Running MapController with batch size: %d", batch_size)
 
         queued = self.queue.fetch(batch_size)
-        logger.info("📥 %d map URLs pulled from queue", len(queued))
+        logger.info("%d map URLs pulled from queue", len(queued))
 
         rotate_every = 8
         inter_map_delay_seconds = 0.75
@@ -32,7 +37,7 @@ class MapController:
             for map_id, map_url in queued:
                 if processed_since_reset >= rotate_every:
                     logger.info(
-                        "🔁 Rotating map scraper session after %d processed maps",
+                        "Rotating map scraper session after %d processed maps",
                         processed_since_reset,
                     )
                     scraper = self._reset_scraper(scraper)
@@ -47,10 +52,10 @@ class MapController:
                         if player_obj:
                             store_players(player_obj)
                             self.queue.mark_as_parsed(map_id)
-                            logger.info("✅ Stored map: %s", map_id)
+                            logger.info("Stored map: %s", map_id)
                         else:
                             self.queue.mark_as_failed(map_id, "Parsing returned None")
-                            logger.warning("❌ Map %s returned None", map_id)
+                            logger.warning("Map %s returned no parsed data", map_id)
 
                         processed_since_reset += 1
                         time.sleep(inter_map_delay_seconds)
@@ -64,7 +69,7 @@ class MapController:
 
                         if should_retry:
                             logger.warning(
-                                "⚠️ Recoverable scraper error for map %s (attempt %d/%d): %s",
+                                "Retryable scraper error for map %s (attempt %d/%d): %s",
                                 map_id,
                                 attempt,
                                 max_attempts,
@@ -75,32 +80,28 @@ class MapController:
                             continue
 
                         self.queue.mark_as_failed(map_id, str(e)[:500])
-                        logger.exception("❌ Error processing map %s: %s", map_id, e)
+                        logger.exception(
+                            "Error processing map %s on attempt %d/%d: %s",
+                            map_id,
+                            attempt,
+                            max_attempts,
+                            e,
+                        )
                         break
         finally:
             with suppress(Exception):
                 scraper.close()
 
-        logger.info("🏁 MapController complete.")
+        logger.info("MapController complete.")
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
-        msg = str(error).lower()
-        recoverable_signatures = (
-            "connection refused",
-            "max retries exceeded",
-            "failed to establish a new connection",
-            "invalid session id",
-            "session deleted",
-            "disconnected",
-            "read timed out",
-        )
-        return any(sig in msg for sig in recoverable_signatures)
+        return isinstance(error, RetryableScrapeError)
 
     def _reset_scraper(self, scraper: MapScraper) -> MapScraper:
         try:
             scraper.close()
         except Exception as e:
-            logger.warning("⚠️ Failed to close map scraper during recovery: %s", e)
+            logger.warning("Failed to close map scraper during recovery: %s", e)
 
         self.scraper = MapScraper()
         time.sleep(1.0)

--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -35,6 +35,9 @@ class MapController:
         inter_map_delay_seconds = 0.75
         retry_backoff_seconds = 3.0
         processed_since_reset = 0
+        succeeded = 0
+        failed = 0
+        retries = 0
 
         scraper = self.scraper
         try:
@@ -56,9 +59,11 @@ class MapController:
                         if player_obj:
                             store_players(player_obj)
                             self.queue.mark_as_parsed(map_id)
+                            succeeded += 1
                             logger.info("Stored map: %s", map_id)
                         else:
                             self.queue.mark_as_failed(map_id, "Parsing returned None")
+                            failed += 1
                             logger.warning("Map %s returned no parsed data", map_id)
 
                         processed_since_reset += 1
@@ -72,6 +77,7 @@ class MapController:
                         )
 
                         if should_retry:
+                            retries += 1
                             logger.warning(
                                 "Retryable scraper error for map %s (attempt %d/%d): %s",
                                 map_id,
@@ -83,6 +89,15 @@ class MapController:
                             scraper = self._reset_scraper(scraper)
                             continue
 
+                        if (
+                            attempt == max_attempts
+                            and self._is_recoverable_scraper_error(e)
+                        ):
+                            logger.error(
+                                "Exhausted retries for map %s after %d attempts; marking failed and continuing.",
+                                map_id,
+                                max_attempts,
+                            )
                         mark_item_failed(
                             self.queue,
                             map_id,
@@ -92,11 +107,19 @@ class MapController:
                             attempt=attempt,
                             max_attempts=max_attempts,
                         )
+                        failed += 1
                         break
         finally:
             with suppress(Exception):
                 scraper.close()
 
+        logger.info(
+            "MapController summary: queued=%d succeeded=%d failed=%d retries=%d",
+            len(queued),
+            succeeded,
+            failed,
+            retries,
+        )
         logger.info("MapController complete.")
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:

--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -3,7 +3,11 @@
 import time
 from contextlib import suppress
 
-from cs2_analytics.exceptions import RetryableScrapeError
+from cs2_analytics.controllers.retry_utils import (
+    is_retryable_scraper_error,
+    mark_item_failed,
+    reset_scraper,
+)
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
 from cs2_analytics.scrapers.map_scraper import MapScraper
@@ -79,13 +83,14 @@ class MapController:
                             scraper = self._reset_scraper(scraper)
                             continue
 
-                        self.queue.mark_as_failed(map_id, str(e)[:500])
-                        logger.exception(
-                            "Error processing map %s on attempt %d/%d: %s",
+                        mark_item_failed(
+                            self.queue,
                             map_id,
-                            attempt,
-                            max_attempts,
                             e,
+                            logger=logger,
+                            log_message="Error processing map %s on attempt %d/%d: %s",
+                            attempt=attempt,
+                            max_attempts=max_attempts,
                         )
                         break
         finally:
@@ -95,14 +100,14 @@ class MapController:
         logger.info("MapController complete.")
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
-        return isinstance(error, RetryableScrapeError)
+        return is_retryable_scraper_error(error)
 
     def _reset_scraper(self, scraper: MapScraper) -> MapScraper:
-        try:
-            scraper.close()
-        except Exception as e:
-            logger.warning("Failed to close map scraper during recovery: %s", e)
-
-        self.scraper = MapScraper()
-        time.sleep(1.0)
+        self.scraper = reset_scraper(
+            scraper,
+            MapScraper,
+            logger=logger,
+            close_warning_message="Failed to close map scraper during recovery: %s",
+            startup_delay_seconds=1.0,
+        )
         return self.scraper

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -41,6 +41,9 @@ class MatchController:
         retry_backoff_seconds = 3.0
         processed_since_reset = 0
         consecutive_recoverable_errors = 0
+        succeeded = 0
+        failed = 0
+        retries = 0
 
         scraper = self.scraper
         try:
@@ -65,11 +68,13 @@ class MatchController:
                             store_matches([match])
                             self._queue_followups(map_links, demo_links)
                             self.match_queue.mark_as_parsed(match_id)
+                            succeeded += 1
                             logger.info("Stored match: %s", match_id)
                         else:
                             self.match_queue.mark_as_failed(
                                 match_id, "Parsing returned None"
                             )
+                            failed += 1
                             logger.warning("Match %s returned no parsed data", match_id)
 
                         consecutive_recoverable_errors = 0
@@ -84,6 +89,7 @@ class MatchController:
                         )
 
                         if should_retry:
+                            retries += 1
                             consecutive_recoverable_errors += 1
                             logger.warning(
                                 "Retryable scraper error for match %s (attempt %d/%d): %s",
@@ -104,6 +110,15 @@ class MatchController:
                             scraper = self._reset_scraper(scraper)
                             continue
 
+                        if (
+                            attempt == max_attempts
+                            and self._is_recoverable_scraper_error(e)
+                        ):
+                            logger.error(
+                                "Exhausted retries for match %s after %d attempts; marking failed and continuing.",
+                                match_id,
+                                max_attempts,
+                            )
                         mark_item_failed(
                             self.match_queue,
                             match_id,
@@ -115,12 +130,20 @@ class MatchController:
                             attempt=attempt,
                             max_attempts=max_attempts,
                         )
+                        failed += 1
                         consecutive_recoverable_errors = 0
                         break
         finally:
             with suppress(Exception):
                 scraper.close()
 
+        logger.info(
+            "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d",
+            len(queued),
+            succeeded,
+            failed,
+            retries,
+        )
         logger.info("MatchController complete.")
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -1,8 +1,9 @@
-"""This module contains the MatchController class, which orchestrates the scraping and parsing of match data."""
+"""Controller for scraping and storing match-level data."""
 
 import time
 from contextlib import suppress
 
+from cs2_analytics.exceptions import RetryableScrapeError
 from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
@@ -15,8 +16,7 @@ logger = get_logger("match_controller")
 
 
 class MatchController:
-    """
-    MatchController orchestrates the scraping and parsing of match data."""
+    """Orchestrates match scraping, parsing, queueing, and storage."""
 
     def __init__(self) -> None:
         self.scraper = MatchScraper()
@@ -26,18 +26,12 @@ class MatchController:
         self.demo_queue = DemoScrapeQueue()
 
     def run(self, batch_size: int = 25) -> None:
-        """
-        Main method to run the MatchController.
-
-        Args:
-            batch_size (int): Number of matches to process in each batch.
-        """
-        logger.info("🕹️ Running MatchController with batch size: %d", batch_size)
+        """Runs the match stage for a batch of queued match URLs."""
+        logger.info("Running MatchController with batch size: %d", batch_size)
 
         queued = self.match_queue.fetch(limit=batch_size)
-        logger.info("📥 %d matches pulled from queue", len(queued))
+        logger.info("%d matches pulled from queue", len(queued))
 
-        # Refresh browser session before it reaches the observed instability window.
         rotate_every = 8
         inter_match_delay_seconds = 1.1
         retry_backoff_seconds = 3.0
@@ -49,7 +43,7 @@ class MatchController:
             for match_id, match_url in queued:
                 if processed_since_reset >= rotate_every:
                     logger.info(
-                        "🔁 Rotating scraper session after %d processed matches",
+                        "Rotating scraper session after %d processed matches",
                         processed_since_reset,
                     )
                     scraper = self._reset_scraper(scraper)
@@ -67,12 +61,12 @@ class MatchController:
                             store_matches([match])
                             self._queue_followups(map_links, demo_links)
                             self.match_queue.mark_as_parsed(match_id)
-                            logger.info("✅ Stored match: %s", match_id)
+                            logger.info("Stored match: %s", match_id)
                         else:
                             self.match_queue.mark_as_failed(
                                 match_id, "Parsing returned None"
                             )
-                            logger.warning("❌ Match %s returned None", match_id)
+                            logger.warning("Match %s returned no parsed data", match_id)
 
                         consecutive_recoverable_errors = 0
                         processed_since_reset += 1
@@ -88,7 +82,7 @@ class MatchController:
                         if should_retry:
                             consecutive_recoverable_errors += 1
                             logger.warning(
-                                "⚠️ Recoverable scraper error for match %s (attempt %d/%d): %s",
+                                "Retryable scraper error for match %s (attempt %d/%d): %s",
                                 match_id,
                                 attempt,
                                 max_attempts,
@@ -97,7 +91,7 @@ class MatchController:
 
                             if consecutive_recoverable_errors >= 2:
                                 logger.info(
-                                    "🧊 Applying cooldown after %d consecutive recoverable errors",
+                                    "Applying cooldown after %d consecutive recoverable errors",
                                     consecutive_recoverable_errors,
                                 )
                                 time.sleep(8.0)
@@ -108,7 +102,11 @@ class MatchController:
 
                         self.match_queue.mark_as_failed(match_id, str(e)[:500])
                         logger.exception(
-                            "❌ Error processing match %s: %s", match_id, e
+                            "Error processing match %s on attempt %d/%d: %s",
+                            match_id,
+                            attempt,
+                            max_attempts,
+                            e,
                         )
                         consecutive_recoverable_errors = 0
                         break
@@ -116,44 +114,33 @@ class MatchController:
             with suppress(Exception):
                 scraper.close()
 
-        logger.info("🏁 MatchController complete.")
+        logger.info("MatchController complete.")
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
-        """Returns True for transient Selenium/session failures worth retrying once."""
-        msg = str(error).lower()
-        recoverable_signatures = (
-            "connection refused",
-            "max retries exceeded",
-            "failed to establish a new connection",
-            "invalid session id",
-            "session deleted",
-            "disconnected",
-            "read timed out",
-        )
-        return any(sig in msg for sig in recoverable_signatures)
+        """Returns True for transient scraper failures worth retrying."""
+        return isinstance(error, RetryableScrapeError)
 
     def _reset_scraper(self, scraper: MatchScraper) -> MatchScraper:
         """Closes and recreates the scraper so the next attempt gets a fresh session."""
         try:
             scraper.close()
         except Exception as e:
-            logger.warning("⚠️ Failed to close scraper during recovery: %s", e)
+            logger.warning("Failed to close scraper during recovery: %s", e)
 
         for reset_attempt in range(1, 4):
             self.scraper = MatchScraper()
-            # Give the new browser session a brief moment to fully initialize.
             time.sleep(1.5)
 
             if self._is_scraper_session_ready(self.scraper):
                 if reset_attempt > 1:
                     logger.info(
-                        "✅ Scraper session recovered on reset attempt %d",
+                        "Scraper session recovered on reset attempt %d",
                         reset_attempt,
                     )
                 return self.scraper
 
             logger.warning(
-                "⚠️ New scraper session not ready on reset attempt %d/3; retrying reset",
+                "New scraper session not ready on reset attempt %d/3; retrying reset",
                 reset_attempt,
             )
             with suppress(Exception):
@@ -161,7 +148,7 @@ class MatchController:
             time.sleep(1.0)
 
         logger.warning(
-            "⚠️ Returning scraper after reset retries; first request may still require retry"
+            "Returning scraper after reset retries; first request may still require retry"
         )
         self.scraper = MatchScraper()
         time.sleep(1.5)
@@ -174,7 +161,7 @@ class MatchController:
             _ = scraper.driver.page_source
             return True
         except Exception as e:
-            logger.warning("⚠️ Scraper session health check failed: %s", e)
+            logger.warning("Scraper session health check failed: %s", e)
             return False
 
     def _queue_followups(

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -3,7 +3,11 @@
 import time
 from contextlib import suppress
 
-from cs2_analytics.exceptions import RetryableScrapeError
+from cs2_analytics.controllers.retry_utils import (
+    is_retryable_scraper_error,
+    mark_item_failed,
+    reset_scraper,
+)
 from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
@@ -100,13 +104,16 @@ class MatchController:
                             scraper = self._reset_scraper(scraper)
                             continue
 
-                        self.match_queue.mark_as_failed(match_id, str(e)[:500])
-                        logger.exception(
-                            "Error processing match %s on attempt %d/%d: %s",
+                        mark_item_failed(
+                            self.match_queue,
                             match_id,
-                            attempt,
-                            max_attempts,
                             e,
+                            logger=logger,
+                            log_message=(
+                                "Error processing match %s on attempt %d/%d: %s"
+                            ),
+                            attempt=attempt,
+                            max_attempts=max_attempts,
                         )
                         consecutive_recoverable_errors = 0
                         break
@@ -118,40 +125,28 @@ class MatchController:
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         """Returns True for transient scraper failures worth retrying."""
-        return isinstance(error, RetryableScrapeError)
+        return is_retryable_scraper_error(error)
 
     def _reset_scraper(self, scraper: MatchScraper) -> MatchScraper:
         """Closes and recreates the scraper so the next attempt gets a fresh session."""
-        try:
-            scraper.close()
-        except Exception as e:
-            logger.warning("Failed to close scraper during recovery: %s", e)
-
-        for reset_attempt in range(1, 4):
-            self.scraper = MatchScraper()
-            time.sleep(1.5)
-
-            if self._is_scraper_session_ready(self.scraper):
-                if reset_attempt > 1:
-                    logger.info(
-                        "Scraper session recovered on reset attempt %d",
-                        reset_attempt,
-                    )
-                return self.scraper
-
-            logger.warning(
-                "New scraper session not ready on reset attempt %d/3; retrying reset",
-                reset_attempt,
-            )
-            with suppress(Exception):
-                self.scraper.close()
-            time.sleep(1.0)
-
-        logger.warning(
-            "Returning scraper after reset retries; first request may still require retry"
+        self.scraper = reset_scraper(
+            scraper,
+            MatchScraper,
+            logger=logger,
+            close_warning_message="Failed to close scraper during recovery: %s",
+            startup_delay_seconds=1.5,
+            health_check=self._is_scraper_session_ready,
+            max_reset_attempts=3,
+            between_attempt_delay_seconds=1.0,
+            recovery_success_message="Scraper session recovered on reset attempt %d",
+            not_ready_warning_message=(
+                "New scraper session not ready on reset attempt %d/%d; retrying reset"
+            ),
+            fallback_warning_message=(
+                "Returning scraper after reset retries; first request may still require retry"
+            ),
+            fallback_delay_seconds=1.5,
         )
-        self.scraper = MatchScraper()
-        time.sleep(1.5)
         return self.scraper
 
     def _is_scraper_session_ready(self, scraper: MatchScraper) -> bool:

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -25,11 +25,15 @@ class ResultsController:
 
         max_attempts = 3
         scraper = self.scraper
+        retries = 0
+        terminal_failures = 0
+        run_status = "failed"
 
         try:
             for attempt in range(1, max_attempts + 1):
                 try:
                     scraper.run(max_matches=max_matches)
+                    run_status = "succeeded"
                     logger.info("ResultsController complete.")
                     return
                 except Exception as e:
@@ -39,6 +43,7 @@ class ResultsController:
                     )
 
                     if should_retry:
+                        retries += 1
                         logger.warning(
                             "Retryable results scraper error (attempt %d/%d): %s",
                             attempt,
@@ -49,6 +54,12 @@ class ResultsController:
                         scraper = self._reset_scraper(scraper)
                         continue
 
+                    terminal_failures += 1
+                    if self._is_recoverable_scraper_error(e):
+                        logger.error(
+                            "ResultsController exhausted retries after %d attempts; failing stage run.",
+                            max_attempts,
+                        )
                     logger.exception(
                         "ResultsController failed on attempt %d/%d: %s",
                         attempt,
@@ -63,6 +74,13 @@ class ResultsController:
                 scraper.close()
             except Exception as e:
                 logger.warning("Failed to close results scraper: %s", e)
+            logger.info(
+                "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d",
+                run_status,
+                retries,
+                terminal_failures,
+                max_matches,
+            )
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         return is_retryable_scraper_error(error)

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -37,10 +37,8 @@ class ResultsController:
                     logger.info("ResultsController complete.")
                     return
                 except Exception as e:
-                    should_retry = (
-                        attempt < max_attempts
-                        and self._is_recoverable_scraper_error(e)
-                    )
+                    is_retryable = self._is_recoverable_scraper_error(e)
+                    should_retry = attempt < max_attempts and is_retryable
 
                     if should_retry:
                         retries += 1
@@ -55,10 +53,19 @@ class ResultsController:
                         continue
 
                     terminal_failures += 1
-                    if self._is_recoverable_scraper_error(e):
+                    if is_retryable:
                         logger.error(
                             "ResultsController exhausted retries after %d attempts; failing stage run.",
                             max_attempts,
+                        )
+                        failure_message = (
+                            "Results stage failed after exhausting retries "
+                            f"({attempt}/{max_attempts} attempts)."
+                        )
+                    else:
+                        failure_message = (
+                            "Results stage failed on non-retryable error "
+                            f"at attempt {attempt}/{max_attempts}."
                         )
                     logger.exception(
                         "ResultsController failed on attempt %d/%d: %s",
@@ -66,9 +73,7 @@ class ResultsController:
                         max_attempts,
                         e,
                     )
-                    raise PipelineError(
-                        "Results stage failed after exhausting retries."
-                    ) from e
+                    raise PipelineError(failure_message) from e
         finally:
             try:
                 scraper.close()

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -2,7 +2,10 @@
 
 import time
 
-from cs2_analytics.exceptions import RetryableScrapeError
+from cs2_analytics.controllers.retry_utils import (
+    is_retryable_scraper_error,
+    reset_scraper,
+)
 from cs2_analytics.scrapers.results_scraper import ResultsScraper
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -59,14 +62,14 @@ class ResultsController:
                 logger.warning("Failed to close results scraper: %s", e)
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
-        return isinstance(error, RetryableScrapeError)
+        return is_retryable_scraper_error(error)
 
     def _reset_scraper(self, scraper: ResultsScraper) -> ResultsScraper:
-        try:
-            scraper.close()
-        except Exception as e:
-            logger.warning("Failed to close results scraper during recovery: %s", e)
-
-        self.scraper = ResultsScraper()
-        time.sleep(1.0)
+        self.scraper = reset_scraper(
+            scraper,
+            ResultsScraper,
+            logger=logger,
+            close_warning_message="Failed to close results scraper during recovery: %s",
+            startup_delay_seconds=1.0,
+        )
         return self.scraper

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -2,6 +2,7 @@
 
 import time
 
+from cs2_analytics.exceptions import RetryableScrapeError
 from cs2_analytics.scrapers.results_scraper import ResultsScraper
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -16,7 +17,7 @@ class ResultsController:
 
     def run(self, max_matches: int = 50) -> None:
         """Scrapes result pages and queues match URLs for downstream stages."""
-        logger.info("🕹️ Running ResultsController with max_matches=%d", max_matches)
+        logger.info("Running ResultsController with max_matches=%d", max_matches)
 
         max_attempts = 3
         scraper = self.scraper
@@ -25,16 +26,17 @@ class ResultsController:
             for attempt in range(1, max_attempts + 1):
                 try:
                     scraper.run(max_matches=max_matches)
-                    logger.info("🏁 ResultsController complete.")
+                    logger.info("ResultsController complete.")
                     return
                 except Exception as e:
                     should_retry = (
-                        attempt < max_attempts and self._is_recoverable_scraper_error(e)
+                        attempt < max_attempts
+                        and self._is_recoverable_scraper_error(e)
                     )
 
                     if should_retry:
                         logger.warning(
-                            "⚠️ Recoverable results scraper error (attempt %d/%d): %s",
+                            "Retryable results scraper error (attempt %d/%d): %s",
                             attempt,
                             max_attempts,
                             e,
@@ -43,32 +45,27 @@ class ResultsController:
                         scraper = self._reset_scraper(scraper)
                         continue
 
-                    logger.exception("❌ ResultsController failed: %s", e)
+                    logger.exception(
+                        "ResultsController failed on attempt %d/%d: %s",
+                        attempt,
+                        max_attempts,
+                        e,
+                    )
                     return
         finally:
             try:
                 scraper.close()
             except Exception as e:
-                logger.warning("⚠️ Failed to close results scraper: %s", e)
+                logger.warning("Failed to close results scraper: %s", e)
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
-        msg = str(error).lower()
-        recoverable_signatures = (
-            "connection refused",
-            "max retries exceeded",
-            "failed to establish a new connection",
-            "invalid session id",
-            "session deleted",
-            "disconnected",
-            "read timed out",
-        )
-        return any(sig in msg for sig in recoverable_signatures)
+        return isinstance(error, RetryableScrapeError)
 
     def _reset_scraper(self, scraper: ResultsScraper) -> ResultsScraper:
         try:
             scraper.close()
         except Exception as e:
-            logger.warning("⚠️ Failed to close results scraper during recovery: %s", e)
+            logger.warning("Failed to close results scraper during recovery: %s", e)
 
         self.scraper = ResultsScraper()
         time.sleep(1.0)

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -6,6 +6,7 @@ from cs2_analytics.controllers.retry_utils import (
     is_retryable_scraper_error,
     reset_scraper,
 )
+from cs2_analytics.exceptions import PipelineError
 from cs2_analytics.scrapers.results_scraper import ResultsScraper
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -54,7 +55,9 @@ class ResultsController:
                         max_attempts,
                         e,
                     )
-                    return
+                    raise PipelineError(
+                        "Results stage failed after exhausting retries."
+                    ) from e
         finally:
             try:
                 scraper.close()

--- a/cs2_analytics/controllers/retry_utils.py
+++ b/cs2_analytics/controllers/retry_utils.py
@@ -1,0 +1,84 @@
+"""Shared retry and recovery helpers for controller orchestration."""
+
+from collections.abc import Callable
+from contextlib import suppress
+import time
+from typing import TypeVar
+
+from cs2_analytics.exceptions import RetryableScrapeError
+
+ScraperT = TypeVar("ScraperT")
+
+
+def is_retryable_scraper_error(error: Exception) -> bool:
+    """Returns True when a scrape failure should trigger controller retry logic."""
+    return isinstance(error, RetryableScrapeError)
+
+
+def reset_scraper(
+    scraper: ScraperT,
+    scraper_factory: Callable[[], ScraperT],
+    *,
+    logger,
+    close_warning_message: str,
+    startup_delay_seconds: float = 1.0,
+    health_check: Callable[[ScraperT], bool] | None = None,
+    max_reset_attempts: int = 1,
+    between_attempt_delay_seconds: float = 1.0,
+    recovery_success_message: str | None = None,
+    not_ready_warning_message: str | None = None,
+    fallback_warning_message: str | None = None,
+    fallback_delay_seconds: float | None = None,
+) -> ScraperT:
+    """Closes and recreates a scraper, optionally retrying until a health check passes."""
+    try:
+        scraper.close()
+    except Exception as e:
+        logger.warning(close_warning_message, e)
+
+    attempt_total = max(1, max_reset_attempts)
+
+    for reset_attempt in range(1, attempt_total + 1):
+        new_scraper = scraper_factory()
+        time.sleep(startup_delay_seconds)
+
+        if health_check is None or health_check(new_scraper):
+            if recovery_success_message and reset_attempt > 1:
+                logger.info(recovery_success_message, reset_attempt)
+            return new_scraper
+
+        if not_ready_warning_message:
+            logger.warning(not_ready_warning_message, reset_attempt, attempt_total)
+
+        with suppress(Exception):
+            new_scraper.close()
+
+        if reset_attempt < attempt_total:
+            time.sleep(between_attempt_delay_seconds)
+
+    if fallback_warning_message:
+        logger.warning(fallback_warning_message)
+
+    fallback_scraper = scraper_factory()
+    time.sleep(
+        startup_delay_seconds
+        if fallback_delay_seconds is None
+        else fallback_delay_seconds
+    )
+    return fallback_scraper
+
+
+def mark_item_failed(
+    queue,
+    item_id: str,
+    error: Exception,
+    *,
+    logger,
+    log_message: str,
+    attempt: int,
+    max_attempts: int,
+    reason_limit: int = 500,
+) -> None:
+    """Marks a queued item failed, then logs the terminal controller exception."""
+    queue.mark_as_failed(item_id, str(error)[:reason_limit])
+    logger.exception(log_message, item_id, attempt, max_attempts, error)

--- a/cs2_analytics/exceptions.py
+++ b/cs2_analytics/exceptions.py
@@ -45,6 +45,10 @@ class MapScrapeError(ScrapeError):
     """Raised when map HTML cannot be fetched."""
 
 
+class DemoScrapeError(ScrapeError):
+    """Raised when demo archives cannot be downloaded or extracted."""
+
+
 class StorageError(CS2AnalyticsError):
     """Base exception for persistence failures."""
 
@@ -69,6 +73,10 @@ class PlayerStorageError(StorageError):
     """Raised when player records cannot be stored."""
 
 
+class DemoStorageError(StorageError):
+    """Raised when demo records cannot be stored."""
+
+
 class QueueError(CS2AnalyticsError):
     """Base exception for queue operation failures."""
 
@@ -87,3 +95,7 @@ class DemoQueueError(QueueError):
 
 class PipelineError(CS2AnalyticsError):
     """Base exception for pipeline orchestration failures."""
+
+
+class AnalyticsProcessingError(PipelineError):
+    """Raised when analytics processing cannot complete."""

--- a/cs2_analytics/exceptions.py
+++ b/cs2_analytics/exceptions.py
@@ -1,0 +1,89 @@
+"""Shared exception hierarchy for CS2 Analytics."""
+
+
+class CS2AnalyticsError(Exception):
+    """Base exception for application-specific failures."""
+
+
+class ParseError(CS2AnalyticsError):
+    """Base exception for parsing failures."""
+
+
+class MatchParseError(ParseError):
+    """Raised when a match page cannot be parsed."""
+
+
+class MapParseError(ParseError):
+    """Raised when a map stats page cannot be parsed."""
+
+
+class DemoParseError(ParseError):
+    """Raised when a demo file cannot be parsed."""
+
+
+class ScrapeError(CS2AnalyticsError):
+    """Base exception for scraping failures."""
+
+
+class RetryableScrapeError(ScrapeError):
+    """Raised for scrape failures that should be retried."""
+
+
+class SessionScrapeError(RetryableScrapeError):
+    """Raised for transient browser/session failures."""
+
+
+class ResultsScrapeError(ScrapeError):
+    """Raised when the results stage cannot scrape match discovery data."""
+
+
+class MatchScrapeError(ScrapeError):
+    """Raised when match HTML cannot be fetched."""
+
+
+class MapScrapeError(ScrapeError):
+    """Raised when map HTML cannot be fetched."""
+
+
+class StorageError(CS2AnalyticsError):
+    """Base exception for persistence failures."""
+
+
+class DatabaseError(StorageError):
+    """Base exception for database connection and operation failures."""
+
+
+class DatabaseConnectionError(DatabaseError):
+    """Raised when a database connection cannot be established or acquired."""
+
+
+class DatabaseOperationError(DatabaseError):
+    """Raised when a database operation fails."""
+
+
+class MatchStorageError(StorageError):
+    """Raised when match records cannot be stored."""
+
+
+class PlayerStorageError(StorageError):
+    """Raised when player records cannot be stored."""
+
+
+class QueueError(CS2AnalyticsError):
+    """Base exception for queue operation failures."""
+
+
+class MatchQueueError(QueueError):
+    """Raised when match queue operations fail."""
+
+
+class MapQueueError(QueueError):
+    """Raised when map queue operations fail."""
+
+
+class DemoQueueError(QueueError):
+    """Raised when demo queue operations fail."""
+
+
+class PipelineError(CS2AnalyticsError):
+    """Base exception for pipeline orchestration failures."""

--- a/cs2_analytics/parsers/demo_parser.py
+++ b/cs2_analytics/parsers/demo_parser.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from cs2_analytics.exceptions import DemoParseError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -36,8 +37,10 @@ class DemoParser:
                 parsed_data = self._parse_demo_file(demo_path)
                 self._save_parsed_data(demo_file, parsed_data)
                 logger.info(f"✅ Successfully parsed {demo_file}.")
+            except DemoParseError:
+                raise
             except Exception as e:
-                raise ValueError(f"Failed to parse demo file: {demo_file}") from e
+                raise DemoParseError(f"Failed to parse demo file: {demo_file}") from e
 
     def _parse_demo_file(
         self, demo_path: str

--- a/cs2_analytics/parsers/demo_parser.py
+++ b/cs2_analytics/parsers/demo_parser.py
@@ -37,7 +37,7 @@ class DemoParser:
                 self._save_parsed_data(demo_file, parsed_data)
                 logger.info(f"✅ Successfully parsed {demo_file}.")
             except Exception as e:
-                logger.error(f"❌ Error parsing {demo_file}: {e}")
+                raise ValueError(f"Failed to parse demo file: {demo_file}") from e
 
     def _parse_demo_file(
         self, demo_path: str
@@ -123,3 +123,4 @@ class DemoParser:
                 f.write("Simulated demo content.")  # Placeholder content
 
             logger.info(f"✅ Downloaded: {demo_file}")
+

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import re
 
+from cs2_analytics.exceptions import MapParseError
 from cs2_analytics.models.player import Player
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -40,6 +41,8 @@ class MapParser:
             tables = soup.select("table.stats-table.totalstats")
             if not tables:
                 tables = soup.select("table.stats-table")
+            if not tables:
+                raise MapParseError("No player stats tables found on map page.")
             for table in tables:
                 table_classes = table.get("class", [])
                 if "hidden" in table_classes:
@@ -98,10 +101,13 @@ class MapParser:
                     )
 
                     # Parse K(hs) format from column 5: "19(10)" -> kills=19, headshots=10
-                    kills_text = self._row_metric_text(
-                        cols,
-                        kills_idx,
-                        ["st-kills"],
+                    kills_text = self._require_metric_text(
+                        self._row_metric_text(
+                            cols,
+                            kills_idx,
+                            ["st-kills"],
+                        ),
+                        "No player kills logged.",
                     )
                     kills, headshots = self._parse_pair(kills_text)
 
@@ -114,10 +120,13 @@ class MapParser:
                     assists, flash_assists = self._parse_pair(assists_text)
 
                     # Parse D(t) format from table: "16(5)" -> deaths=16, traded_deaths=5
-                    deaths_text = self._row_metric_text(
-                        cols,
-                        deaths_idx,
-                        ["st-deaths"],
+                    deaths_text = self._require_metric_text(
+                        self._row_metric_text(
+                            cols,
+                            deaths_idx,
+                            ["st-deaths"],
+                        ),
+                        "No player deaths logged.",
                     )
                     deaths, traded_deaths = self._parse_pair(deaths_text)
 
@@ -228,8 +237,10 @@ class MapParser:
                     logger.debug("Extracted stats for player: %s", player.player_name)
                     players.append(player)
 
+        except MapParseError:
+            raise
         except Exception as e:
-            raise ValueError(f"Failed to extract player stats from {map_url}") from e
+            raise MapParseError(f"Failed to parse map stats page: {map_url}") from e
 
         logger.info("Extracted %s player stats from %s", len(players), map_url)
         return players
@@ -316,6 +327,12 @@ class MapParser:
         if single:
             return int(single.group(1)), 0
         return 0, 0
+
+    def _require_metric_text(self, text: str, message: str) -> str:
+        """Raises a parsing error when a required metric cell is missing."""
+        if text:
+            return text
+        raise MapParseError(message)
 
     def _extract_numeric_id(self, url: str) -> int:
         match = re.search(r"/(\d+)/", url)

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -86,9 +86,8 @@ class MapParser:
                             if name_tag and "href" in name_tag.attrs
                             else None
                         )
-                    except Exception as e:
+                    except Exception:
                         player_url = None
-                        logger.error("Failed to extract player URL: %s", e)
 
                     player_id = (
                         self._extract_numeric_id(player_url) if player_url else -1
@@ -230,7 +229,7 @@ class MapParser:
                     players.append(player)
 
         except Exception as e:
-            logger.error("Failed to extract player stats from %s: %s", map_url, e)
+            raise ValueError(f"Failed to extract player stats from {map_url}") from e
 
         logger.info("Extracted %s player stats from %s", len(players), map_url)
         return players

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -95,8 +95,7 @@ class MatchParser:
             return match_obj, map_links, demo_links
 
         except (AttributeError, ValueError, TypeError, KeyError) as e:
-            logger.error("Error extracting match info: %s", e)
-            return None, [], []
+            raise ValueError(f"Failed to parse match page: {match_url}") from e
 
     def _extract_teams(self, soup) -> tuple[str, str]:
         """Extracts team names from the match page."""
@@ -104,8 +103,7 @@ class MatchParser:
         try:
             team1, team2 = [t.text.strip() for t in team_names[0:2]]
         except ValueError as e:
-            logger.error("Error extracting team names: %s", e)
-            return None, None
+            raise ValueError("Failed to extract team names from match page") from e
         return team1, team2
 
     def _extract_demo_links(self, soup) -> list[tuple[str, str]]:
@@ -119,7 +117,7 @@ class MatchParser:
                 demo_links.append((demo_id, url))
             logger.info("Successfully found %s demo link(s).", len(demo_links))
         except (AttributeError, IndexError) as e:
-            logger.error("Error extracting demo link: %s", e)
+            raise ValueError("Failed to extract demo links from match page") from e
         return demo_links
 
     def _extract_map_stats_links(self, soup) -> list[tuple[str, str]]:
@@ -134,7 +132,7 @@ class MatchParser:
                     map_links.append((map_id, url))
             logger.info("Found %s map stats links.", len(map_links))
         except (AttributeError, IndexError) as e:
-            logger.error("Error extracting map stats links: %s", e)
+            raise ValueError("Failed to extract map links from match page") from e
         return map_links
 
     def _extract_id(self, url: str) -> str:

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import re
 
+from cs2_analytics.exceptions import MatchParseError
 from cs2_analytics.models.match import Match
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -94,8 +95,10 @@ class MatchParser:
 
             return match_obj, map_links, demo_links
 
+        except MatchParseError:
+            raise
         except (AttributeError, ValueError, TypeError, KeyError) as e:
-            raise ValueError(f"Failed to parse match page: {match_url}") from e
+            raise MatchParseError(f"Failed to parse match page: {match_url}") from e
 
     def _extract_teams(self, soup) -> tuple[str, str]:
         """Extracts team names from the match page."""
@@ -103,7 +106,7 @@ class MatchParser:
         try:
             team1, team2 = [t.text.strip() for t in team_names[0:2]]
         except ValueError as e:
-            raise ValueError("Failed to extract team names from match page") from e
+            raise MatchParseError("Missing team names on match page.") from e
         return team1, team2
 
     def _extract_demo_links(self, soup) -> list[tuple[str, str]]:
@@ -117,7 +120,7 @@ class MatchParser:
                 demo_links.append((demo_id, url))
             logger.info("Successfully found %s demo link(s).", len(demo_links))
         except (AttributeError, IndexError) as e:
-            raise ValueError("Failed to extract demo links from match page") from e
+            raise MatchParseError("Invalid demo link markup on match page.") from e
         return demo_links
 
     def _extract_map_stats_links(self, soup) -> list[tuple[str, str]]:
@@ -132,7 +135,7 @@ class MatchParser:
                     map_links.append((map_id, url))
             logger.info("Found %s map stats links.", len(map_links))
         except (AttributeError, IndexError) as e:
-            raise ValueError("Failed to extract map links from match page") from e
+            raise MatchParseError("Invalid map link markup on match page.") from e
         return map_links
 
     def _extract_id(self, url: str) -> str:

--- a/cs2_analytics/queues/base_scrape_queue.py
+++ b/cs2_analytics/queues/base_scrape_queue.py
@@ -65,12 +65,9 @@ class BaseScrapeQueue:
             for item_id, url in items
         ]
 
-        try:
-            with db.get_cursor() as cur:
-                cur.executemany(query, values)
-                logger.info("📥 Queued %d items in %s", len(items), self.table_name)
-        except Exception as e:
-            logger.error("❌ Failed to queue batch in %s: %s", self.table_name, e)
+        with db.get_cursor() as cur:
+            cur.executemany(query, values)
+            logger.info("Queued %d items in %s", len(items), self.table_name)
 
     def mark_as_parsed(self, id_value: str) -> None:
         """Marks the item as successfully processed."""
@@ -91,3 +88,4 @@ class BaseScrapeQueue:
         """
         with db.get_cursor() as cur:
             cur.execute(query, (dt.datetime.now(), reason, id_value))
+

--- a/cs2_analytics/queues/base_scrape_queue.py
+++ b/cs2_analytics/queues/base_scrape_queue.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 
+from cs2_analytics.exceptions import QueueError
 from cs2_analytics.storage.db_instance import db
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -17,10 +18,17 @@ class BaseScrapeQueue:
     - url_field: the URL field name (e.g. match_url, map_url, demo_url)
     """
 
-    def __init__(self, table_name: str, id_field: str, url_field: str):
+    def __init__(
+        self,
+        table_name: str,
+        id_field: str,
+        url_field: str,
+        error_cls: type[QueueError] = QueueError,
+    ):
         self.table_name = table_name
         self.id_field = id_field
         self.url_field = url_field
+        self.error_cls = error_cls
 
     def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
         """Fetches items with status='queued' from the queue."""
@@ -31,9 +39,14 @@ class BaseScrapeQueue:
         ORDER BY last_inserted_at ASC
         LIMIT %s;
         """
-        with db.get_cursor() as cur:
-            cur.execute(query, (limit,))
-            return cur.fetchall()
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(query, (limit,))
+                return cur.fetchall()
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to fetch queued items from {self.table_name}."
+            ) from e
 
     def queue(
         self, id_value: str, url: str, source: str = "unknown", priority: int = 0
@@ -44,8 +57,13 @@ class BaseScrapeQueue:
         VALUES (%s, %s, 'queued', %s, %s, %s)
         ON CONFLICT ({self.id_field}) DO NOTHING;
         """
-        with db.get_cursor() as cur:
-            cur.execute(query, (id_value, url, source, priority, dt.datetime.now()))
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(
+                    query, (id_value, url, source, priority, dt.datetime.now())
+                )
+        except Exception as e:
+            raise self.error_cls(f"Failed to queue item in {self.table_name}.") from e
 
     def queue_many(
         self, items: list[tuple[str, str]], source: str = "unknown", priority: int = 0
@@ -65,9 +83,12 @@ class BaseScrapeQueue:
             for item_id, url in items
         ]
 
-        with db.get_cursor() as cur:
-            cur.executemany(query, values)
-            logger.info("Queued %d items in %s", len(items), self.table_name)
+        try:
+            with db.get_cursor() as cur:
+                cur.executemany(query, values)
+                logger.info("Queued %d items in %s", len(items), self.table_name)
+        except Exception as e:
+            raise self.error_cls(f"Failed to queue items in {self.table_name}.") from e
 
     def mark_as_parsed(self, id_value: str) -> None:
         """Marks the item as successfully processed."""
@@ -76,8 +97,13 @@ class BaseScrapeQueue:
         SET status = 'parsed', last_updated_at = %s
         WHERE {self.id_field} = %s;
         """
-        with db.get_cursor() as cur:
-            cur.execute(query, (dt.datetime.now(), id_value))
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(query, (dt.datetime.now(), id_value))
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to mark item as parsed in {self.table_name}."
+            ) from e
 
     def mark_as_failed(self, id_value: str, reason: str = "unknown") -> None:
         """Marks the item as failed and stores the reason."""
@@ -86,6 +112,11 @@ class BaseScrapeQueue:
         SET status = 'failed', last_updated_at = %s, last_error = %s
         WHERE {self.id_field} = %s;
         """
-        with db.get_cursor() as cur:
-            cur.execute(query, (dt.datetime.now(), reason, id_value))
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(query, (dt.datetime.now(), reason, id_value))
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to mark item as failed in {self.table_name}."
+            ) from e
 

--- a/cs2_analytics/queues/demo_scrape_queue.py
+++ b/cs2_analytics/queues/demo_scrape_queue.py
@@ -1,5 +1,6 @@
 """Manages queue operations for demo file scraping and processing."""
 
+from cs2_analytics.exceptions import DemoQueueError
 from cs2_analytics.queues.base_scrape_queue import BaseScrapeQueue
 
 
@@ -11,4 +12,9 @@ class DemoScrapeQueue(BaseScrapeQueue):
     """
 
     def __init__(self) -> None:
-        super().__init__(table_name="demo_scrape_queue", id_field="demo_id", url_field="demo_url")
+        super().__init__(
+            table_name="demo_scrape_queue",
+            id_field="demo_id",
+            url_field="demo_url",
+            error_cls=DemoQueueError,
+        )

--- a/cs2_analytics/queues/map_scrape_queue.py
+++ b/cs2_analytics/queues/map_scrape_queue.py
@@ -1,5 +1,6 @@
 """Manages queue operations for map-level data scraping."""
 
+from cs2_analytics.exceptions import MapQueueError
 from cs2_analytics.queues.base_scrape_queue import BaseScrapeQueue
 
 
@@ -11,4 +12,9 @@ class MapScrapeQueue(BaseScrapeQueue):
     """
 
     def __init__(self) -> None:
-        super().__init__(table_name="map_scrape_queue", id_field="map_id", url_field="map_url")
+        super().__init__(
+            table_name="map_scrape_queue",
+            id_field="map_id",
+            url_field="map_url",
+            error_cls=MapQueueError,
+        )

--- a/cs2_analytics/queues/match_scrape_queue.py
+++ b/cs2_analytics/queues/match_scrape_queue.py
@@ -1,5 +1,6 @@
 """Manages queue operations for match result scraping."""
 
+from cs2_analytics.exceptions import MatchQueueError
 from cs2_analytics.queues.base_scrape_queue import BaseScrapeQueue
 
 
@@ -12,4 +13,9 @@ class MatchScrapeQueue(BaseScrapeQueue):
     """
 
     def __init__(self) -> None:
-        super().__init__(table_name="match_scrape_queue", id_field="match_id", url_field="match_url")
+        super().__init__(
+            table_name="match_scrape_queue",
+            id_field="match_id",
+            url_field="match_url",
+            error_cls=MatchQueueError,
+        )

--- a/cs2_analytics/scrapers/demo_scraper.py
+++ b/cs2_analytics/scrapers/demo_scraper.py
@@ -14,6 +14,7 @@ import rarfile
 from selenium.webdriver.chrome.options import Options
 from seleniumbase import Driver
 
+from cs2_analytics.exceptions import DemoScrapeError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -67,7 +68,7 @@ class DemoScraper:
             # ✅ Get the most recently downloaded file
             demo_file = self._get_latest_downloaded_file()
             if not demo_file:
-                raise FileNotFoundError("No demo file detected in download folder.")
+                raise DemoScrapeError("No demo file detected in download folder.")
 
             # ✅ Read the file into RAM
             with open(demo_file, "rb") as f:
@@ -80,7 +81,7 @@ class DemoScraper:
             return archive_buffer
 
         except Exception as e:
-            raise RuntimeError("Failed to download demo archive.") from e
+            raise DemoScrapeError("Failed to download demo archive.") from e
 
     def _get_latest_downloaded_file(self):
         """Returns the most recently downloaded file in the configured directory."""
@@ -93,7 +94,7 @@ class DemoScraper:
                 return None
             return max(files, key=os.path.getctime)  # ✅ Get most recent file
         except Exception as e:
-            raise RuntimeError("Failed to inspect downloaded demo files.") from e
+            raise DemoScrapeError("Failed to inspect downloaded demo files.") from e
 
     def extract_demo_in_memory(self, archive_buffer):
         """
@@ -131,7 +132,7 @@ class DemoScraper:
             return extracted_files
 
         except Exception as e:
-            raise RuntimeError("Failed to extract demo archive in memory.") from e
+            raise DemoScrapeError("Failed to extract demo archive in memory.") from e
 
     def process_demo(self, demo_data):
         """

--- a/cs2_analytics/scrapers/demo_scraper.py
+++ b/cs2_analytics/scrapers/demo_scraper.py
@@ -67,8 +67,7 @@ class DemoScraper:
             # ✅ Get the most recently downloaded file
             demo_file = self._get_latest_downloaded_file()
             if not demo_file:
-                logger.error("❌ No demo file detected in download folder.")
-                return None
+                raise FileNotFoundError("No demo file detected in download folder.")
 
             # ✅ Read the file into RAM
             with open(demo_file, "rb") as f:
@@ -81,8 +80,7 @@ class DemoScraper:
             return archive_buffer
 
         except Exception as e:
-            logger.error("Failed to download demo: %s", e)
-            return None
+            raise RuntimeError("Failed to download demo archive.") from e
 
     def _get_latest_downloaded_file(self):
         """Returns the most recently downloaded file in the configured directory."""
@@ -95,8 +93,7 @@ class DemoScraper:
                 return None
             return max(files, key=os.path.getctime)  # ✅ Get most recent file
         except Exception as e:
-            logger.error("Error retrieving downloaded file: %s", e)
-            return None
+            raise RuntimeError("Failed to inspect downloaded demo files.") from e
 
     def extract_demo_in_memory(self, archive_buffer):
         """
@@ -134,8 +131,7 @@ class DemoScraper:
             return extracted_files
 
         except Exception as e:
-            logger.error(f"❌ Error extracting demo in memory: {e}")
-            return None
+            raise RuntimeError("Failed to extract demo archive in memory.") from e
 
     def process_demo(self, demo_data):
         """
@@ -155,3 +151,4 @@ class DemoScraper:
         """Closes SeleniumBase driver."""
         self.driver.quit()
         logger.info("🚪 Selenium driver closed.")
+

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -5,6 +5,7 @@ import time
 from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
+from cs2_analytics.exceptions import MapScrapeError, SessionScrapeError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -32,11 +33,17 @@ class MapScraper:
 
     def _fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a map page and returns its parsed HTML."""
-        self.driver.get(url)
-        time.sleep(3.0)
-        return BeautifulSoup(self.driver.page_source, "html.parser")
+        try:
+            self.driver.get(url)
+            time.sleep(3.0)
+            return BeautifulSoup(self.driver.page_source, "html.parser")
+        except Exception as e:
+            raise SessionScrapeError(f"Failed to fetch map stats page: {url}") from e
 
     def close(self) -> None:
         """Closes the Selenium driver."""
-        self.driver.quit()
-        logger.info("Selenium driver closed.")
+        try:
+            self.driver.quit()
+            logger.info("Selenium driver closed.")
+        except Exception as e:
+            raise MapScrapeError("Failed to close map scraper driver.") from e

--- a/cs2_analytics/scrapers/match_scraper.py
+++ b/cs2_analytics/scrapers/match_scraper.py
@@ -5,6 +5,7 @@ import time
 from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
+from cs2_analytics.exceptions import MatchScrapeError, SessionScrapeError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -31,11 +32,17 @@ class MatchScraper:
         return self._fetch_soup(url)
 
     def _fetch_soup(self, url: str) -> BeautifulSoup:
-        self.driver.get(url)
-        time.sleep(3)
-        return BeautifulSoup(self.driver.page_source, "html.parser")
+        try:
+            self.driver.get(url)
+            time.sleep(3)
+            return BeautifulSoup(self.driver.page_source, "html.parser")
+        except Exception as e:
+            raise SessionScrapeError(f"Failed to fetch match page: {url}") from e
 
     def close(self) -> None:
         """Closes the Selenium driver."""
-        self.driver.quit()
-        logger.info("Selenium driver closed.")
+        try:
+            self.driver.quit()
+            logger.info("Selenium driver closed.")
+        except Exception as e:
+            raise MatchScrapeError("Failed to close match scraper driver.") from e

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
 from cs2_analytics.config.config import END_DATE, HLTV_URL, MAX_MATCHES, START_DATE
+from cs2_analytics.exceptions import ResultsScrapeError, SessionScrapeError
 from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 from cs2_analytics.utils.log_manager import get_logger
 from cs2_analytics.utils.queue_helpers import chunk_and_queue
@@ -52,7 +53,7 @@ class ResultsScraper:
 
         while total_queued < max_matches:
             page_url = f"{self.base_url}?offset={offset}&gameType=CS2"
-            logger.info("🔄 Scraping page: %s", page_url)
+            logger.info("Scraping page: %s", page_url)
 
             match_urls, stop = self._extract_matches_from_page(page_url)
             batch = []
@@ -73,9 +74,9 @@ class ResultsScraper:
                 break
 
             offset += 100
-            time.sleep(random.uniform(1.0, 2.0))  # Polite crawl delay
+            time.sleep(random.uniform(1.0, 2.0))
 
-        logger.info("✅ Queued %s matches total.", total_queued)
+        logger.info("Queued %s matches total.", total_queued)
 
     def _extract_matches_from_page(self, url: str) -> tuple[list[str], bool]:
         """
@@ -87,10 +88,13 @@ class ResultsScraper:
         Returns:
             Tuple of (list of match URLs, whether to stop scraping)
         """
-        self.driver.get(url)
-        time.sleep(random.uniform(3, 5))
+        try:
+            self.driver.get(url)
+            time.sleep(random.uniform(3, 5))
+            soup = BeautifulSoup(self.driver.page_source, "html.parser")
+        except Exception as e:
+            raise SessionScrapeError(f"Failed to fetch results page: {url}") from e
 
-        soup = BeautifulSoup(self.driver.page_source, "html.parser")
         matches = []
         stop_scraping = False
 
@@ -105,13 +109,13 @@ class ResultsScraper:
             try:
                 match_date = dt.datetime.strptime(raw_date.strip(), "%B %d %Y").date()
             except ValueError:
-                logger.warning("❌ Could not parse date: %s", raw_date)
+                logger.warning("Could not parse date: %s", raw_date)
                 continue
 
             if match_date > self.end_date:
                 continue
             if match_date < self.start_date:
-                logger.info("⏹️ Stopping at match date %s — out of range.", match_date)
+                logger.info("Stopping at match date %s because it is out of range.", match_date)
                 return matches, True
 
             for match in section.find_all("div", class_="result-con"):
@@ -138,8 +142,11 @@ class ResultsScraper:
 
     def close(self) -> None:
         """Closes the SeleniumBase driver."""
-        self.driver.quit()
-        logger.info("🚪 Selenium driver closed.")
+        try:
+            self.driver.quit()
+            logger.info("Selenium driver closed.")
+        except Exception as e:
+            raise ResultsScrapeError("Failed to close results scraper driver.") from e
 
 
 if __name__ == "__main__":

--- a/cs2_analytics/services/player_analytics.py
+++ b/cs2_analytics/services/player_analytics.py
@@ -48,7 +48,7 @@ class PlayerAnalytics:
                 logger.info(f"✅ Processed player stats from {file}")
 
             except Exception as e:
-                logger.error(f"❌ Error processing {file}: {e}")
+                raise ValueError(f"Failed to process analytics file: {file}") from e
 
         self._save_aggregated_data(aggregated_data)
 
@@ -111,3 +111,4 @@ class PlayerAnalytics:
             json.dump(aggregated_data, f, indent=4)
 
         logger.info(f"💾 Saved aggregated player performance data: {output_file}")
+

--- a/cs2_analytics/services/player_analytics.py
+++ b/cs2_analytics/services/player_analytics.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from cs2_analytics.exceptions import AnalyticsProcessingError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -48,7 +49,9 @@ class PlayerAnalytics:
                 logger.info(f"✅ Processed player stats from {file}")
 
             except Exception as e:
-                raise ValueError(f"Failed to process analytics file: {file}") from e
+                raise AnalyticsProcessingError(
+                    f"Failed to process analytics file: {file}"
+                ) from e
 
         self._save_aggregated_data(aggregated_data)
 

--- a/cs2_analytics/storage/database.py
+++ b/cs2_analytics/storage/database.py
@@ -6,6 +6,7 @@ import psycopg2
 import psycopg2.pool
 
 from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
+from cs2_analytics.exceptions import DatabaseConnectionError, DatabaseOperationError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -33,7 +34,9 @@ def _initialize_db_pool() -> psycopg2.pool.SimpleConnectionPool | None:
         logger.info("✅ PostgreSQL connection pool initialized successfully.")
     except (psycopg2.pool.PoolError, psycopg2.Error) as e:
         DB_POOL = None
-        raise ConnectionError("Failed to initialize database connection pool.") from e
+        raise DatabaseConnectionError(
+            "Failed to initialize database connection pool."
+        ) from e
 
     return DB_POOL
 
@@ -47,7 +50,7 @@ class Database:
         """Initialize database connection."""
         self.pool = _initialize_db_pool()
         if self.pool is None:
-            raise ConnectionError("Database connection pool is not available.")
+            raise DatabaseConnectionError("Database connection pool is not available.")
 
         if not Database._indexes_ensured:
             Database._indexes_ensured = self.create_indexes()
@@ -59,7 +62,7 @@ class Database:
             logger.debug("✅ Retrieved database connection from pool.")
             return conn
         except (psycopg2.pool.PoolError, psycopg2.Error) as e:
-            raise ConnectionError(
+            raise DatabaseConnectionError(
                 "Failed to acquire a database connection from the pool."
             ) from e
 
@@ -83,7 +86,7 @@ class Database:
         """Yields a DB cursor and handles commit/rollback and connection release."""
         conn = self.get_connection()
         if conn is None:
-            raise ConnectionError(
+            raise DatabaseConnectionError(
                 "Unable to acquire a database connection from the pool."
             )
 
@@ -91,9 +94,9 @@ class Database:
             cur = conn.cursor()
             yield cur
             conn.commit()
-        except Exception:
+        except Exception as e:
             conn.rollback()
-            raise
+            raise DatabaseOperationError("Failed during database operation.") from e
         finally:
             self.release_connection(conn)
 
@@ -125,7 +128,7 @@ class Database:
             return True
 
         except Exception as e:
-            raise RuntimeError("Failed to create database indexes.") from e
+            raise DatabaseOperationError("Failed to create database indexes.") from e
         finally:
             self.release_connection(conn)
 

--- a/cs2_analytics/storage/database.py
+++ b/cs2_analytics/storage/database.py
@@ -32,8 +32,8 @@ def _initialize_db_pool() -> psycopg2.pool.SimpleConnectionPool | None:
         )
         logger.info("✅ PostgreSQL connection pool initialized successfully.")
     except (psycopg2.pool.PoolError, psycopg2.Error) as e:
-        logger.error("❌ Failed to initialize database connection pool: %s", e)
         DB_POOL = None
+        raise ConnectionError("Failed to initialize database connection pool.") from e
 
     return DB_POOL
 
@@ -59,8 +59,9 @@ class Database:
             logger.debug("✅ Retrieved database connection from pool.")
             return conn
         except (psycopg2.pool.PoolError, psycopg2.Error) as e:
-            logger.error("Database connection error: %s", e)
-            return None
+            raise ConnectionError(
+                "Failed to acquire a database connection from the pool."
+            ) from e
 
     def release_connection(self, conn):
         """Releases a database connection back to the pool."""
@@ -90,9 +91,8 @@ class Database:
             cur = conn.cursor()
             yield cur
             conn.commit()
-        except Exception as e:
+        except Exception:
             conn.rollback()
-            logger.error("❌ Error during DB operation: %s", e)
             raise
         finally:
             self.release_connection(conn)
@@ -125,9 +125,9 @@ class Database:
             return True
 
         except Exception as e:
-            logger.error("Error creating indexes: %s", e)
-            return False
+            raise RuntimeError("Failed to create database indexes.") from e
         finally:
             self.release_connection(conn)
+
 
 

--- a/cs2_analytics/storage/demo_storage.py
+++ b/cs2_analytics/storage/demo_storage.py
@@ -45,7 +45,7 @@ def store_demo_file(
         last_processed_at = EXCLUDED.last_processed_at;
     """
 
-    now = dt.datetime.utcnow()
+    now = dt.datetime.now(dt.UTC)
 
     values = {
         "map_id": map_id,
@@ -61,7 +61,6 @@ def store_demo_file(
     try:
         with db.get_cursor() as cur:
             cur.execute(query, values)
-            db.commit()
             logger.info("📥 Stored demo file for map_id: %s", map_id)
     except Exception as e:
         raise DemoStorageError("Failed to store demo file.") from e

--- a/cs2_analytics/storage/demo_storage.py
+++ b/cs2_analytics/storage/demo_storage.py
@@ -62,5 +62,6 @@ def store_demo_file(
             cur.execute(query, values)
             db.commit()
             logger.info("📥 Stored demo file for map_id: %s", map_id)
-    except Exception as e:
-        logger.error("❌ Failed to store demo file for map_id %s: %s", map_id, e)
+    except Exception:
+        raise
+

--- a/cs2_analytics/storage/demo_storage.py
+++ b/cs2_analytics/storage/demo_storage.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+from cs2_analytics.exceptions import DemoStorageError
 from cs2_analytics.storage.db_instance import db
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -62,6 +63,6 @@ def store_demo_file(
             cur.execute(query, values)
             db.commit()
             logger.info("📥 Stored demo file for map_id: %s", map_id)
-    except Exception:
-        raise
+    except Exception as e:
+        raise DemoStorageError("Failed to store demo file.") from e
 

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -30,8 +30,9 @@ def initialize_database():
         logger.info("✅ Database initialized successfully.")
 
     except Exception as e:
-        logger.error("Error initializing database: %s", e)
+        raise RuntimeError("Failed to initialize database schema.") from e
 
 
 if __name__ == "__main__":
     initialize_database()
+

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -14,20 +14,19 @@ logger = get_logger(__name__)
 def initialize_database():
     """Executes the schema.sql file to create/update the database schema."""
     try:
-        conn = psycopg2.connect(
-            dbname=DB_NAME, user=DB_USER, password=DB_PASS, host=DB_HOST, port=DB_PORT
-        )
-        cur = conn.cursor()
+        with psycopg2.connect(
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASS,
+            host=DB_HOST,
+            port=DB_PORT,
+        ) as conn:
+            with conn.cursor() as cur:
+                schema_path = os.path.join(os.path.dirname(__file__), "schema.sql")
 
-        schema_path = os.path.join(os.path.dirname(__file__), "schema.sql")
-
-        with open(schema_path, encoding="utf-8") as schema_file:
-            schema_sql = schema_file.read()
-            cur.execute(schema_sql)
-
-        conn.commit()
-        cur.close()
-        conn.close()
+                with open(schema_path, encoding="utf-8") as schema_file:
+                    schema_sql = schema_file.read()
+                    cur.execute(schema_sql)
         logger.info("✅ Database initialized successfully.")
 
     except Exception as e:

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -5,6 +5,7 @@ import os
 import psycopg2
 
 from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
+from cs2_analytics.exceptions import DatabaseOperationError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -30,7 +31,7 @@ def initialize_database():
         logger.info("✅ Database initialized successfully.")
 
     except Exception as e:
-        raise RuntimeError("Failed to initialize database schema.") from e
+        raise DatabaseOperationError("Failed to initialize database schema.") from e
 
 
 if __name__ == "__main__":

--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -1,3 +1,4 @@
+from cs2_analytics.exceptions import MatchStorageError
 from cs2_analytics.models.match import Match
 from cs2_analytics.storage.db_instance import db
 from cs2_analytics.utils.log_manager import get_logger
@@ -57,9 +58,9 @@ def store_matches(matches: list[Match]) -> None:
             )
         conn.commit()
         logger.info("📥 Stored %d match records.", len(matches))
-    except Exception:
+    except Exception as e:
         conn.rollback()
-        raise
+        raise MatchStorageError("Failed to store match records.") from e
     finally:
         db.release_connection(conn)
 

--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -57,7 +57,9 @@ def store_matches(matches: list[Match]) -> None:
             )
         conn.commit()
         logger.info("📥 Stored %d match records.", len(matches))
-    except Exception as e:
-        logger.error("❌ Error storing matches: %s", e)
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         db.release_connection(conn)
+

--- a/cs2_analytics/storage/player_storage.py
+++ b/cs2_analytics/storage/player_storage.py
@@ -1,3 +1,4 @@
+from cs2_analytics.exceptions import PlayerStorageError
 from cs2_analytics.models.player import Player
 from cs2_analytics.storage.db_instance import db
 from cs2_analytics.utils.log_manager import get_logger
@@ -45,37 +46,40 @@ def store_players(players: list[Player]) -> None:
         data_complete = EXCLUDED.data_complete;
     """
 
-    with db.get_cursor() as cur:
-        for p in players:
-            cur.execute(
-                insert_query,
-                {
-                    "map_id": p.map_id,
-                    "player_id": p.player_id,
-                    "player_name": p.player_name,
-                    "player_url": p.player_url,
-                    "map_name": p.map_name,
-                    "team_name": p.team_name,
-                    "kills": p.kills,
-                    "headshots": p.headshots,
-                    "assists": p.assists,
-                    "flash_assists": p.flash_assists,
-                    "deaths": p.deaths,
-                    "traded_deaths": p.traded_deaths,
-                    "opening_kills": p.opening_kills,
-                    "opening_deaths": p.opening_deaths,
-                    "multi_kills": p.multi_kills,
-                    "clutches_won": p.clutches_won,
-                    "kast": p.kast,
-                    "kd_diff": p.kd_diff,
-                    "adr": p.adr,
-                    "fk_diff": p.fk_diff,
-                    "round_swing": p.round_swing,
-                    "rating": p.rating,
-                    "last_inserted_at": p.last_inserted_at,
-                    "last_scraped_at": p.last_scraped_at,
-                    "last_updated_at": p.last_updated_at,
-                    "data_complete": p.data_complete,
-                },
-            )
-        logger.info("📥 Stored %d player stat records.", len(players))
+    try:
+        with db.get_cursor() as cur:
+            for p in players:
+                cur.execute(
+                    insert_query,
+                    {
+                        "map_id": p.map_id,
+                        "player_id": p.player_id,
+                        "player_name": p.player_name,
+                        "player_url": p.player_url,
+                        "map_name": p.map_name,
+                        "team_name": p.team_name,
+                        "kills": p.kills,
+                        "headshots": p.headshots,
+                        "assists": p.assists,
+                        "flash_assists": p.flash_assists,
+                        "deaths": p.deaths,
+                        "traded_deaths": p.traded_deaths,
+                        "opening_kills": p.opening_kills,
+                        "opening_deaths": p.opening_deaths,
+                        "multi_kills": p.multi_kills,
+                        "clutches_won": p.clutches_won,
+                        "kast": p.kast,
+                        "kd_diff": p.kd_diff,
+                        "adr": p.adr,
+                        "fk_diff": p.fk_diff,
+                        "round_swing": p.round_swing,
+                        "rating": p.rating,
+                        "last_inserted_at": p.last_inserted_at,
+                        "last_scraped_at": p.last_scraped_at,
+                        "last_updated_at": p.last_updated_at,
+                        "data_complete": p.data_complete,
+                    },
+                )
+            logger.info("Stored %d player stat records.", len(players))
+    except Exception as e:
+        raise PlayerStorageError("Failed to store player records.") from e

--- a/cs2_analytics/utils/log_manager.py
+++ b/cs2_analytics/utils/log_manager.py
@@ -1,16 +1,42 @@
-"""This file sets up the logging configuration for the application."""
+"""Shared logging configuration for the application."""
 
+import json
 import logging
 import os
+from datetime import datetime, timezone
 
 from cs2_analytics.config.config import LOG_LEVEL
 
-# Ensure the "logs" directory exists
 LOG_DIR = "./logs"
 if not os.path.exists(LOG_DIR):
     os.makedirs(LOG_DIR)
 
 LOG_FILE = os.path.join(LOG_DIR, "app.log")
+
+
+class JsonFormatter(logging.Formatter):
+    """Formats log records as newline-delimited JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+
+        return json.dumps(payload, ensure_ascii=False)
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -20,23 +46,24 @@ def get_logger(name: str) -> logging.Logger:
     """
     logger = logging.getLogger(name)
 
-    if not logger.handlers:  # ✅ Prevent duplicate handlers
+    if not logger.handlers:
         logger.setLevel(LOG_LEVEL)
 
-        log_format = logging.Formatter(
+        json_formatter = JsonFormatter()
+        console_formatter = logging.Formatter(
             "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
         )
 
         file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
         file_handler.setLevel(LOG_LEVEL)
-        file_handler.setFormatter(log_format)
+        file_handler.setFormatter(json_formatter)
         logger.addHandler(file_handler)
 
         console_handler = logging.StreamHandler()
         console_handler.setLevel(LOG_LEVEL)
-        console_handler.setFormatter(log_format)
+        console_handler.setFormatter(console_formatter)
         logger.addHandler(console_handler)
 
-        logger.propagate = False  # ✅ Optional: prevent bubbling to root logger
+        logger.propagate = False
 
     return logger

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,7 +22,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 ### Remaining hardening priorities
 
 - [ ] Decide failure policy when retries are exhausted (continue stage vs fail run)
-- [ ] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
+- [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [ ] Improve observability around retry exhaustion and run-level outcomes
 - [ ] Add targeted tests for controller retry and recovery behavior
 - [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -26,7 +26,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [ ] Improve observability around retry exhaustion and run-level outcomes
 - [ ] Add targeted tests for controller retry and recovery behavior
 - [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
-- [ ] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
+- [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,7 +23,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 
 - [x] Decide failure policy when retries are exhausted (results fails run; match/map fail item and continue)
 - [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
-- [ ] Improve observability around retry exhaustion and run-level outcomes
+- [x] Improve observability around retry exhaustion and run-level outcomes
 - [ ] Add targeted tests for controller retry and recovery behavior
 - [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
 - [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,7 +21,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 
 ### Remaining hardening priorities
 
-- [ ] Decide failure policy when retries are exhausted (continue stage vs fail run)
+- [x] Decide failure policy when retries are exhausted (results fails run; match/map fail item and continue)
 - [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [ ] Improve observability around retry exhaustion and run-level outcomes
 - [ ] Add targeted tests for controller retry and recovery behavior

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,7 +24,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [x] Decide failure policy when retries are exhausted (results fails run; match/map fail item and continue)
 - [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [x] Improve observability around retry exhaustion and run-level outcomes
-- [ ] Add targeted tests for controller retry and recovery behavior
+- [x] Add targeted tests for controller retry and recovery behavior
 - [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
 - [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -13,12 +13,14 @@
 - No orchestration logic
 - No queue state transitions
 - No storage writes
+- Raise typed parse exceptions with specific helper-level messages
 
 ## Controllers
 
 - Coordinate workflow
 - Handle queue interaction and queue status transitions
 - Call scrapers, parsers, and storage modules
+- Own terminal error logging and queue failure outcomes
 
 ## Pipelines
 
@@ -30,9 +32,11 @@
 - Match/player writes belong in storage modules (`match_storage.py`, `player_storage.py`)
 - Shared DB connection/cursor concerns belong in `storage/database.py`
 - Structured data stays in relational tables
+- Raise typed storage/database exceptions instead of logging terminal errors
 
 ## Queues
 
 - Stored in PostgreSQL
 - Current statuses: `queued`, `parsed`, `failed`
 - Include retry and error tracking metadata
+- Raise typed queue exceptions instead of logging terminal errors

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -16,10 +16,10 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 
 - Queue-status and responsibility cleanup for the active match/map flow
 - Match/player persistence remains centralized in storage modules
+- Shared controller retry/session-recovery behavior centralized in controller-scoped helpers
 
 ## Current Work
 
-- Stabilizing retry/backoff and session-recovery paths
 - Deciding failure handling when retries are exhausted
 - Improving observability around retry exhaustion and run-level outcomes
 - Adding targeted tests for controller retry and recovery behavior

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -20,10 +20,9 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Shared controller retry/session-recovery behavior centralized in controller-scoped helpers
 - Retry-exhaustion policy defined for results vs match/map stages
 - Run-level retry/failure visibility added to controller summaries and retry-exhaustion logs
+- Targeted controller and retry-helper tests added for retry, recovery, and run summaries
 
 ## Current Work
-
-- Adding targeted tests for controller retry and recovery behavior
 
 ## Rules
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -19,10 +19,10 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Match/player persistence remains centralized in storage modules
 - Shared controller retry/session-recovery behavior centralized in controller-scoped helpers
 - Retry-exhaustion policy defined for results vs match/map stages
+- Run-level retry/failure visibility added to controller summaries and retry-exhaustion logs
 
 ## Current Work
 
-- Improving observability around retry exhaustion and run-level outcomes
 - Adding targeted tests for controller retry and recovery behavior
 
 ## Rules

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -9,6 +9,7 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Scrapers fetch content only
 - Parsers extract structured data only
 - Controllers orchestrate queue transitions and persistence handoff
+- Results-stage retry exhaustion fails the run; match/map item exhaustion marks failed and continues
 - Queues stay PostgreSQL-backed
 - Demo-related work remains deferred until ingestion hardening is stable
 
@@ -17,10 +18,10 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Queue-status and responsibility cleanup for the active match/map flow
 - Match/player persistence remains centralized in storage modules
 - Shared controller retry/session-recovery behavior centralized in controller-scoped helpers
+- Retry-exhaustion policy defined for results vs match/map stages
 
 ## Current Work
 
-- Deciding failure handling when retries are exhausted
 - Improving observability around retry exhaustion and run-level outcomes
 - Adding targeted tests for controller retry and recovery behavior
 

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -45,6 +45,7 @@ def test_map_controller_continues_after_item_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stored_players: list[list[object]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(map_module, "MapScraper", _SuccessfulScraper)
     monkeypatch.setattr(map_module, "MapParser", _FailOnceThenSucceedParser)
     monkeypatch.setattr(map_module, "MapScrapeQueue", _FakeMapQueue)
@@ -54,6 +55,11 @@ def test_map_controller_continues_after_item_failure(
         lambda players: stored_players.append(players),
     )
     monkeypatch.setattr(map_module.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        map_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
 
     controller = map_module.MapController()
     controller.run(batch_size=2)
@@ -61,3 +67,9 @@ def test_map_controller_continues_after_item_failure(
     assert controller.queue.failed == [("map-1", "No player kills logged.")]
     assert controller.queue.parsed == ["map-2"]
     assert len(stored_players) == 1
+    assert any(
+        call_args[0]
+        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (2, 1, 1, 0)
+        for call_args, _ in info_calls
+    )

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -1,0 +1,63 @@
+import pytest
+
+from cs2_analytics.controllers import map_controller as map_module
+from cs2_analytics.exceptions import MapParseError
+
+
+class _FakeMapQueue:
+    def __init__(self) -> None:
+        self.failed: list[tuple[str, str]] = []
+        self.parsed: list[str] = []
+
+    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+        return [
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test"),
+            ("map-2", "https://www.hltv.org/stats/matches/mapstatsid/2/test"),
+        ]
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+    def mark_as_parsed(self, item_id: str) -> None:
+        self.parsed.append(item_id)
+
+
+class _SuccessfulScraper:
+    def fetch_soup(self, url: str) -> object:
+        return object()
+
+    def close(self) -> None:
+        return None
+
+
+class _FailOnceThenSucceedParser:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def parse_map(self, soup: object, map_url: str, map_id: str) -> list[object]:
+        self.calls += 1
+        if self.calls == 1:
+            raise MapParseError("No player kills logged.")
+        return [object()]
+
+
+def test_map_controller_continues_after_item_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_players: list[list[object]] = []
+    monkeypatch.setattr(map_module, "MapScraper", _SuccessfulScraper)
+    monkeypatch.setattr(map_module, "MapParser", _FailOnceThenSucceedParser)
+    monkeypatch.setattr(map_module, "MapScrapeQueue", _FakeMapQueue)
+    monkeypatch.setattr(
+        map_module,
+        "store_players",
+        lambda players: stored_players.append(players),
+    )
+    monkeypatch.setattr(map_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    controller = map_module.MapController()
+    controller.run(batch_size=2)
+
+    assert controller.queue.failed == [("map-1", "No player kills logged.")]
+    assert controller.queue.parsed == ["map-2"]
+    assert len(stored_players) == 1

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cs2_analytics.controllers import map_controller as map_module
-from cs2_analytics.exceptions import MapParseError
+from cs2_analytics.exceptions import MapParseError, SessionScrapeError
 
 
 class _FakeMapQueue:
@@ -30,6 +30,22 @@ class _SuccessfulScraper:
         return None
 
 
+class _AlwaysRetryableScraper(_SuccessfulScraper):
+    def fetch_soup(self, url: str) -> object:
+        raise SessionScrapeError(f"Failed to fetch map stats page: {url}")
+
+
+class _RetryThenSucceedScraper(_SuccessfulScraper):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def fetch_soup(self, url: str) -> object:
+        self.calls += 1
+        if self.calls == 1:
+            raise SessionScrapeError(f"Failed to fetch map stats page: {url}")
+        return object()
+
+
 class _FailOnceThenSucceedParser:
     def __init__(self) -> None:
         self.calls = 0
@@ -39,6 +55,28 @@ class _FailOnceThenSucceedParser:
         if self.calls == 1:
             raise MapParseError("No player kills logged.")
         return [object()]
+
+
+class _SuccessfulParser:
+    def parse_map(self, soup: object, map_url: str, map_id: str) -> list[object]:
+        return [object()]
+
+
+def _build_map_controller(
+    monkeypatch: pytest.MonkeyPatch,
+    scraper_cls: type[object],
+    parser_cls: type[object],
+) -> map_module.MapController:
+    monkeypatch.setattr(map_module, "MapScraper", scraper_cls)
+    monkeypatch.setattr(map_module, "MapParser", parser_cls)
+    monkeypatch.setattr(map_module, "MapScrapeQueue", _FakeMapQueue)
+    monkeypatch.setattr(
+        map_module,
+        "store_players",
+        lambda players: None,
+    )
+    monkeypatch.setattr(map_module.time, "sleep", lambda *_args, **_kwargs: None)
+    return map_module.MapController()
 
 
 def test_map_controller_continues_after_item_failure(
@@ -71,5 +109,115 @@ def test_map_controller_continues_after_item_failure(
         call_args[0]
         == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (2, 1, 1, 0)
+        for call_args, _ in info_calls
+    )
+
+
+def test_map_controller_retries_retryable_error_before_succeeding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
+    controller = _build_map_controller(
+        monkeypatch,
+        _RetryThenSucceedScraper,
+        _SuccessfulParser,
+    )
+    stored_players: list[list[object]] = []
+    monkeypatch.setattr(
+        map_module,
+        "store_players",
+        lambda players: stored_players.append(players),
+    )
+    monkeypatch.setattr(
+        map_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
+    monkeypatch.setattr(
+        controller.queue,
+        "fetch",
+        lambda limit=25: [("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
+    )
+
+    controller.run(batch_size=1)
+
+    assert controller.queue.failed == []
+    assert controller.queue.parsed == ["map-1"]
+    assert len(stored_players) == 1
+    assert len(reset_calls) == 1
+    assert any(
+        call_args[0]
+        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (1, 1, 0, 1)
+        for call_args, _ in info_calls
+    )
+
+
+def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
+    controller = _build_map_controller(
+        monkeypatch,
+        _AlwaysRetryableScraper,
+        _SuccessfulParser,
+    )
+    monkeypatch.setattr(
+        map_module.logger,
+        "error",
+        lambda *args, **kwargs: error_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        map_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        map_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
+    monkeypatch.setattr(
+        controller.queue,
+        "fetch",
+        lambda limit=25: [("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
+    )
+
+    controller.run(batch_size=1)
+
+    assert controller.queue.failed == [
+        ("map-1", "Failed to fetch map stats page: https://www.hltv.org/stats/matches/mapstatsid/1/test")
+    ]
+    assert controller.queue.parsed == []
+    assert len(reset_calls) == 2
+    assert error_calls == [
+        (
+            (
+                "Exhausted retries for map %s after %d attempts; marking failed and continuing.",
+                "map-1",
+                3,
+            ),
+            {},
+        )
+    ]
+    assert len(exception_calls) == 1
+    assert any(
+        call_args[0]
+        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (1, 0, 1, 2)
         for call_args, _ in info_calls
     )

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -52,6 +52,17 @@ class _SuccessfulParser:
         return object(), [], []
 
 
+class _FailOnceThenSucceedParser:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+        self.calls += 1
+        if self.calls == 1:
+            raise MatchParseError("Missing team names on match page.")
+        return object(), [], []
+
+
 def _build_match_controller(
     monkeypatch: pytest.MonkeyPatch,
     scraper_cls: type[_PassiveScraper],
@@ -114,3 +125,35 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
     assert failed_id == "match-1"
     assert "Failed to fetch match page" in reason
     assert len(exception_calls) == 1
+
+
+def test_match_controller_continues_after_item_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stored_matches: list[list[object]] = []
+    controller = _build_match_controller(
+        monkeypatch,
+        _SuccessfulScraper,
+        _FailOnceThenSucceedParser,
+    )
+    monkeypatch.setattr(
+        controller.match_queue,
+        "fetch",
+        lambda limit=25: [
+            ("match-1", "https://www.hltv.org/matches/1/test"),
+            ("match-2", "https://www.hltv.org/matches/2/test"),
+        ],
+    )
+    monkeypatch.setattr(
+        match_module,
+        "store_matches",
+        lambda matches: stored_matches.append(matches),
+    )
+
+    controller.run(batch_size=2)
+
+    assert controller.match_queue.failed == [
+        ("match-1", "Missing team names on match page.")
+    ]
+    assert controller.match_queue.parsed == ["match-2"]
+    assert len(stored_matches) == 1

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -111,10 +111,22 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
         _SuccessfulParser,
     )
     exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(
         match_module.logger,
         "exception",
         lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        match_module.logger,
+        "error",
+        lambda *args, **kwargs: error_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        match_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
     )
     monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
 
@@ -125,16 +137,38 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
     assert failed_id == "match-1"
     assert "Failed to fetch match page" in reason
     assert len(exception_calls) == 1
+    assert error_calls == [
+        (
+            (
+                "Exhausted retries for match %s after %d attempts; marking failed and continuing.",
+                "match-1",
+                3,
+            ),
+            {},
+        )
+    ]
+    assert any(
+        call_args[0]
+        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (1, 0, 1, 2)
+        for call_args, _ in info_calls
+    )
 
 
 def test_match_controller_continues_after_item_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stored_matches: list[list[object]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     controller = _build_match_controller(
         monkeypatch,
         _SuccessfulScraper,
         _FailOnceThenSucceedParser,
+    )
+    monkeypatch.setattr(
+        match_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
     )
     monkeypatch.setattr(
         controller.match_queue,
@@ -157,3 +191,9 @@ def test_match_controller_continues_after_item_failure(
     ]
     assert controller.match_queue.parsed == ["match-2"]
     assert len(stored_matches) == 1
+    assert any(
+        call_args[0]
+        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (2, 1, 1, 0)
+        for call_args, _ in info_calls
+    )

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -1,0 +1,116 @@
+import pytest
+
+from cs2_analytics.controllers import match_controller as match_module
+from cs2_analytics.exceptions import MatchParseError, SessionScrapeError
+
+
+class _FakeMatchQueue:
+    def __init__(self) -> None:
+        self.failed: list[tuple[str, str]] = []
+        self.parsed: list[str] = []
+
+    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+        return [("match-1", "https://www.hltv.org/matches/1/test")]
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+    def mark_as_parsed(self, item_id: str) -> None:
+        self.parsed.append(item_id)
+
+
+class _FakeFollowupQueue:
+    def __init__(self) -> None:
+        self.queued: list[tuple[str, str, str]] = []
+
+    def queue(self, item_id: str, url: str, source: str = "unknown") -> None:
+        self.queued.append((item_id, url, source))
+
+
+class _PassiveScraper:
+    def close(self) -> None:
+        return None
+
+
+class _AlwaysRetryableScraper(_PassiveScraper):
+    def fetch_soup(self, url: str) -> None:
+        raise SessionScrapeError(f"Failed to fetch match page: {url}")
+
+
+class _SuccessfulScraper(_PassiveScraper):
+    def fetch_soup(self, url: str) -> object:
+        return object()
+
+
+class _ParseFailureParser:
+    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+        raise MatchParseError("Missing team names on match page.")
+
+
+class _SuccessfulParser:
+    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+        return object(), [], []
+
+
+def _build_match_controller(
+    monkeypatch: pytest.MonkeyPatch,
+    scraper_cls: type[_PassiveScraper],
+    parser_cls: type[object],
+) -> match_module.MatchController:
+    monkeypatch.setattr(match_module, "MatchScraper", scraper_cls)
+    monkeypatch.setattr(match_module, "MatchParser", parser_cls)
+    monkeypatch.setattr(match_module, "MatchScrapeQueue", _FakeMatchQueue)
+    monkeypatch.setattr(match_module, "MapScrapeQueue", _FakeFollowupQueue)
+    monkeypatch.setattr(match_module, "DemoScrapeQueue", _FakeFollowupQueue)
+    monkeypatch.setattr(match_module, "store_matches", lambda matches: None)
+    monkeypatch.setattr(match_module.time, "sleep", lambda *_args, **_kwargs: None)
+    return match_module.MatchController()
+
+
+def test_match_controller_marks_non_retryable_parse_error_failed_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_match_controller(
+        monkeypatch,
+        _SuccessfulScraper,
+        _ParseFailureParser,
+    )
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        match_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+
+    controller.run(batch_size=1)
+
+    assert controller.match_queue.failed == [
+        ("match-1", "Missing team names on match page.")
+    ]
+    assert controller.match_queue.parsed == []
+    assert len(exception_calls) == 1
+
+
+def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_match_controller(
+        monkeypatch,
+        _AlwaysRetryableScraper,
+        _SuccessfulParser,
+    )
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        match_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+
+    controller.run(batch_size=1)
+
+    assert len(controller.match_queue.failed) == 1
+    failed_id, reason = controller.match_queue.failed[0]
+    assert failed_id == "match-1"
+    assert "Failed to fetch match page" in reason
+    assert len(exception_calls) == 1

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -37,6 +37,17 @@ class _AlwaysRetryableScraper(_PassiveScraper):
         raise SessionScrapeError(f"Failed to fetch match page: {url}")
 
 
+class _RetryTwiceThenSucceedScraper(_PassiveScraper):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def fetch_soup(self, url: str) -> object:
+        self.calls += 1
+        if self.calls <= 2:
+            raise SessionScrapeError(f"Failed to fetch match page: {url}")
+        return object()
+
+
 class _SuccessfulScraper(_PassiveScraper):
     def fetch_soup(self, url: str) -> object:
         return object()
@@ -87,10 +98,16 @@ def test_match_controller_marks_non_retryable_parse_error_failed_immediately(
         _ParseFailureParser,
     )
     exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
     monkeypatch.setattr(
         match_module.logger,
         "exception",
         lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
     )
 
     controller.run(batch_size=1)
@@ -100,6 +117,7 @@ def test_match_controller_marks_non_retryable_parse_error_failed_immediately(
     ]
     assert controller.match_queue.parsed == []
     assert len(exception_calls) == 1
+    assert reset_calls == []
 
 
 def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_errors(
@@ -113,6 +131,7 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
     exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
     monkeypatch.setattr(
         match_module.logger,
         "exception",
@@ -128,7 +147,11 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
         "info",
         lambda *args, **kwargs: info_calls.append((args, kwargs)),
     )
-    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
 
     controller.run(batch_size=1)
 
@@ -137,6 +160,7 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
     assert failed_id == "match-1"
     assert "Failed to fetch match page" in reason
     assert len(exception_calls) == 1
+    assert len(reset_calls) == 2
     assert error_calls == [
         (
             (
@@ -195,5 +219,59 @@ def test_match_controller_continues_after_item_failure(
         call_args[0]
         == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (2, 1, 1, 0)
+        for call_args, _ in info_calls
+    )
+
+
+def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    stored_matches: list[list[object]] = []
+    reset_calls: list[object] = []
+    controller = _build_match_controller(
+        monkeypatch,
+        _RetryTwiceThenSucceedScraper,
+        _SuccessfulParser,
+    )
+    monkeypatch.setattr(
+        match_module.time,
+        "sleep",
+        lambda seconds, *_args, **_kwargs: sleep_calls.append(seconds),
+    )
+    monkeypatch.setattr(
+        match_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
+    monkeypatch.setattr(
+        match_module,
+        "store_matches",
+        lambda matches: stored_matches.append(matches),
+    )
+
+    controller.run(batch_size=1)
+
+    assert controller.match_queue.failed == []
+    assert controller.match_queue.parsed == ["match-1"]
+    assert len(stored_matches) == 1
+    assert len(reset_calls) == 2
+    assert 8.0 in sleep_calls
+    assert any(
+        call_args[0]
+        == "Applying cooldown after %d consecutive recoverable errors"
+        and call_args[1:] == (2,)
+        for call_args, _ in info_calls
+    )
+    assert any(
+        call_args[0]
+        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        and call_args[1:] == (1, 1, 0, 2)
         for call_args, _ in info_calls
     )

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -1,0 +1,32 @@
+import pytest
+
+from cs2_analytics.controllers import results_controller as results_module
+from cs2_analytics.exceptions import SessionScrapeError
+
+
+class _RetryThenSucceedScraper:
+    def __init__(self) -> None:
+        self.run_calls = 0
+        self.close_calls = 0
+
+    def run(self, max_matches: int = 50) -> None:
+        self.run_calls += 1
+        if self.run_calls == 1:
+            raise SessionScrapeError("Session dropped while fetching results page.")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def test_results_controller_retries_retryable_scrape_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(results_module, "ResultsScraper", _RetryThenSucceedScraper)
+    monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    controller = results_module.ResultsController()
+    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+
+    controller.run(max_matches=25)
+
+    assert controller.scraper.run_calls == 2

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -31,6 +31,19 @@ class _AlwaysFailingRetryableScraper:
         self.close_calls += 1
 
 
+class _NonRetryableFailingScraper:
+    def __init__(self) -> None:
+        self.run_calls = 0
+        self.close_calls = 0
+
+    def run(self, max_matches: int = 50) -> None:
+        self.run_calls += 1
+        raise RuntimeError("Unexpected parse failure")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 def test_results_controller_retries_retryable_scrape_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -100,7 +113,8 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
     )
 
     with pytest.raises(
-        PipelineError, match="Results stage failed after exhausting retries."
+        PipelineError,
+        match=r"Results stage failed after exhausting retries \(3/3 attempts\)\.",
     ) as exc_info:
         controller.run(max_matches=25)
 
@@ -131,5 +145,70 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
         call_args[0]
         == "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d"
         and call_args[1:] == ("failed", 2, 1, 25)
+        for call_args, _ in info_calls
+    )
+
+
+def test_results_controller_raises_pipeline_error_for_non_retryable_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
+    monkeypatch.setattr(
+        results_module,
+        "ResultsScraper",
+        _NonRetryableFailingScraper,
+    )
+    monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        results_module.logger,
+        "error",
+        lambda *args, **kwargs: error_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        results_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        results_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
+
+    controller = results_module.ResultsController()
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
+
+    with pytest.raises(
+        PipelineError,
+        match=r"Results stage failed on non-retryable error at attempt 1/3\.",
+    ) as exc_info:
+        controller.run(max_matches=25)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert controller.scraper.run_calls == 1
+    assert reset_calls == []
+    assert error_calls == []
+    assert exception_calls == [
+        (
+            (
+                "ResultsController failed on attempt %d/%d: %s",
+                1,
+                3,
+                exc_info.value.__cause__,
+            ),
+            {},
+        )
+    ]
+    assert any(
+        call_args[0]
+        == "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d"
+        and call_args[1:] == ("failed", 0, 1, 25)
         for call_args, _ in info_calls
     )

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -34,8 +34,14 @@ class _AlwaysFailingRetryableScraper:
 def test_results_controller_retries_retryable_scrape_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(results_module, "ResultsScraper", _RetryThenSucceedScraper)
     monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        results_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
 
     controller = results_module.ResultsController()
     monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
@@ -43,17 +49,41 @@ def test_results_controller_retries_retryable_scrape_error(
     controller.run(max_matches=25)
 
     assert controller.scraper.run_calls == 2
+    assert any(
+        call_args[0]
+        == "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d"
+        and call_args[1:] == ("succeeded", 1, 0, 25)
+        for call_args, _ in info_calls
+    )
 
 
 def test_results_controller_raises_pipeline_error_after_exhausting_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(
         results_module,
         "ResultsScraper",
         _AlwaysFailingRetryableScraper,
     )
     monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        results_module.logger,
+        "error",
+        lambda *args, **kwargs: error_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        results_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        results_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
 
     controller = results_module.ResultsController()
     monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
@@ -65,3 +95,29 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
 
     assert isinstance(exc_info.value.__cause__, SessionScrapeError)
     assert controller.scraper.run_calls == 3
+    assert error_calls == [
+        (
+            (
+                "ResultsController exhausted retries after %d attempts; failing stage run.",
+                3,
+            ),
+            {},
+        )
+    ]
+    assert exception_calls == [
+        (
+            (
+                "ResultsController failed on attempt %d/%d: %s",
+                3,
+                3,
+                exc_info.value.__cause__,
+            ),
+            {},
+        )
+    ]
+    assert any(
+        call_args[0]
+        == "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d"
+        and call_args[1:] == ("failed", 2, 1, 25)
+        for call_args, _ in info_calls
+    )

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -35,6 +35,7 @@ def test_results_controller_retries_retryable_scrape_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
     monkeypatch.setattr(results_module, "ResultsScraper", _RetryThenSucceedScraper)
     monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
@@ -44,11 +45,16 @@ def test_results_controller_retries_retryable_scrape_error(
     )
 
     controller = results_module.ResultsController()
-    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
 
     controller.run(max_matches=25)
 
     assert controller.scraper.run_calls == 2
+    assert len(reset_calls) == 1
     assert any(
         call_args[0]
         == "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d"
@@ -63,6 +69,7 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
     error_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    reset_calls: list[object] = []
     monkeypatch.setattr(
         results_module,
         "ResultsScraper",
@@ -86,7 +93,11 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
     )
 
     controller = results_module.ResultsController()
-    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_calls.append(scraper) or scraper,
+    )
 
     with pytest.raises(
         PipelineError, match="Results stage failed after exhausting retries."
@@ -95,6 +106,7 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
 
     assert isinstance(exc_info.value.__cause__, SessionScrapeError)
     assert controller.scraper.run_calls == 3
+    assert len(reset_calls) == 2
     assert error_calls == [
         (
             (

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cs2_analytics.controllers import results_controller as results_module
-from cs2_analytics.exceptions import SessionScrapeError
+from cs2_analytics.exceptions import PipelineError, SessionScrapeError
 
 
 class _RetryThenSucceedScraper:
@@ -13,6 +13,19 @@ class _RetryThenSucceedScraper:
         self.run_calls += 1
         if self.run_calls == 1:
             raise SessionScrapeError("Session dropped while fetching results page.")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _AlwaysFailingRetryableScraper:
+    def __init__(self) -> None:
+        self.run_calls = 0
+        self.close_calls = 0
+
+    def run(self, max_matches: int = 50) -> None:
+        self.run_calls += 1
+        raise SessionScrapeError("Session dropped while fetching results page.")
 
     def close(self) -> None:
         self.close_calls += 1
@@ -30,3 +43,25 @@ def test_results_controller_retries_retryable_scrape_error(
     controller.run(max_matches=25)
 
     assert controller.scraper.run_calls == 2
+
+
+def test_results_controller_raises_pipeline_error_after_exhausting_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        results_module,
+        "ResultsScraper",
+        _AlwaysFailingRetryableScraper,
+    )
+    monkeypatch.setattr(results_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    controller = results_module.ResultsController()
+    monkeypatch.setattr(controller, "_reset_scraper", lambda scraper: scraper)
+
+    with pytest.raises(
+        PipelineError, match="Results stage failed after exhausting retries."
+    ) as exc_info:
+        controller.run(max_matches=25)
+
+    assert isinstance(exc_info.value.__cause__, SessionScrapeError)
+    assert controller.scraper.run_calls == 3

--- a/tests/controllers/test_retry_utils.py
+++ b/tests/controllers/test_retry_utils.py
@@ -1,0 +1,101 @@
+import pytest
+
+from cs2_analytics.controllers import retry_utils
+from cs2_analytics.exceptions import MatchQueueError, SessionScrapeError
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.infos: list[tuple[str, object]] = []
+        self.warnings: list[tuple[str, object]] = []
+        self.exceptions: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def info(self, message: str, *args: object) -> None:
+        self.infos.append((message, *args))
+
+    def warning(self, message: str, *args: object) -> None:
+        self.warnings.append((message, *args))
+
+    def exception(self, *args: object, **kwargs: object) -> None:
+        self.exceptions.append((args, kwargs))
+
+
+class _Scraper:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FailingQueue:
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        raise MatchQueueError("Failed to mark item as failed in match_scrape_queue.")
+
+
+def test_reset_scraper_retries_until_health_check_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(retry_utils.time, "sleep", lambda *_args, **_kwargs: None)
+    logger = _Logger()
+    original = _Scraper("original")
+    created: list[_Scraper] = []
+    health_checks = iter([False, True])
+
+    def scraper_factory() -> _Scraper:
+        scraper = _Scraper(f"generated-{len(created) + 1}")
+        created.append(scraper)
+        return scraper
+
+    def health_check(scraper: _Scraper) -> bool:
+        return next(health_checks)
+
+    recovered = retry_utils.reset_scraper(
+        original,
+        scraper_factory,
+        logger=logger,
+        close_warning_message="Failed to close scraper during recovery: %s",
+        startup_delay_seconds=1.5,
+        health_check=health_check,
+        max_reset_attempts=3,
+        between_attempt_delay_seconds=1.0,
+        recovery_success_message="Scraper session recovered on reset attempt %d",
+        not_ready_warning_message=(
+            "New scraper session not ready on reset attempt %d/%d; retrying reset"
+        ),
+    )
+
+    assert recovered is created[1]
+    assert original.close_calls == 1
+    assert created[0].close_calls == 1
+    assert logger.warnings == [
+        (
+            "New scraper session not ready on reset attempt %d/%d; retrying reset",
+            1,
+            3,
+        )
+    ]
+    assert logger.infos == [("Scraper session recovered on reset attempt %d", 2)]
+
+
+def test_mark_item_failed_propagates_queue_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _Logger()
+    error = SessionScrapeError("Failed to fetch match page: https://www.hltv.org")
+
+    with pytest.raises(
+        MatchQueueError, match="Failed to mark item as failed in match_scrape_queue."
+    ):
+        retry_utils.mark_item_failed(
+            _FailingQueue(),
+            "match-1",
+            error,
+            logger=logger,
+            log_message="Error processing match %s on attempt %d/%d: %s",
+            attempt=3,
+            max_attempts=3,
+        )
+
+    assert logger.exceptions == []

--- a/tests/controllers/test_retry_utils.py
+++ b/tests/controllers/test_retry_utils.py
@@ -21,12 +21,15 @@ class _Logger:
 
 
 class _Scraper:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, close_error: Exception | None = None) -> None:
         self.name = name
         self.close_calls = 0
+        self.close_error = close_error
 
     def close(self) -> None:
         self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
 
 
 class _FailingQueue:
@@ -99,3 +102,52 @@ def test_mark_item_failed_propagates_queue_errors(
         )
 
     assert logger.exceptions == []
+
+
+def test_reset_scraper_warns_on_close_failure_and_returns_fallback_scraper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(retry_utils.time, "sleep", lambda *_args, **_kwargs: None)
+    logger = _Logger()
+    original = _Scraper("original", close_error=RuntimeError("close failed"))
+    created: list[_Scraper] = []
+
+    def scraper_factory() -> _Scraper:
+        scraper = _Scraper(f"generated-{len(created) + 1}")
+        created.append(scraper)
+        return scraper
+
+    fallback = retry_utils.reset_scraper(
+        original,
+        scraper_factory,
+        logger=logger,
+        close_warning_message="Failed to close scraper during recovery: %s",
+        startup_delay_seconds=1.0,
+        health_check=lambda scraper: False,
+        max_reset_attempts=2,
+        between_attempt_delay_seconds=1.0,
+        not_ready_warning_message=(
+            "New scraper session not ready on reset attempt %d/%d; retrying reset"
+        ),
+        fallback_warning_message="Returning scraper after reset retries.",
+    )
+
+    assert fallback is created[2]
+    assert original.close_calls == 1
+    assert created[0].close_calls == 1
+    assert created[1].close_calls == 1
+    assert logger.warnings[0][0] == "Failed to close scraper during recovery: %s"
+    assert str(logger.warnings[0][1]) == "close failed"
+    assert logger.warnings[1:] == [
+        (
+            "New scraper session not ready on reset attempt %d/%d; retrying reset",
+            1,
+            2,
+        ),
+        (
+            "New scraper session not ready on reset attempt %d/%d; retrying reset",
+            2,
+            2,
+        ),
+        ("Returning scraper after reset retries.",),
+    ]

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -1,0 +1,72 @@
+from bs4 import BeautifulSoup
+import pytest
+
+from cs2_analytics.exceptions import MapParseError, MatchParseError
+from cs2_analytics.parsers.map_parser import MapParser
+from cs2_analytics.parsers.match_parser import MatchParser
+
+
+def test_match_parser_raises_typed_error_for_missing_team_names() -> None:
+    parser = MatchParser()
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    with pytest.raises(MatchParseError, match="Missing team names on match page.") as exc_info:
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_map_parser_raises_typed_error_for_missing_kills() -> None:
+    parser = MapParser()
+    soup = BeautifulSoup(
+        """
+        <html>
+          <body>
+            <div class="match-info-box">
+              <div class="small-text">Map</div>
+              Inferno
+            </div>
+            <table class="stats-table totalstats">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Op. K-D</th>
+                  <th>MKs</th>
+                  <th>KAST</th>
+                  <th>1vsX</th>
+                  <th>K (hs)</th>
+                  <th>A (f)</th>
+                  <th>D (t)</th>
+                  <th>ADR</th>
+                  <th>Swing</th>
+                  <th>Rating 3.0</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="st-player"><a href="/player/22/test-player">TestPlayer</a></td>
+                  <td class="st-opkd">1 : 1</td>
+                  <td class="st-mks">1</td>
+                  <td class="st-kast">70.0%</td>
+                  <td class="st-clutches">0</td>
+                  <td class="st-kills"></td>
+                  <td class="st-assists">2 (0)</td>
+                  <td class="st-deaths">10 (1)</td>
+                  <td class="st-adr">80.0</td>
+                  <td class="st-roundSwing">+1.00%</td>
+                  <td class="st-rating">1.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    with pytest.raises(MapParseError, match="No player kills logged."):
+        parser.parse_map(
+            soup,
+            map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
+            map_id="2",
+        )

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -1,0 +1,24 @@
+from contextlib import contextmanager
+
+import pytest
+
+from cs2_analytics.exceptions import MatchQueueError
+from cs2_analytics.queues import base_scrape_queue as base_queue_module
+from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
+
+
+class _FailingQueueDb:
+    @contextmanager
+    def get_cursor(self):
+        raise RuntimeError("db down")
+        yield
+
+
+def test_match_queue_wraps_db_failures_in_typed_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(base_queue_module, "db", _FailingQueueDb())
+    queue = MatchScrapeQueue()
+
+    with pytest.raises(MatchQueueError, match="Failed to queue items in match_scrape_queue."):
+        queue.queue_many([("1", "https://www.hltv.org/matches/1/test")])

--- a/tests/storage/test_demo_storage.py
+++ b/tests/storage/test_demo_storage.py
@@ -1,0 +1,46 @@
+from datetime import UTC
+from contextlib import contextmanager
+
+from cs2_analytics.storage import demo_storage as demo_storage_module
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.executed = False
+        self.query: str | None = None
+        self.values: dict | None = None
+
+    def execute(self, query: str, values: dict) -> None:
+        self.executed = True
+        self.query = query
+        self.values = values
+
+
+class _CursorOnlyDb:
+    def __init__(self) -> None:
+        self.cursor = _RecordingCursor()
+
+    @contextmanager
+    def get_cursor(self):
+        yield self.cursor
+
+
+def test_store_demo_file_relies_on_get_cursor_for_commit(
+    monkeypatch,
+) -> None:
+    fake_db = _CursorOnlyDb()
+    monkeypatch.setattr(demo_storage_module, "db", fake_db)
+
+    demo_storage_module.store_demo_file(
+        map_id=123,
+        demo_url="https://www.hltv.org/download/demo/123",
+        local_path="demos/test.dem",
+        parsed=True,
+    )
+
+    assert fake_db.cursor.executed is True
+    assert fake_db.cursor.values is not None
+    assert fake_db.cursor.values["map_id"] == 123
+    assert fake_db.cursor.values["demo_url"] == "https://www.hltv.org/download/demo/123"
+    assert fake_db.cursor.values["last_inserted_at"].tzinfo is UTC
+    assert fake_db.cursor.values["last_processed_at"].tzinfo is UTC

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -1,0 +1,91 @@
+import io
+import builtins
+
+import pytest
+
+from cs2_analytics.exceptions import DatabaseOperationError
+from cs2_analytics.storage import initialize_db as initialize_db_module
+
+
+class _RecordingCursor:
+    def __init__(self, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.executed_sql: str | None = None
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.exited = True
+
+    def execute(self, sql: str) -> None:
+        if self.should_fail:
+            raise RuntimeError("schema apply failed")
+        self.executed_sql = sql
+
+
+class _RecordingConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor_obj = cursor
+        self.entered = False
+        self.exited = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.exited = True
+
+    def cursor(self) -> _RecordingCursor:
+        return self.cursor_obj
+
+
+def test_initialize_database_executes_schema_with_context_managers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    connection = _RecordingConnection(cursor)
+
+    monkeypatch.setattr(initialize_db_module.psycopg2, "connect", lambda **_: connection)
+    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda *args, **kwargs: io.StringIO("SELECT 1;"),
+    )
+
+    initialize_db_module.initialize_database()
+
+    assert connection.entered is True
+    assert connection.exited is True
+    assert cursor.entered is True
+    assert cursor.exited is True
+    assert cursor.executed_sql == "SELECT 1;"
+
+
+def test_initialize_database_wraps_schema_failures_in_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(should_fail=True)
+    connection = _RecordingConnection(cursor)
+
+    monkeypatch.setattr(initialize_db_module.psycopg2, "connect", lambda **_: connection)
+    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
+    monkeypatch.setattr(
+        builtins,
+        "open",
+        lambda *args, **kwargs: io.StringIO("SELECT 1;"),
+    )
+
+    with pytest.raises(
+        DatabaseOperationError, match="Failed to initialize database schema."
+    ) as exc_info:
+        initialize_db_module.initialize_database()
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert connection.exited is True
+    assert cursor.exited is True

--- a/tests/storage/test_storage_exceptions.py
+++ b/tests/storage/test_storage_exceptions.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cs2_analytics.exceptions import MatchStorageError
+from cs2_analytics.models.match import Match
+from cs2_analytics.storage import match_storage as match_storage_module
+
+
+class _FailingCursor:
+    def execute(self, *args, **kwargs) -> None:
+        raise RuntimeError("insert failed")
+
+
+class _FailingConnection:
+    def __init__(self) -> None:
+        self.rollback_called = False
+
+    def cursor(self) -> _FailingCursor:
+        return _FailingCursor()
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        self.rollback_called = True
+
+
+class _FakeDb:
+    def __init__(self, conn: _FailingConnection) -> None:
+        self.conn = conn
+        self.released = False
+
+    def get_connection(self) -> _FailingConnection:
+        return self.conn
+
+    def release_connection(self, conn: _FailingConnection) -> None:
+        self.released = True
+
+
+def test_store_matches_wraps_database_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FailingConnection()
+    fake_db = _FakeDb(conn)
+    monkeypatch.setattr(match_storage_module, "db", fake_db)
+    now = datetime.now(UTC)
+
+    match = Match(
+        match_id=1,
+        match_url="https://www.hltv.org/matches/1/test",
+        map_links=[],
+        demo_links=[],
+        team1="A",
+        team2="B",
+        score1=16,
+        score2=10,
+        winner="A",
+        event="Event",
+        match_type="bo1",
+        forfeit=False,
+        date="2026-01-01",
+        last_inserted_at=now,
+        last_scraped_at=now,
+        last_updated_at=now,
+        data_complete=True,
+    )
+
+    with pytest.raises(MatchStorageError, match="Failed to store match records."):
+        match_storage_module.store_matches([match])
+
+    assert conn.rollback_called is True
+    assert fake_db.released is True

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,29 @@
+from cs2_analytics.exceptions import (
+    CS2AnalyticsError,
+    DatabaseConnectionError,
+    DatabaseError,
+    MapParseError,
+    MatchParseError,
+    ParseError,
+    PlayerStorageError,
+    QueueError,
+    RetryableScrapeError,
+    ScrapeError,
+    SessionScrapeError,
+    StorageError,
+)
+
+
+def test_exception_hierarchy_uses_shared_base_classes() -> None:
+    assert issubclass(ParseError, CS2AnalyticsError)
+    assert issubclass(ScrapeError, CS2AnalyticsError)
+    assert issubclass(StorageError, CS2AnalyticsError)
+    assert issubclass(QueueError, CS2AnalyticsError)
+
+    assert issubclass(MatchParseError, ParseError)
+    assert issubclass(MapParseError, ParseError)
+    assert issubclass(RetryableScrapeError, ScrapeError)
+    assert issubclass(SessionScrapeError, RetryableScrapeError)
+    assert issubclass(DatabaseError, StorageError)
+    assert issubclass(DatabaseConnectionError, DatabaseError)
+    assert issubclass(PlayerStorageError, StorageError)


### PR DESCRIPTION
# Summary

This PR completes the branch’s error-handling and observability hardening for the active ingestion pipeline.

It standardizes typed exceptions across parsing, scraping, storage, queue, and pipeline boundaries, makes controllers the clear owners of retry and terminal failure behavior, centralizes shared retry/session-recovery logic, and adds run-level visibility plus targeted retry/recovery tests for the active `results`, `match`, and `map` stages.

# What Changed

- Added and extended the shared exception hierarchy in `cs2_analytics/exceptions.py`
- Updated parsers, scrapers, storage modules, and queues to raise typed exceptions instead of leaking generic runtime errors
- Refactored controllers to treat only `RetryableScrapeError` failures as retryable
- Centralized shared controller retry/session-recovery behavior in `cs2_analytics/controllers/retry_utils.py`
- Defined retry exhaustion policy:
  - `results` fails the stage run after exhausting retries
  - `match` and `map` mark the current item failed and continue processing
- Added run-level observability:
  - retry exhaustion logs
  - controller summary logs for retries, successes, failures, and stage status
- Expanded targeted tests for:
  - typed exception behavior
  - parser/storage/queue error wrapping
  - controller retry and exhaustion behavior
  - match/map continue-on-failure behavior
  - retry helper recovery and fallback behavior
- Updated `docs/backlog.md` and `docs/current_focus.md` to reflect completed hardening work

# Behavior Notes

- Retry behavior is now driven by typed exceptions instead of brittle string matching
- Queue/storage failures still bubble appropriately and are not swallowed by controller helpers
- The active pipeline stages remain independently runnable and decoupled
- Demo-stage work remains deferred and was not brought into the hardened active flow

# Validation

```powershell
.\.venv\Scripts\python.exe -m pytest -q
```
20 passes , 3 skipped (intentionally)

# Follow-up Work
- Clean up scraper/parser helper bondaries and naming
- Evaluate queue schema upgrades for future multi-worker support