### PR TITLE
Cleanup/parser scraper class structure

### DIFF
--- a/cs2_analytics/models/match.py
+++ b/cs2_analytics/models/match.py
@@ -10,8 +10,8 @@ class Match:
 
     match_id: int
     match_url: str
-    map_links: list[str]
-    demo_links: list[str]
+    map_links: list[tuple[str, str]]
+    demo_links: list[tuple[str, str]]
     team1: str
     team2: str
     score1: int
@@ -26,7 +26,7 @@ class Match:
     last_updated_at: datetime
     data_complete: bool
 
-    def to_dict(self) -> dict[str, int | str | bool | datetime | list[str]]:
+    def to_dict(self) -> dict[str, int | str | bool | datetime | list[tuple[str, str]]]:
         """Converts match object to a dictionary."""
         return {
             "match_id": self.match_id,

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -16,218 +16,15 @@ class MapParser:
     def parse_map(self, soup, map_url: str, map_id: int | str) -> list[Player]:
         """Extracts player object from a map stats page."""
         logger.info("Parsing %s for player stats", map_url)
-        players = []
         try:
-            map_id_value = int(map_id)
-        except (TypeError, ValueError):
-            map_id_value = self._extract_numeric_id(map_url)
-
-        map_name = self._extract_map_name(soup)
-        try:
-            tables = soup.select("table.stats-table.totalstats")
-            if not tables:
-                tables = soup.select("table.stats-table")
-            if not tables:
-                raise MapParseError("No player stats tables found on map page.")
-            for table in tables:
-                table_classes = table.get("class", [])
-                if "hidden" in table_classes:
-                    continue
-
-                team_header = table.find("th", class_="st-teamname")
-                team_name = team_header.text.strip() if team_header else "Unknown"
-
-                column_map = self._build_column_map(table)
-                opkd_idx = self._pick_column_index(
-                    column_map, ["op.k-d", "opkd", "op.kd"], 1
-                )
-                mks_idx = self._pick_column_index(column_map, ["mks"], 2)
-                kast_idx = self._pick_column_index(column_map, ["kast"], 4)
-                clutches_idx = self._pick_column_index(
-                    column_map, ["1vsx", "clutches"], 6
-                )
-                kills_idx = self._pick_column_index(
-                    column_map, ["k(hs)", "khs", "kills"], 7
-                )
-                assists_idx = self._pick_column_index(
-                    column_map, ["a(f)", "af", "assists"], 9
-                )
-                deaths_idx = self._pick_column_index(
-                    column_map, ["d(t)", "dt", "d(q)", "dq", "deaths", "d"], 10
-                )
-                adr_idx = self._pick_column_index(column_map, ["adr"], 12)
-                round_swing_idx = self._pick_column_index(
-                    column_map, ["swing", "roundswing"], 16
-                )
-                rating_idx = self._pick_column_index(
-                    column_map,
-                    ["rating3.0", "rating30", "rating2.1", "rating2.0", "rating", "rt"],
-                    17,
-                )
-
-                tbody = table.find("tbody")
-                if not tbody:
-                    logger.warning("Skipping table without tbody in %s", map_url)
-                    continue
-
-                player_rows = tbody.find_all("tr")
-                for row in player_rows:
-                    cols = row.find_all("td")
-                    if not cols:
-                        continue
-
-                    name_tag = cols[0].find("a")
-                    try:
-                        player_url = (
-                            f"https://www.hltv.org{name_tag['href']}"
-                            if name_tag and "href" in name_tag.attrs
-                            else None
-                        )
-                    except Exception:
-                        player_url = None
-
-                    player_id = (
-                        self._extract_numeric_id(player_url) if player_url else -1
-                    )
-
-                    player_name = self._extract_player_name(cols, name_tag)
-
-                    # Parse K(hs) format from column 5: "19(10)" -> kills=19, headshots=10
-                    kills_text = self._require_metric_text(
-                        self._extract_metric_text(
-                            cols,
-                            kills_idx,
-                            ["st-kills"],
-                        ),
-                        "No player kills logged.",
-                    )
-                    kills, headshots = self._parse_pair(kills_text)
-
-                    # Parse A(f) format from column 6: "3(0)" -> assists=3, flash_assists=0
-                    assists_text = self._extract_metric_text(
-                        cols,
-                        assists_idx,
-                        ["st-assists"],
-                    )
-                    assists, flash_assists = self._parse_pair(assists_text)
-
-                    # Parse D(t) format from table: "16(5)" -> deaths=16, traded_deaths=5
-                    deaths_text = self._require_metric_text(
-                        self._extract_metric_text(
-                            cols,
-                            deaths_idx,
-                            ["st-deaths"],
-                        ),
-                        "No player deaths logged.",
-                    )
-                    deaths, traded_deaths = self._parse_pair(deaths_text)
-
-                    opening_kills, opening_deaths = self._parse_colon_pair(
-                        self._extract_metric_text(cols, opkd_idx, ["st-opkd"])
-                    )
-                    multi_kills = self._parse_int_value(
-                        self._extract_metric_text(cols, mks_idx, ["st-mks"])
-                    )
-                    clutches_won = self._parse_int_value(
-                        self._extract_metric_text(cols, clutches_idx, ["st-clutches"])
-                    )
-                    round_swing = self._parse_percent_value(
-                        self._extract_metric_text(
-                            cols,
-                            round_swing_idx,
-                            ["st-roundSwing"],
-                            prefer_hidden=False,
-                        )
-                    )
-
-                    # Parse KAST percentage from column 3: "72.7%" -> 0.727
-                    try:
-                        kast_text = self._extract_metric_text(
-                            cols,
-                            kast_idx,
-                            ["st-kast"],
-                            prefer_hidden=False,
-                        ).replace("%", "")
-                        kast = round(float(kast_text) / 100, 3)
-                    except ValueError:
-                        kast = 0.0
-                        logger.warning(
-                            "Could not parse KAST from: %s",
-                            self._extract_metric_text(cols, kast_idx, ["st-kast"]),
-                        )
-
-                    # Parse other numeric fields with error handling
-                    try:
-                        adr = float(
-                            self._extract_metric_text(
-                                cols,
-                                adr_idx,
-                                ["st-adr"],
-                                prefer_hidden=False,
-                            )
-                        )
-                    except ValueError:
-                        adr = 0.0
-                        logger.warning(
-                            "Could not parse ADR from: %s",
-                            self._extract_metric_text(cols, adr_idx, ["st-adr"]),
-                        )
-
-                    # Parse rating from column 10 (skip the Swing column 9 which has percentages)
-                    try:
-                        rating_text = self._extract_metric_text(
-                            cols,
-                            rating_idx,
-                            ["st-rating"],
-                            prefer_hidden=False,
-                        )
-                        # Remove any color indicators or extra formatting
-                        rating_clean = (
-                            rating_text.replace("+", "")
-                            .replace("-", "")
-                            .replace("%", "")
-                        )
-                        rating = float(rating_clean)
-                    except (ValueError, IndexError):
-                        rating = 0.0
-                        logger.warning(
-                            "Could not parse Rating from: %s",
-                            self._extract_metric_text(cols, rating_idx, ["st-rating"]),
-                        )
-
-                    kd_diff = kills - deaths
-                    fk_diff = opening_kills - opening_deaths
-
-                    player = Player(
-                        map_id=map_id_value,
-                        player_id=player_id,
-                        player_name=player_name,
-                        player_url=player_url or "",
-                        map_name=map_name,
-                        team_name=team_name,
-                        kills=kills,
-                        headshots=headshots,
-                        assists=assists,
-                        flash_assists=flash_assists,
-                        deaths=deaths,
-                        traded_deaths=traded_deaths,
-                        opening_kills=opening_kills,
-                        opening_deaths=opening_deaths,
-                        multi_kills=multi_kills,
-                        clutches_won=clutches_won,
-                        kast=kast,
-                        kd_diff=kd_diff,
-                        adr=adr,
-                        fk_diff=fk_diff,
-                        round_swing=round_swing,
-                        rating=rating,
-                        last_inserted_at=dt.datetime.now(),
-                        last_scraped_at=dt.datetime.now(),
-                        last_updated_at=dt.datetime.now(),
-                        data_complete=True,
-                    )
-                    logger.debug("Extracted stats for player: %s", player.player_name)
-                    players.append(player)
+            map_id_value = self._resolve_map_id(map_id, map_url)
+            map_name = self._extract_map_name(soup)
+            players = self._extract_players_from_tables(
+                soup=soup,
+                map_url=map_url,
+                map_id_value=map_id_value,
+                map_name=map_name,
+            )
 
         except MapParseError:
             raise
@@ -236,6 +33,302 @@ class MapParser:
 
         logger.info("Extracted %s player stats from %s", len(players), map_url)
         return players
+
+    def _resolve_map_id(self, map_id: int | str, map_url: str) -> int:
+        """Resolves the numeric map identifier from the explicit id or URL."""
+        try:
+            return int(map_id)
+        except (TypeError, ValueError):
+            return self._extract_numeric_id(map_url)
+
+    def _iter_visible_stat_tables(self, soup, map_url: str):
+        """Yields visible player stat tables from the map page."""
+        tables = soup.select("table.stats-table.totalstats")
+        if not tables:
+            tables = soup.select("table.stats-table")
+        if not tables:
+            raise MapParseError("No player stats tables found on map page.")
+
+        for table in tables:
+            table_classes = table.get("class", [])
+            if "hidden" in table_classes:
+                continue
+            yield table
+
+    def _extract_team_name(self, table) -> str:
+        """Extracts the team name heading for a player stats table."""
+        team_header = table.find("th", class_="st-teamname")
+        return team_header.text.strip() if team_header else "Unknown"
+
+    def _extract_players_from_tables(
+        self, *, soup, map_url: str, map_id_value: int, map_name: str
+    ) -> list[Player]:
+        """Extracts parsed player rows from each visible stats table."""
+        players: list[Player] = []
+
+        for table in self._iter_visible_stat_tables(soup, map_url):
+            team_name = self._extract_team_name(table)
+            column_indexes = self._build_column_indexes(table)
+            tbody = table.find("tbody")
+            if not tbody:
+                logger.warning("Skipping table without tbody in %s", map_url)
+                continue
+
+            for row in tbody.find_all("tr"):
+                player = self._parse_player_row(
+                    row=row,
+                    map_id_value=map_id_value,
+                    map_name=map_name,
+                    team_name=team_name,
+                    column_indexes=column_indexes,
+                )
+                if player is None:
+                    continue
+                logger.debug("Extracted stats for player: %s", player.player_name)
+                players.append(player)
+
+        return players
+
+    def _build_column_indexes(self, table) -> dict[str, int]:
+        """Builds the column indexes used to parse a stats table row."""
+        column_map = self._build_column_map(table)
+        return {
+            "opkd": self._pick_column_index(column_map, ["op.k-d", "opkd", "op.kd"], 1),
+            "mks": self._pick_column_index(column_map, ["mks"], 2),
+            "kast": self._pick_column_index(column_map, ["kast"], 4),
+            "clutches": self._pick_column_index(
+                column_map, ["1vsx", "clutches"], 6
+            ),
+            "kills": self._pick_column_index(
+                column_map, ["k(hs)", "khs", "kills"], 7
+            ),
+            "assists": self._pick_column_index(
+                column_map, ["a(f)", "af", "assists"], 9
+            ),
+            "deaths": self._pick_column_index(
+                column_map, ["d(t)", "dt", "d(q)", "dq", "deaths", "d"], 10
+            ),
+            "adr": self._pick_column_index(column_map, ["adr"], 12),
+            "round_swing": self._pick_column_index(
+                column_map, ["swing", "roundswing"], 16
+            ),
+            "rating": self._pick_column_index(
+                column_map,
+                ["rating3.0", "rating30", "rating2.1", "rating2.0", "rating", "rt"],
+                17,
+            ),
+        }
+
+    def _parse_player_row(
+        self,
+        *,
+        row,
+        map_id_value: int,
+        map_name: str,
+        team_name: str,
+        column_indexes: dict[str, int],
+    ) -> Player | None:
+        """Parses a single player row into a Player model."""
+        cols = row.find_all("td")
+        if not cols:
+            return None
+
+        player_name, player_url, player_id = self._extract_player_identity(cols)
+        stats = self._extract_player_stats(cols, column_indexes)
+        return self._build_player(
+            map_id_value=map_id_value,
+            player_id=player_id,
+            player_name=player_name,
+            player_url=player_url,
+            map_name=map_name,
+            team_name=team_name,
+            stats=stats,
+        )
+
+    def _extract_player_identity(self, cols) -> tuple[str, str, int]:
+        """Extracts player display identity from the first row cell."""
+        name_tag = cols[0].find("a")
+        player_url = self._extract_player_url(name_tag)
+        player_id = self._extract_numeric_id(player_url) if player_url else -1
+        player_name = self._extract_player_name(cols, name_tag)
+        return player_name, player_url or "", player_id
+
+    def _extract_player_url(self, name_tag) -> str | None:
+        """Extracts the absolute player URL when one is present."""
+        try:
+            if name_tag and "href" in name_tag.attrs:
+                return f"https://www.hltv.org{name_tag['href']}"
+        except Exception:
+            return None
+        return None
+
+    def _extract_player_stats(
+        self, cols, column_indexes: dict[str, int]
+    ) -> dict[str, int | float]:
+        """Extracts parsed combat and utility stats from a player row."""
+        kills, headshots = self._extract_kills(cols, column_indexes["kills"])
+        assists, flash_assists = self._extract_assists(cols, column_indexes["assists"])
+        deaths, traded_deaths = self._extract_deaths(cols, column_indexes["deaths"])
+        opening_kills, opening_deaths = self._parse_colon_pair(
+            self._extract_metric_text(cols, column_indexes["opkd"], ["st-opkd"])
+        )
+        multi_kills = self._parse_int_value(
+            self._extract_metric_text(cols, column_indexes["mks"], ["st-mks"])
+        )
+        clutches_won = self._parse_int_value(
+            self._extract_metric_text(
+                cols, column_indexes["clutches"], ["st-clutches"]
+            )
+        )
+        round_swing = self._parse_percent_value(
+            self._extract_metric_text(
+                cols,
+                column_indexes["round_swing"],
+                ["st-roundSwing"],
+                prefer_hidden=False,
+            )
+        )
+        kast = self._extract_kast(cols, column_indexes["kast"])
+        adr = self._extract_adr(cols, column_indexes["adr"])
+        rating = self._extract_rating(cols, column_indexes["rating"])
+
+        return {
+            "kills": kills,
+            "headshots": headshots,
+            "assists": assists,
+            "flash_assists": flash_assists,
+            "deaths": deaths,
+            "traded_deaths": traded_deaths,
+            "opening_kills": opening_kills,
+            "opening_deaths": opening_deaths,
+            "multi_kills": multi_kills,
+            "clutches_won": clutches_won,
+            "round_swing": round_swing,
+            "kast": kast,
+            "adr": adr,
+            "rating": rating,
+        }
+
+    def _extract_kills(self, cols, kills_idx: int) -> tuple[int, int]:
+        """Extracts kills and headshots from the player row."""
+        kills_text = self._require_metric_text(
+            self._extract_metric_text(cols, kills_idx, ["st-kills"]),
+            "No player kills logged.",
+        )
+        return self._parse_pair(kills_text)
+
+    def _extract_assists(self, cols, assists_idx: int) -> tuple[int, int]:
+        """Extracts assists and flash assists from the player row."""
+        assists_text = self._extract_metric_text(cols, assists_idx, ["st-assists"])
+        return self._parse_pair(assists_text)
+
+    def _extract_deaths(self, cols, deaths_idx: int) -> tuple[int, int]:
+        """Extracts deaths and traded deaths from the player row."""
+        deaths_text = self._require_metric_text(
+            self._extract_metric_text(cols, deaths_idx, ["st-deaths"]),
+            "No player deaths logged.",
+        )
+        return self._parse_pair(deaths_text)
+
+    def _extract_kast(self, cols, kast_idx: int) -> float:
+        """Extracts KAST as a decimal ratio."""
+        try:
+            kast_text = self._extract_metric_text(
+                cols,
+                kast_idx,
+                ["st-kast"],
+                prefer_hidden=False,
+            ).replace("%", "")
+            return round(float(kast_text) / 100, 3)
+        except ValueError:
+            logger.warning(
+                "Could not parse KAST from: %s",
+                self._extract_metric_text(cols, kast_idx, ["st-kast"]),
+            )
+            return 0.0
+
+    def _extract_adr(self, cols, adr_idx: int) -> float:
+        """Extracts ADR as a float value."""
+        try:
+            return float(
+                self._extract_metric_text(
+                    cols,
+                    adr_idx,
+                    ["st-adr"],
+                    prefer_hidden=False,
+                )
+            )
+        except ValueError:
+            logger.warning(
+                "Could not parse ADR from: %s",
+                self._extract_metric_text(cols, adr_idx, ["st-adr"]),
+            )
+            return 0.0
+
+    def _extract_rating(self, cols, rating_idx: int) -> float:
+        """Extracts rating as a float value."""
+        try:
+            rating_text = self._extract_metric_text(
+                cols,
+                rating_idx,
+                ["st-rating"],
+                prefer_hidden=False,
+            )
+            rating_clean = rating_text.replace("+", "").replace("-", "").replace("%", "")
+            return float(rating_clean)
+        except (ValueError, IndexError):
+            logger.warning(
+                "Could not parse Rating from: %s",
+                self._extract_metric_text(cols, rating_idx, ["st-rating"]),
+            )
+            return 0.0
+
+    def _build_player(
+        self,
+        *,
+        map_id_value: int,
+        player_id: int,
+        player_name: str,
+        player_url: str,
+        map_name: str,
+        team_name: str,
+        stats: dict[str, int | float],
+    ) -> Player:
+        """Builds a Player model from a parsed row."""
+        now = dt.datetime.now()
+        kills = int(stats["kills"])
+        deaths = int(stats["deaths"])
+        opening_kills = int(stats["opening_kills"])
+        opening_deaths = int(stats["opening_deaths"])
+
+        return Player(
+            map_id=map_id_value,
+            player_id=player_id,
+            player_name=player_name,
+            player_url=player_url,
+            map_name=map_name,
+            team_name=team_name,
+            kills=kills,
+            headshots=int(stats["headshots"]),
+            assists=int(stats["assists"]),
+            flash_assists=int(stats["flash_assists"]),
+            deaths=deaths,
+            traded_deaths=int(stats["traded_deaths"]),
+            opening_kills=opening_kills,
+            opening_deaths=opening_deaths,
+            multi_kills=int(stats["multi_kills"]),
+            clutches_won=int(stats["clutches_won"]),
+            kast=float(stats["kast"]),
+            kd_diff=kills - deaths,
+            adr=float(stats["adr"]),
+            fk_diff=opening_kills - opening_deaths,
+            round_swing=float(stats["round_swing"]),
+            rating=float(stats["rating"]),
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
 
     def _normalize_header(self, value: str) -> str:
         return re.sub(r"[^a-z0-9.]", "", value.lower())

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -41,7 +41,7 @@ class MapParser:
         except (TypeError, ValueError):
             return self._extract_numeric_id(map_url)
 
-    def _iter_visible_stat_tables(self, soup, map_url: str):
+    def _iter_visible_stat_tables(self, soup):
         """Yields visible player stat tables from the map page."""
         tables = soup.select("table.stats-table.totalstats")
         if not tables:
@@ -66,7 +66,7 @@ class MapParser:
         """Extracts parsed player rows from each visible stats table."""
         players: list[Player] = []
 
-        for table in self._iter_visible_stat_tables(soup, map_url):
+        for table in self._iter_visible_stat_tables(soup):
             team_name = self._extract_team_name(table)
             column_indexes = self._build_column_indexes(table)
             tbody = table.find("tbody")

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -38,7 +38,10 @@ class MatchParser:
 
     def _extract_match_id(self, match_url: str) -> int:
         """Extracts the match identifier from the match URL."""
-        return int(match_url.split("/")[-2])
+        match = re.search(r"/matches/(\d+)", match_url)
+        if not match:
+            raise MatchParseError("Failed to extract match id from match URL.")
+        return int(match.group(1))
 
     def _extract_follow_up_links(
         self, soup

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -18,40 +18,15 @@ class MatchParser:
     ) -> tuple[Match, list[tuple[str, str]], list[tuple[str, str]]]:
         """Parses match metadata and returns match data with extracted follow-up links."""
         try:
-            match_id = match_url.split("/")[-2]
-
-            team1, team2 = self._extract_teams(soup)
-            logger.debug("Team1: %s Team2: %s", team1, team2)
-            score1, score2 = self._extract_scores(soup)
-
-            winner = team1 if score1 > score2 else team2
-            logger.debug("Winner: %s", winner)
-            event = self._extract_event_name(soup)
-            best_ty = self._extract_match_type(soup)
-            forfeit = self._extract_forfeit_status(soup)
-            match_date = self._extract_match_date(soup)
-
-            demo_links = self._extract_demo_links(soup)
-            map_links = self._extract_map_stats_links(soup)
-
-            match_obj = Match(
+            match_id = self._extract_match_id(match_url)
+            metadata = self._extract_match_metadata(soup)
+            map_links, demo_links = self._extract_follow_up_links(soup)
+            match_obj = self._build_match(
                 match_id=match_id,
                 match_url=match_url,
                 map_links=map_links,
                 demo_links=demo_links,
-                team1=team1,
-                team2=team2,
-                score1=score1,
-                score2=score2,
-                winner=winner,
-                event=event,
-                match_type=best_ty,
-                forfeit=forfeit,
-                date=match_date,
-                last_inserted_at=dt.datetime.now(),
-                last_scraped_at=dt.datetime.now(),
-                last_updated_at=dt.datetime.now(),
-                data_complete=True,
+                **metadata,
             )
 
             return match_obj, map_links, demo_links
@@ -60,6 +35,86 @@ class MatchParser:
             raise
         except (AttributeError, ValueError, TypeError, KeyError) as e:
             raise MatchParseError(f"Failed to parse match page: {match_url}") from e
+
+    def _extract_match_id(self, match_url: str) -> str:
+        """Extracts the match identifier from the match URL."""
+        return match_url.split("/")[-2]
+
+    def _extract_follow_up_links(
+        self, soup
+    ) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+        """Extracts map and demo follow-up links from the match page."""
+        map_links = self._extract_map_stats_links(soup)
+        demo_links = self._extract_demo_links(soup)
+        return map_links, demo_links
+
+    def _extract_match_metadata(self, soup) -> dict[str, str | int | bool]:
+        """Extracts the core match fields needed to build a Match model."""
+        team1, team2 = self._extract_teams(soup)
+        logger.debug("Team1: %s Team2: %s", team1, team2)
+        score1, score2 = self._extract_scores(soup)
+        winner = self._determine_winner(team1, team2, score1, score2)
+        event = self._extract_event_name(soup)
+        match_type = self._extract_match_type(soup)
+        forfeit = self._extract_forfeit_status(soup)
+        match_date = self._extract_match_date(soup)
+
+        return {
+            "team1": team1,
+            "team2": team2,
+            "score1": score1,
+            "score2": score2,
+            "winner": winner,
+            "event": event,
+            "match_type": match_type,
+            "forfeit": forfeit,
+            "match_date": match_date,
+        }
+
+    def _determine_winner(self, team1: str, team2: str, score1: int, score2: int) -> str:
+        """Determines the winning team name from the parsed scores."""
+        winner = team1 if score1 > score2 else team2
+        logger.debug("Winner: %s", winner)
+        return winner
+
+    def _build_match(
+        self,
+        *,
+        match_id: str,
+        match_url: str,
+        map_links: list[tuple[str, str]],
+        demo_links: list[tuple[str, str]],
+        team1: str,
+        team2: str,
+        score1: int,
+        score2: int,
+        winner: str,
+        event: str,
+        match_type: str,
+        forfeit: bool,
+        match_date: str,
+    ) -> Match:
+        """Builds a Match model from already-extracted values."""
+        now = dt.datetime.now()
+        return Match(
+            match_id=match_id,
+            match_url=match_url,
+            map_links=map_links,
+            demo_links=demo_links,
+            team1=team1,
+            team2=team2,
+            score1=score1,
+            score2=score2,
+            winner=winner,
+            event=event,
+            match_type=match_type,
+            forfeit=forfeit,
+            date=match_date,
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
 
     def _extract_teams(self, soup) -> tuple[str, str]:
         """Extracts team names from the match page."""

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -36,9 +36,9 @@ class MatchParser:
         except (AttributeError, ValueError, TypeError, KeyError) as e:
             raise MatchParseError(f"Failed to parse match page: {match_url}") from e
 
-    def _extract_match_id(self, match_url: str) -> str:
+    def _extract_match_id(self, match_url: str) -> int:
         """Extracts the match identifier from the match URL."""
-        return match_url.split("/")[-2]
+        return int(match_url.split("/")[-2])
 
     def _extract_follow_up_links(
         self, soup
@@ -80,7 +80,7 @@ class MatchParser:
     def _build_match(
         self,
         *,
-        match_id: str,
+        match_id: int,
         match_url: str,
         map_links: list[tuple[str, str]],
         demo_links: list[tuple[str, str]],

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -55,7 +55,7 @@ Introduce transformation models after ingestion behavior is stable.
 
 ### Before starting
 
-- [ ] Clean up parser/scraper class structure for readability without changing behavior
+- [x] Clean up parser/scraper class structure for readability without changing behavior
 
 ### Planned work
 

--- a/docs/current_focus.md
+++ b/docs/current_focus.md
@@ -12,7 +12,7 @@ Transition from ingestion hardening into dbt while preserving clear stage bounda
 - Results-stage retry exhaustion fails the run; match/map item exhaustion marks failed and continues
 - Queues stay PostgreSQL-backed
 - Demo-related work remains deferred until much later in development (TBD)
-- The next major phase is dbt, after one small parser/scraper readability cleanup
+- The next major phase is dbt
 
 ## Recently Completed
 
@@ -23,11 +23,11 @@ Transition from ingestion hardening into dbt while preserving clear stage bounda
 - Run-level retry/failure visibility added to controller summaries and retry-exhaustion logs
 - Targeted controller and retry-helper tests added for retry, recovery, and run summaries
 - Field-specific parser extraction errors added for required match/map fields with direct parser coverage
+- Parser/scraper class structure cleaned up for readability without changing active-flow behavior
 
 ## Current Work
 
-- Do one last parser/scraper class structure cleanup branch focused on readability only
-- Initialize the dbt project once that cleanup lands
+- Initialize the dbt project
 - Start with staging models for matches, maps, and players
 
 ## Rules

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -97,6 +97,20 @@ def test_match_parser_raises_typed_error_for_missing_team_names() -> None:
     assert isinstance(exc_info.value.__cause__, ValueError)
 
 
+def test_match_parser_returns_numeric_match_id() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup()
+
+    match, map_links, demo_links = parser.parse_match(
+        soup, "https://www.hltv.org/matches/123456/test-match"
+    )
+
+    assert match.match_id == 123456
+    assert isinstance(match.match_id, int)
+    assert map_links == [("2", "https://www.hltv.org/stats/matches/mapstatsid/2/test-map")]
+    assert demo_links == []
+
+
 def test_map_parser_raises_typed_error_for_missing_kills() -> None:
     parser = MapParser()
     soup = BeautifulSoup(

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -111,6 +111,16 @@ def test_match_parser_returns_numeric_match_id() -> None:
     assert demo_links == []
 
 
+def test_match_parser_raises_typed_error_for_missing_match_id_in_url() -> None:
+    parser = MatchParser()
+    soup = _build_match_soup()
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match id from match URL."
+    ):
+        parser.parse_match(soup, "https://www.hltv.org/match/test-match")
+
+
 def test_map_parser_raises_typed_error_for_missing_kills() -> None:
     parser = MapParser()
     soup = BeautifulSoup(


### PR DESCRIPTION
# Summary

This PR cleans up parser class structure for readability in the active match/map ingestion flow.

It keeps behavior the same while making `MatchParser` and `MapParser` more orchestration-focused, pushing row/field/model-construction details into clearer private helpers. It also updates the planning docs to mark this cleanup complete and make dbt the next active phase.

# What Changed

- Refactored `cs2_analytics/parsers/match_parser.py` so `parse_match()` now:
  - extracts the match id
  - extracts a metadata bundle
  - extracts follow-up links
  - builds the `Match` model
- Added small helper boundaries in `MatchParser` for:
  - match metadata extraction
  - winner determination
  - follow-up link extraction
  - model construction
- Refactored `cs2_analytics/parsers/map_parser.py` so `parse_map()` now:
  - resolves the map id
  - extracts the map name
  - delegates visible-table/player collection to a dedicated helper
- Added clearer helper boundaries in `MapParser` for:
  - visible stats table iteration
  - player collection from tables
  - player identity extraction
  - stat extraction
  - player model construction
- Updated `docs/backlog.md` and `docs/current_focus.md` to show the parser/scraper readability cleanup as complete and dbt as the next focus

# Notes

- This is a readability/structure cleanup only
- No queue, storage, controller, or feature behavior was intentionally changed
- The docs now reflect that dbt initialization and staging models are next

# Validation

```powershell
.\.venv\Scripts\python.exe -m pytest -q tests\parsers\test_parser_exceptions.py tests\parsers\test_map_parser_regression.py tests\controllers\test_match_controller.py tests\controllers\test_map_controller.py
```
- 19 passed