### PR TITLE
update planning docs for dbt transition and future hardening

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,11 +24,27 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 - [x] Add targeted tests for controller retry and recovery behavior
 - [x] Clean up scraper/parser helper methods to clarify responsibilities, naming, and public vs private method boundaries
 - [x] Centralize shared controller retry/session-recovery logic to reduce duplication across stages
-
-### Remaining hardening priorities
-
 - [x] Add field-specific parser extraction errors for required match/map fields
+
+### Future hardening backlog
+
 - [ ] Evaluate queue schema upgrades (`processing`, locks, `available_at`) when multi-worker support is needed
+- [ ] Add parser tests for malformed-but-partial HLTV markup
+- [ ] Define required vs optional fields for match/map parsing
+- [ ] Add idempotency tests for queue and storage writes
+- [ ] Standardize timezone-aware timestamps across parser/storage models
+- [ ] Add controller tests for queue/storage failure paths after parse success
+- [ ] Add structured run identifiers to controller logs for cross-stage tracing
+- [ ] Truncate and normalize stored error messages consistently across controllers
+- [ ] Add dead-letter/retry requeue policy for failed items
+- [ ] Validate follow-up queue payloads before enqueueing map/demo links
+- [ ] Add health-check coverage for scraper reset failure/fallback behavior
+- [ ] Add startup checks for required config/env vars before pipeline execution
+- [ ] Separate integration tests from unit tests for DB and scraper-dependent paths
+- [ ] Add protection against duplicate processing when the same item is queued twice
+- [ ] Audit and normalize naive `datetime.now()` usage outside the recent UTC fix
+- [ ] Add explicit controller summaries for zero-item runs
+- [ ] Document expected failure modes by stage in `docs/current_focus.md` or a dedicated hardening note
 
 ---
 
@@ -36,6 +52,10 @@ Maintain reliability while preserving clean stage boundaries and queue-driven pr
 
 Goal:
 Introduce transformation models after ingestion behavior is stable.
+
+### Before starting
+
+- [ ] Clean up parser/scraper class structure for readability without changing behavior
 
 ### Planned work
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -11,7 +11,7 @@ Transition from ingestion hardening into dbt while preserving clear stage bounda
 - Controllers orchestrate queue transitions and persistence handoff
 - Results-stage retry exhaustion fails the run; match/map item exhaustion marks failed and continues
 - Queues stay PostgreSQL-backed
-- Demo-related work remains deferred until ingestion hardening is stable
+- Demo-related work remains deferred until much later in development (TBD)
 - The next major phase is dbt, after one small parser/scraper readability cleanup
 
 ## Recently Completed
@@ -26,7 +26,7 @@ Transition from ingestion hardening into dbt while preserving clear stage bounda
 
 ## Current Work
 
-- Do one last parser/scraper class-structure cleanup branch focused on readability only
+- Do one last parser/scraper class structure cleanup branch focused on readability only
 - Initialize the dbt project once that cleanup lands
 - Start with staging models for matches, maps, and players
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Keep the ingestion pipeline reliable while preserving clear stage boundaries.
+Transition from ingestion hardening into dbt while preserving clear stage boundaries.
 
 ## Key Decisions
 
@@ -12,6 +12,7 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Results-stage retry exhaustion fails the run; match/map item exhaustion marks failed and continues
 - Queues stay PostgreSQL-backed
 - Demo-related work remains deferred until ingestion hardening is stable
+- The next major phase is dbt, after one small parser/scraper readability cleanup
 
 ## Recently Completed
 
@@ -24,6 +25,10 @@ Keep the ingestion pipeline reliable while preserving clear stage boundaries.
 - Field-specific parser extraction errors added for required match/map fields with direct parser coverage
 
 ## Current Work
+
+- Do one last parser/scraper class-structure cleanup branch focused on readability only
+- Initialize the dbt project once that cleanup lands
+- Start with staging models for matches, maps, and players
 
 ## Rules
 


### PR DESCRIPTION
# Summary

This PR updates the planning docs to shift the project focus from pipeline hardening toward dbt.

It adds a future hardening backlog, keeps the remaining queue-schema work visible, and makes the next step explicit: one small parser/scraper readability cleanup before starting dbt.

# What Changed

- Added a `Future hardening backlog` section to `docs/backlog.md`
- Added the planned hardening follow-up items for later branches
- Marked parser/scraper readability cleanup as the last pre-dbt step
- Updated `docs/current_focus.md` to reflect the transition toward dbt
- Clarified that the next major phase is dbt initialization and staging models

# Notes

- This is a docs-only planning update
- No application behavior or tests changed