### PR TITLE
add field-specific parser errors for required match and map fieldsGive

### DIFF
--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -17,23 +17,12 @@ class MapParser:
         """Extracts player object from a map stats page."""
         logger.info("Parsing %s for player stats", map_url)
         players = []
-        map_name = "unknown"
         try:
             map_id_value = int(map_id)
         except (TypeError, ValueError):
             map_id_value = self._extract_numeric_id(map_url)
 
-        match_box = soup.find("div", class_="match-info-box")
-
-        if match_box:
-            # Find the small-text div and get the next sibling that's a string
-            small_text_div = match_box.find("div", class_="small-text")
-            if small_text_div:
-                for elem in small_text_div.next_siblings:
-                    if isinstance(elem, str):
-                        map_name = elem.strip()
-                        if map_name:
-                            break
+        map_name = self._extract_map_name(soup)
         try:
             tables = soup.select("table.stats-table.totalstats")
             if not tables:
@@ -101,9 +90,7 @@ class MapParser:
                         self._extract_numeric_id(player_url) if player_url else -1
                     )
 
-                    player_name = (
-                        name_tag.text.strip() if name_tag else cols[0].text.strip()
-                    )
+                    player_name = self._extract_player_name(cols, name_tag)
 
                     # Parse K(hs) format from column 5: "19(10)" -> kills=19, headshots=10
                     kills_text = self._require_metric_text(
@@ -216,7 +203,7 @@ class MapParser:
                         player_id=player_id,
                         player_name=player_name,
                         player_url=player_url or "",
-                        map_name=map_name or "unknown",
+                        map_name=map_name,
                         team_name=team_name,
                         kills=kills,
                         headshots=headshots,
@@ -253,6 +240,24 @@ class MapParser:
     def _normalize_header(self, value: str) -> str:
         return re.sub(r"[^a-z0-9.]", "", value.lower())
 
+    def _extract_map_name(self, soup) -> str:
+        """Extracts the map name from the match info box."""
+        match_box = soup.find("div", class_="match-info-box")
+        if not match_box:
+            raise MapParseError("Failed to extract map name from map stats page.")
+
+        small_text_div = match_box.find("div", class_="small-text")
+        if not small_text_div:
+            raise MapParseError("Failed to extract map name from map stats page.")
+
+        for elem in small_text_div.next_siblings:
+            if isinstance(elem, str):
+                map_name = elem.strip()
+                if map_name:
+                    return map_name
+
+        raise MapParseError("Failed to extract map name from map stats page.")
+
     def _build_column_map(self, table) -> dict[str, int]:
         """Builds a normalized header->index map from table headers."""
         mapping = {}
@@ -265,6 +270,20 @@ class MapParser:
             if normalized not in mapping:
                 mapping[normalized] = idx
         return mapping
+
+    def _extract_player_name(self, cols, name_tag) -> str:
+        """Extracts a non-empty player name from the first stats cell."""
+        if name_tag:
+            player_name = name_tag.get_text(strip=True)
+            if player_name:
+                return player_name
+
+        if cols:
+            player_name = cols[0].get_text(strip=True)
+            if player_name:
+                return player_name
+
+        raise MapParseError("Failed to extract player name from map stats page.")
 
     def _pick_column_index(
         self, mapping: dict[str, int], keys: list[str], default: int

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -22,36 +22,14 @@ class MatchParser:
 
             team1, team2 = self._extract_teams(soup)
             logger.debug("Team1: %s Team2: %s", team1, team2)
-
-            # Extract scores
-            team1_gradient = soup.find("div", class_="team1-gradient")
-            score1 = int(team1_gradient.a.find_next_sibling("div").text.strip())
-
-            team2_gradient = soup.find("div", class_="team2-gradient")
-            score2 = int(team2_gradient.a.find_next_sibling("div").text.strip())
+            score1, score2 = self._extract_scores(soup)
 
             winner = team1 if score1 > score2 else team2
             logger.debug("Winner: %s", winner)
-
-            # Extract event name
-            event_tag = soup.find("div", class_="event text-ellipsis")
-            event = event_tag.text.strip() if event_tag else "Unknown Event"
-
+            event = self._extract_event_name(soup)
             best_ty = self._extract_match_type(soup)
-
-            # Check if match was forfeited
-            map_name_check = soup.find("div", class_="mapname").text.lower()
-            forfeit = map_name_check == "default"
-
-            # Extract match date
-            match_date_tag = soup.find("div", class_="date")
-            match_date = (
-                dt.datetime.fromtimestamp(
-                    int(match_date_tag["data-unix"]) / 1000
-                ).strftime("%Y-%m-%d")
-                if match_date_tag and match_date_tag.has_attr("data-unix")
-                else None
-            )
+            forfeit = self._extract_forfeit_status(soup)
+            match_date = self._extract_match_date(soup)
 
             demo_links = self._extract_demo_links(soup)
             map_links = self._extract_map_stats_links(soup)
@@ -87,9 +65,11 @@ class MatchParser:
         """Extracts team names from the match page."""
         team_names = soup.find_all("div", class_="teamName")
         try:
-            team1, team2 = [t.text.strip() for t in team_names[0:2]]
+            team1, team2 = [t.get_text(strip=True) for t in team_names[0:2]]
         except ValueError as e:
             raise MatchParseError("Missing team names on match page.") from e
+        if not team1 or not team2:
+            raise MatchParseError("Missing team names on match page.")
         return team1, team2
 
     def _extract_demo_links(self, soup) -> list[tuple[str, str]]:
@@ -126,14 +106,42 @@ class MatchParser:
         match = re.search(r"(\d+)", url)
         return match.group(1) if match else url
 
+    def _extract_scores(self, soup) -> tuple[int, int]:
+        """Extracts both team scores from the match page."""
+        try:
+            team1_gradient = soup.find("div", class_="team1-gradient")
+            score1 = int(team1_gradient.a.find_next_sibling("div").text.strip())
+
+            team2_gradient = soup.find("div", class_="team2-gradient")
+            score2 = int(team2_gradient.a.find_next_sibling("div").text.strip())
+        except (AttributeError, TypeError, ValueError) as e:
+            raise MatchParseError("Failed to extract team scores from match page.") from e
+        return score1, score2
+
+    def _extract_event_name(self, soup) -> str:
+        """Extracts the event name for the match."""
+        event_tag = soup.find("div", class_="event text-ellipsis")
+        if event_tag:
+            event_name = event_tag.text.strip()
+            if event_name:
+                return event_name
+        raise MatchParseError("Failed to extract event name from match page.")
+
     def _extract_match_type(self, soup) -> str:
         """Extracts a normalized best-of value such as bo1, bo3, or bo5."""
         match_type_tag = soup.find("div", class_="padding preformatted-text")
-        match_type_text = (
-            match_type_tag.text.strip().upper() if match_type_tag else "UNKNOWN"
-        )
+        if not match_type_tag:
+            raise MatchParseError("Failed to extract match type from match page.")
+
+        match_type_text = match_type_tag.text.strip().upper()
+        if not match_type_text:
+            raise MatchParseError("Failed to extract match type from match page.")
+
         best_of_match = re.search(r"^(.*?)(?=\n|$)", match_type_text)
-        best_of_text = best_of_match.group(1).strip() if best_of_match else "UNKNOWN"
+        if not best_of_match:
+            raise MatchParseError("Failed to extract match type from match page.")
+
+        best_of_text = best_of_match.group(1).strip()
         return self._normalize_best_of_type(best_of_text)
 
     def _normalize_best_of_type(self, text: str) -> str:
@@ -142,4 +150,29 @@ class MatchParser:
             return "bo3"
         if "5" in text:
             return "bo5"
-        return "bo1"
+        if "1" in text:
+            return "bo1"
+        raise MatchParseError("Failed to extract match type from match page.")
+
+    def _extract_forfeit_status(self, soup) -> bool:
+        """Extracts whether the match was forfeited/defaulted."""
+        map_name_tag = soup.find("div", class_="mapname")
+        if not map_name_tag:
+            raise MatchParseError("Failed to extract forfeit status from match page.")
+        map_name = map_name_tag.get_text(strip=True)
+        if not map_name:
+            raise MatchParseError("Failed to extract forfeit status from match page.")
+        return map_name.lower() == "default"
+
+    def _extract_match_date(self, soup) -> str:
+        """Extracts the match date in YYYY-MM-DD format."""
+        match_date_tag = soup.find("div", class_="date")
+        if not match_date_tag or not match_date_tag.has_attr("data-unix"):
+            raise MatchParseError("Failed to extract match date from match page.")
+
+        try:
+            return dt.datetime.fromtimestamp(
+                int(match_date_tag["data-unix"]) / 1000
+            ).strftime("%Y-%m-%d")
+        except (TypeError, ValueError, OSError) as e:
+            raise MatchParseError("Failed to extract match date from match page.") from e

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -174,5 +174,5 @@ class MatchParser:
             return dt.datetime.fromtimestamp(
                 int(match_date_tag["data-unix"]) / 1000
             ).strftime("%Y-%m-%d")
-        except (TypeError, ValueError, OSError) as e:
+        except (TypeError, ValueError, OSError, OverflowError) as e:
             raise MatchParseError("Failed to extract match date from match page.") from e

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,7 +27,7 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 
 ### Remaining hardening priorities
 
-- [ ] Add field-specific parser extraction errors for required match/map fields
+- [x] Add field-specific parser extraction errors for required match/map fields
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
 
 ---

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -21,6 +21,7 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Retry-exhaustion policy defined for results vs match/map stages
 - Run-level retry/failure visibility added to controller summaries and retry-exhaustion logs
 - Targeted controller and retry-helper tests added for retry, recovery, and run summaries
+- Field-specific parser extraction errors added for required match/map fields with direct parser coverage
 
 ## Current Work
 

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -303,6 +303,37 @@ def test_match_parser_raises_typed_error_for_missing_match_date() -> None:
         parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
 
 
+def test_match_parser_raises_typed_error_for_overflow_match_date() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="mapname">Inferno</div>
+            <div class="date" data-unix="999999999999999999999"></div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match date from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
 def test_map_parser_raises_typed_error_for_missing_map_name() -> None:
     parser = MapParser()
     soup = _build_map_soup(

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -6,6 +6,87 @@ from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.parsers.match_parser import MatchParser
 
 
+def _build_match_soup(html_override: str | None = None) -> BeautifulSoup:
+    if html_override is not None:
+        return BeautifulSoup(html_override, "html.parser")
+
+    return BeautifulSoup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="mapname">Inferno</div>
+            <div class="date" data-unix="1704067200000"></div>
+            <a class="results-stats" href="/stats/matches/mapstatsid/2/test-map"></a>
+          </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+
+def _build_map_soup(html_override: str | None = None) -> BeautifulSoup:
+    if html_override is not None:
+        return BeautifulSoup(html_override, "html.parser")
+
+    return BeautifulSoup(
+        """
+        <html>
+          <body>
+            <div class="match-info-box">
+              <div class="small-text">Map</div>
+              Inferno
+            </div>
+            <table class="stats-table totalstats">
+              <thead>
+                <tr>
+                  <th class="st-teamname">BIG</th>
+                  <th>Op. K-D</th>
+                  <th>MKs</th>
+                  <th>KAST</th>
+                  <th>1vsX</th>
+                  <th>K (hs)</th>
+                  <th>A (f)</th>
+                  <th>D (t)</th>
+                  <th>ADR</th>
+                  <th>Swing</th>
+                  <th>Rating 3.0</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="st-player"><a href="/player/22/test-player">TestPlayer</a></td>
+                  <td class="st-opkd">1 : 1</td>
+                  <td class="st-mks">1</td>
+                  <td class="st-kast">70.0%</td>
+                  <td class="st-clutches">0</td>
+                  <td class="st-kills">20 (10)</td>
+                  <td class="st-assists">2 (0)</td>
+                  <td class="st-deaths">10 (1)</td>
+                  <td class="st-adr">80.0</td>
+                  <td class="st-roundSwing">+1.00%</td>
+                  <td class="st-rating">1.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+
 def test_match_parser_raises_typed_error_for_missing_team_names() -> None:
     parser = MatchParser()
     soup = BeautifulSoup("<html><body></body></html>", "html.parser")
@@ -65,6 +146,289 @@ def test_map_parser_raises_typed_error_for_missing_kills() -> None:
     )
 
     with pytest.raises(MapParseError, match="No player kills logged."):
+        parser.parse_map(
+            soup,
+            map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
+            map_id="2",
+        )
+
+
+def test_match_parser_raises_typed_error_for_missing_team_scores() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="mapname">Inferno</div>
+            <div class="date" data-unix="1704067200000"></div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract team scores from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
+def test_match_parser_raises_typed_error_for_missing_match_type() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="mapname">Inferno</div>
+            <div class="date" data-unix="1704067200000"></div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match type from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
+def test_match_parser_raises_typed_error_for_missing_event_name() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="mapname">Inferno</div>
+            <div class="date" data-unix="1704067200000"></div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract event name from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
+def test_match_parser_raises_typed_error_for_missing_forfeit_status() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="date" data-unix="1704067200000"></div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract forfeit status from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
+def test_match_parser_raises_typed_error_for_missing_match_date() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup(
+        """
+        <html>
+          <body>
+            <div class="teamName">Team One</div>
+            <div class="teamName">Team Two</div>
+            <div class="team1-gradient">
+              <a href="/team/1/team-one">Team One</a>
+              <div>16</div>
+            </div>
+            <div class="team2-gradient">
+              <a href="/team/2/team-two">Team Two</a>
+              <div>10</div>
+            </div>
+            <div class="event text-ellipsis">Test Event</div>
+            <div class="padding preformatted-text">Best of 3</div>
+            <div class="mapname">Inferno</div>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match date from match page."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/matches/1/test-match")
+
+
+def test_map_parser_raises_typed_error_for_missing_map_name() -> None:
+    parser = MapParser()
+    soup = _build_map_soup(
+        """
+        <html>
+          <body>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map name from map stats page."
+    ):
+        parser.parse_map(
+            soup,
+            map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
+            map_id="2",
+        )
+
+
+def test_map_parser_raises_typed_error_for_missing_player_name() -> None:
+    parser = MapParser()
+    soup = _build_map_soup(
+        """
+        <html>
+          <body>
+            <div class="match-info-box">
+              <div class="small-text">Map</div>
+              Inferno
+            </div>
+            <table class="stats-table totalstats">
+              <thead>
+                <tr>
+                  <th class="st-teamname">BIG</th>
+                  <th>Op. K-D</th>
+                  <th>MKs</th>
+                  <th>KAST</th>
+                  <th>1vsX</th>
+                  <th>K (hs)</th>
+                  <th>A (f)</th>
+                  <th>D (t)</th>
+                  <th>ADR</th>
+                  <th>Swing</th>
+                  <th>Rating 3.0</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="st-player"></td>
+                  <td class="st-opkd">1 : 1</td>
+                  <td class="st-mks">1</td>
+                  <td class="st-kast">70.0%</td>
+                  <td class="st-clutches">0</td>
+                  <td class="st-kills">20 (10)</td>
+                  <td class="st-assists">2 (0)</td>
+                  <td class="st-deaths">10 (1)</td>
+                  <td class="st-adr">80.0</td>
+                  <td class="st-roundSwing">+1.00%</td>
+                  <td class="st-rating">1.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract player name from map stats page."
+    ):
+        parser.parse_map(
+            soup,
+            map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
+            map_id="2",
+        )
+
+
+def test_map_parser_raises_typed_error_for_missing_deaths() -> None:
+    parser = MapParser()
+    soup = _build_map_soup(
+        """
+        <html>
+          <body>
+            <div class="match-info-box">
+              <div class="small-text">Map</div>
+              Inferno
+            </div>
+            <table class="stats-table totalstats">
+              <thead>
+                <tr>
+                  <th class="st-teamname">BIG</th>
+                  <th>Op. K-D</th>
+                  <th>MKs</th>
+                  <th>KAST</th>
+                  <th>1vsX</th>
+                  <th>K (hs)</th>
+                  <th>A (f)</th>
+                  <th>D (t)</th>
+                  <th>ADR</th>
+                  <th>Swing</th>
+                  <th>Rating 3.0</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="st-player"><a href="/player/22/test-player">TestPlayer</a></td>
+                  <td class="st-opkd">1 : 1</td>
+                  <td class="st-mks">1</td>
+                  <td class="st-kast">70.0%</td>
+                  <td class="st-clutches">0</td>
+                  <td class="st-kills">20 (10)</td>
+                  <td class="st-assists">2 (0)</td>
+                  <td class="st-deaths"></td>
+                  <td class="st-adr">80.0</td>
+                  <td class="st-roundSwing">+1.00%</td>
+                  <td class="st-rating">1.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        """
+    )
+
+    with pytest.raises(MapParseError, match="No player deaths logged."):
         parser.parse_map(
             soup,
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",


### PR DESCRIPTION
# Summary

This PR finishes parser field-level hardening for the active ingestion flow.

It adds specific parse errors for every required extracted match/map field we currently enforce, adds one direct parser test per required field, and updates the hardening docs to mark that work complete.

# What Changed

- Added field-specific `MatchParseError` messages for required match fields in `cs2_analytics/parsers/match_parser.py`
- Added field-specific `MapParseError` messages for required map/player fields in `cs2_analytics/parsers/map_parser.py`
- Tightened parser helpers so required values fail explicitly instead of falling through to generic parse failures
- Added direct parser exception coverage in `tests/parsers/test_parser_exceptions.py` for:
  - missing team names
  - missing team scores
  - missing event name
  - missing match type
  - missing forfeit status
  - missing match date
  - missing map name
  - missing player name
  - missing kills
  - missing deaths
- Updated `docs/backlog.md` and `docs/current_focus.md` to reflect completion of the parser field-specific error work

# Notes

- This PR keeps the scope intentionally narrow to parser contracts and parser tests only
- `team_name` in `MapParser` was left unchanged because the current schema still treats it as optional, so this branch does not introduce a new requirement there

# Validation

```powershell
.\.venv\Scripts\python.exe -m pytest -q tests\parsers\test_parser_exceptions.py tests\parsers\test_map_parser_regression.py
text
```
- 11 passed

# Follow-up Work
- Start dbt initialization and staging models
- Revisit additional parser hardening later if the ingestion contract changes