### PR TITLE
Cleanup/parser scraper helper boundaries

### DIFF
--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -13,9 +13,6 @@ logger = get_logger(__name__)
 class MapParser:
     """Extracts player stats from a map stats page."""
 
-    def __init__(self):
-        """Initializes the parser."""
-
     def parse_map(self, soup, map_url: str, map_id: int | str) -> list[Player]:
         """Extracts player object from a map stats page."""
         logger.info("Parsing %s for player stats", map_url)
@@ -52,20 +49,28 @@ class MapParser:
                 team_name = team_header.text.strip() if team_header else "Unknown"
 
                 column_map = self._build_column_map(table)
-                opkd_idx = self._pick_col(column_map, ["op.k-d", "opkd", "op.kd"], 1)
-                mks_idx = self._pick_col(column_map, ["mks"], 2)
-                kast_idx = self._pick_col(column_map, ["kast"], 4)
-                clutches_idx = self._pick_col(column_map, ["1vsx", "clutches"], 6)
-                kills_idx = self._pick_col(column_map, ["k(hs)", "khs", "kills"], 7)
-                assists_idx = self._pick_col(column_map, ["a(f)", "af", "assists"], 9)
-                deaths_idx = self._pick_col(
+                opkd_idx = self._pick_column_index(
+                    column_map, ["op.k-d", "opkd", "op.kd"], 1
+                )
+                mks_idx = self._pick_column_index(column_map, ["mks"], 2)
+                kast_idx = self._pick_column_index(column_map, ["kast"], 4)
+                clutches_idx = self._pick_column_index(
+                    column_map, ["1vsx", "clutches"], 6
+                )
+                kills_idx = self._pick_column_index(
+                    column_map, ["k(hs)", "khs", "kills"], 7
+                )
+                assists_idx = self._pick_column_index(
+                    column_map, ["a(f)", "af", "assists"], 9
+                )
+                deaths_idx = self._pick_column_index(
                     column_map, ["d(t)", "dt", "d(q)", "dq", "deaths", "d"], 10
                 )
-                adr_idx = self._pick_col(column_map, ["adr"], 12)
-                round_swing_idx = self._pick_col(
+                adr_idx = self._pick_column_index(column_map, ["adr"], 12)
+                round_swing_idx = self._pick_column_index(
                     column_map, ["swing", "roundswing"], 16
                 )
-                rating_idx = self._pick_col(
+                rating_idx = self._pick_column_index(
                     column_map,
                     ["rating3.0", "rating30", "rating2.1", "rating2.0", "rating", "rt"],
                     17,
@@ -102,7 +107,7 @@ class MapParser:
 
                     # Parse K(hs) format from column 5: "19(10)" -> kills=19, headshots=10
                     kills_text = self._require_metric_text(
-                        self._row_metric_text(
+                        self._extract_metric_text(
                             cols,
                             kills_idx,
                             ["st-kills"],
@@ -112,7 +117,7 @@ class MapParser:
                     kills, headshots = self._parse_pair(kills_text)
 
                     # Parse A(f) format from column 6: "3(0)" -> assists=3, flash_assists=0
-                    assists_text = self._row_metric_text(
+                    assists_text = self._extract_metric_text(
                         cols,
                         assists_idx,
                         ["st-assists"],
@@ -121,7 +126,7 @@ class MapParser:
 
                     # Parse D(t) format from table: "16(5)" -> deaths=16, traded_deaths=5
                     deaths_text = self._require_metric_text(
-                        self._row_metric_text(
+                        self._extract_metric_text(
                             cols,
                             deaths_idx,
                             ["st-deaths"],
@@ -131,16 +136,16 @@ class MapParser:
                     deaths, traded_deaths = self._parse_pair(deaths_text)
 
                     opening_kills, opening_deaths = self._parse_colon_pair(
-                        self._row_metric_text(cols, opkd_idx, ["st-opkd"])
+                        self._extract_metric_text(cols, opkd_idx, ["st-opkd"])
                     )
                     multi_kills = self._parse_int_value(
-                        self._row_metric_text(cols, mks_idx, ["st-mks"])
+                        self._extract_metric_text(cols, mks_idx, ["st-mks"])
                     )
                     clutches_won = self._parse_int_value(
-                        self._row_metric_text(cols, clutches_idx, ["st-clutches"])
+                        self._extract_metric_text(cols, clutches_idx, ["st-clutches"])
                     )
                     round_swing = self._parse_percent_value(
-                        self._row_metric_text(
+                        self._extract_metric_text(
                             cols,
                             round_swing_idx,
                             ["st-roundSwing"],
@@ -150,7 +155,7 @@ class MapParser:
 
                     # Parse KAST percentage from column 3: "72.7%" -> 0.727
                     try:
-                        kast_text = self._row_metric_text(
+                        kast_text = self._extract_metric_text(
                             cols,
                             kast_idx,
                             ["st-kast"],
@@ -161,13 +166,13 @@ class MapParser:
                         kast = 0.0
                         logger.warning(
                             "Could not parse KAST from: %s",
-                            self._row_metric_text(cols, kast_idx, ["st-kast"]),
+                            self._extract_metric_text(cols, kast_idx, ["st-kast"]),
                         )
 
                     # Parse other numeric fields with error handling
                     try:
                         adr = float(
-                            self._row_metric_text(
+                            self._extract_metric_text(
                                 cols,
                                 adr_idx,
                                 ["st-adr"],
@@ -178,12 +183,12 @@ class MapParser:
                         adr = 0.0
                         logger.warning(
                             "Could not parse ADR from: %s",
-                            self._row_metric_text(cols, adr_idx, ["st-adr"]),
+                            self._extract_metric_text(cols, adr_idx, ["st-adr"]),
                         )
 
                     # Parse rating from column 10 (skip the Swing column 9 which has percentages)
                     try:
-                        rating_text = self._row_metric_text(
+                        rating_text = self._extract_metric_text(
                             cols,
                             rating_idx,
                             ["st-rating"],
@@ -200,7 +205,7 @@ class MapParser:
                         rating = 0.0
                         logger.warning(
                             "Could not parse Rating from: %s",
-                            self._row_metric_text(cols, rating_idx, ["st-rating"]),
+                            self._extract_metric_text(cols, rating_idx, ["st-rating"]),
                         )
 
                     kd_diff = kills - deaths
@@ -261,7 +266,9 @@ class MapParser:
                 mapping[normalized] = idx
         return mapping
 
-    def _pick_col(self, mapping: dict[str, int], keys: list[str], default: int) -> int:
+    def _pick_column_index(
+        self, mapping: dict[str, int], keys: list[str], default: int
+    ) -> int:
         """Returns the first matching column index from candidate normalized keys."""
         for key in keys:
             normalized = self._normalize_header(key)
@@ -269,12 +276,12 @@ class MapParser:
                 return mapping[normalized]
         return default
 
-    def _safe_col_text(self, cols, idx: int) -> str:
+    def _column_text_or_empty(self, cols, idx: int) -> str:
         if idx < len(cols):
             return str(cols[idx].get_text(strip=True))
         return ""
 
-    def _row_metric_text(
+    def _extract_metric_text(
         self,
         cols,
         fallback_idx: int,
@@ -315,7 +322,7 @@ class MapParser:
             if hidden_match is not None:
                 return hidden_match
 
-        return self._safe_col_text(cols, fallback_idx)
+        return self._column_text_or_empty(cols, fallback_idx)
 
     def _parse_pair(self, text: str) -> tuple[int, int]:
         """Parses values like '19(10)' into tuple (19, 10)."""

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -37,24 +37,7 @@ class MatchParser:
             event_tag = soup.find("div", class_="event text-ellipsis")
             event = event_tag.text.strip() if event_tag else "Unknown Event"
 
-            # Extract match type (BO1, BO3, etc.)
-            match_type_tag = soup.find("div", class_="padding preformatted-text")
-            match_type = (
-                match_type_tag.text.strip().upper() if match_type_tag else "UNKNOWN"
-            )
-            best_of_temp = re.search(r"^(.*?)(?=\n|$)", match_type)
-            best_type = best_of_temp.group(1).strip() if best_of_temp else "Unknown"
-
-            def determine_match_type(text: str) -> str:
-                """Determines match type based on presence of '3' or '5' in the text."""
-                if "3" in text:
-                    return "bo3"
-                elif "5" in text:
-                    return "bo5"
-                else:
-                    return "bo1"
-
-            best_ty: str = determine_match_type(best_type)
+            best_ty = self._extract_match_type(soup)
 
             # Check if match was forfeited
             map_name_check = soup.find("div", class_="mapname").text.lower()
@@ -142,3 +125,21 @@ class MatchParser:
         """Extracts the first numeric ID from a URL."""
         match = re.search(r"(\d+)", url)
         return match.group(1) if match else url
+
+    def _extract_match_type(self, soup) -> str:
+        """Extracts a normalized best-of value such as bo1, bo3, or bo5."""
+        match_type_tag = soup.find("div", class_="padding preformatted-text")
+        match_type_text = (
+            match_type_tag.text.strip().upper() if match_type_tag else "UNKNOWN"
+        )
+        best_of_match = re.search(r"^(.*?)(?=\n|$)", match_type_text)
+        best_of_text = best_of_match.group(1).strip() if best_of_match else "UNKNOWN"
+        return self._normalize_best_of_type(best_of_text)
+
+    def _normalize_best_of_type(self, text: str) -> str:
+        """Maps the scraped best-of text into the normalized match type."""
+        if "3" in text:
+            return "bo3"
+        if "5" in text:
+            return "bo5"
+        return "bo1"

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -29,10 +29,6 @@ class MapScraper:
 
     def fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a map page and returns its parsed HTML."""
-        return self._fetch_soup(url)
-
-    def _fetch_soup(self, url: str) -> BeautifulSoup:
-        """Loads a map page and returns its parsed HTML."""
         try:
             self.driver.get(url)
             time.sleep(3.0)

--- a/cs2_analytics/scrapers/match_scraper.py
+++ b/cs2_analytics/scrapers/match_scraper.py
@@ -29,9 +29,6 @@ class MatchScraper:
 
     def fetch_soup(self, url: str) -> BeautifulSoup:
         """Loads a match page and returns its parsed HTML."""
-        return self._fetch_soup(url)
-
-    def _fetch_soup(self, url: str) -> BeautifulSoup:
         try:
             self.driver.get(url)
             time.sleep(3)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,15 +18,16 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [x] Map parser hidden-vs-visible metric regression fix + tests
 - [x] Storage ownership centralized for match/player writes
 - [x] Controller/parser/scraper responsibilities aligned for active match/map flow
-
-### Remaining hardening priorities
-
 - [x] Decide failure policy when retries are exhausted (results fails run; match/map fail item and continue)
 - [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [x] Improve observability around retry exhaustion and run-level outcomes
 - [x] Add targeted tests for controller retry and recovery behavior
 - [x] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
 - [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
+
+### Remaining hardening priorities
+
+- [ ] Add field-specific parser extraction errors for required match/map fields
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
 
 ---

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -25,7 +25,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [x] Standardize scraper/parser/storage error handling so controllers own retry and terminal queue outcomes
 - [x] Improve observability around retry exhaustion and run-level outcomes
 - [x] Add targeted tests for controller retry and recovery behavior
-- [ ] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
+- [x] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
 - [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
 


### PR DESCRIPTION
# Summary

This PR cleans up scraper/parser helper boundaries in the active match/map ingestion flow.

It keeps the behavior the same while making the public/private method boundaries clearer, removing redundant helper indirection in scrapers, and making parser helper names more explicit so responsibilities are easier to follow and maintain.

# What Changed

- Removed redundant private fetch wrappers in:
  - `cs2_analytics/scrapers/match_scraper.py`
  - `cs2_analytics/scrapers/map_scraper.py`
- Kept `fetch_soup()` as the single public fetch entrypoint for the active scrapers
- Extracted match-type parsing into explicit private helpers in `cs2_analytics/parsers/match_parser.py`
- Renamed ambiguous internal map parser helpers in `cs2_analytics/parsers/map_parser.py` to clearer private names
- Removed the empty constructor from `cs2_analytics/parsers/map_parser.py`
- Updated the backlog to call out field-specific parser extraction errors as a separate remaining hardening item

# Why

This branch is intentionally small and behavior-neutral.

The goal is to make it easier to see:
- which scraper/parser methods are public entrypoints
- which methods are internal helpers
- where parsing logic actually lives
- how helper responsibilities align with the repo’s layer conventions

That should make future parser hardening work easier to review and safer to implement in separate branches.

# Validation

```powershell
.\.venv\Scripts\python.exe -m pytest -q tests\parsers\test_parser_exceptions.py tests\parsers\test_map_parser_regression.py tests\controllers\test_match_controller.py tests\controllers\test_map_controller.py
```
10 passed

# Follow-up Work
- Add field-specific parser extraction errors for required match/map fields
- Define required vs optional parser fields explicitly
- Add malformed-markup parser tests for required extraction paths