### PR TITLE
Document ingestion lifecycle decisions

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -10,8 +10,7 @@ The active codebase already has useful stage boundaries and controller retry har
 
 Current priorities:
 
-- clarify match/map ingestion and discovery state semantics
-- decide whether the current `*_scrape_queue` names still fit their actual purpose
+- migrate `*_scrape_queue` naming to `*_ingestion_state`
 - add distinct lifecycle and audit fields where they provide real value
 - move per-item stage workflow out of `MatchController` and `MapController`
 
@@ -20,16 +19,19 @@ Current priorities:
 ## Phase 1: Schema and Lifecycle Review
 
 Goal:
-Define the intended meaning of the current match and map discovery tables before changing code structure around them.
+Define the intended meaning of the scrape queue tables before changing schema or code structure around them.
 
-### Planned work
+Status:
+Complete. The project will move from scrape queue terminology toward ingestion state tables. See `docs/ingestion_lifecycle.md`.
 
-- [x] Review the actual role of `match_scrape_queue` and `map_scrape_queue`
-- [x] Decide whether those tables are still simple work queues or are now lifecycle/state tables
-- [x] Document the intended status model and field semantics
-- [x] Identify redundant versus meaningful timestamps
-- [x] Define naming guidance for current-state versus future-state terminology
-- [x] Keep `cs2_analytics/storage/schema.sql` as the source of truth during the review
+### Completed work
+
+- [x] Reviewed the actual role of the scrape queue tables
+- [x] Decided they are lifecycle/state tables, not simple work queues
+- [x] Documented the intended status model and field semantics
+- [x] Identified redundant versus meaningful timestamps
+- [x] Defined naming guidance for current-state versus future-state terminology
+- [x] Kept `cs2_analytics/storage/schema.sql` as the source of truth during the review
 
 ---
 
@@ -112,7 +114,7 @@ These items remain important, but they are not ahead of lifecycle semantics and 
 
 ### Demo Pipeline
 
-- [ ] Validate the long-term role of `demo_scrape_queue`
+- [ ] Validate the long-term lifecycle semantics of `demo_ingestion_state`
 - [ ] Implement downloader/parser pipeline with cleanup strategy
 - [ ] Persist structured demo outputs and error metadata
 - [ ] Revisit demo orchestration after the active match/map stages are cleaner

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,28 +24,31 @@ Define the intended meaning of the current match and map discovery tables before
 
 ### Planned work
 
-- [ ] Review the actual role of `match_scrape_queue` and `map_scrape_queue`
-- [ ] Decide whether those tables are still simple work queues or are now lifecycle/state tables
-- [ ] Document the intended status model and field semantics
-- [ ] Identify redundant versus meaningful timestamps
-- [ ] Define naming guidance for current-state versus future-state terminology
-- [ ] Keep `cs2_analytics/storage/schema.sql` as the source of truth during the review
+- [x] Review the actual role of `match_scrape_queue` and `map_scrape_queue`
+- [x] Decide whether those tables are still simple work queues or are now lifecycle/state tables
+- [x] Document the intended status model and field semantics
+- [x] Identify redundant versus meaningful timestamps
+- [x] Define naming guidance for current-state versus future-state terminology
+- [x] Keep `cs2_analytics/storage/schema.sql` as the source of truth during the review
 
 ---
 
-## Phase 2: Match and Map State Table Updates
+## Phase 2: Ingestion State Table Updates
 
 Goal:
-Update the current discovery tables so they clearly support ingestion/lifecycle tracking.
+Rename and update the current scrape queue tables so they clearly support ingestion/lifecycle tracking.
 
 ### Planned work
 
-- [ ] Add or revise distinct lifecycle fields such as `status`, `first_seen_at`, `last_seen_at`, `last_attempted_at`, `last_processed_at`, `last_failed_at`, `retry_count`, `failure_count`, `last_error_message`, `run_id`, `worker_id`, `inserted_at`, and `last_updated_at`
-- [ ] Keep only fields with distinct meanings and avoid redundant timestamps
-- [ ] Decide whether `match_scrape_queue` and `map_scrape_queue` should keep their current names or move toward names like `match_ingestion_state` and `map_ingestion_state`
-- [ ] Preserve idempotency and duplicate-discovery protection
-- [ ] Document success, retryable failure, terminal failure, and rediscovery semantics
-- [ ] Reserve multi-worker fields and lock semantics for cases where they are actually needed
+- [ ] Update `cs2_analytics/storage/schema.sql` to match the Phase 1 ingestion state decisions
+- [ ] Rename `match_scrape_queue`, `map_scrape_queue`, and `demo_scrape_queue` to `match_ingestion_state`, `map_ingestion_state`, and `demo_ingestion_state`
+- [ ] Update lifecycle fields to the agreed Phase 1 shape: `status`, `first_seen_at`, `last_seen_at`, `last_attempted_at`, `last_processed_at`, `last_failed_at`, `failure_count`, `last_error_message`, `source`, `priority`, and `last_updated_at`
+- [ ] Remove or avoid redundant fields such as `inserted_at`, `last_inserted_at`, unused `retry_count`, `run_id`, and `worker_id`
+- [ ] Update status values from `queued`, `parsed`, `failed` to `pending`, `processing`, `processed`, `failed`, and `skipped`
+- [ ] Preserve idempotency by keeping source IDs as primary keys and refreshing existing rows on rediscovery
+- [ ] Update Python queue/state classes, controllers, and tests to use the new table names and status values
+- [ ] Keep demo behavior minimal while aligning its table name and schema with ingestion state naming
+- [ ] Document success, retryable failure, terminal failure, skipped, and rediscovery semantics
 
 ---
 

--- a/docs/ingestion_lifecycle.md
+++ b/docs/ingestion_lifecycle.md
@@ -1,6 +1,6 @@
 # Ingestion Lifecycle Review
 
-Draft status: in progress
+Status: Phase 1 complete; implementation pending Phase 2
 
 This document captures the current Phase 1 decisions for moving scrape queue
 tables toward ingestion state tables. The implementation source of truth remains
@@ -111,7 +111,7 @@ row changes.
 - `last_updated_at`
   Most recent meaningful update to the ingestion state row.
 
-## Still To Decide
+## Implementation Decisions For Phase 2
 
 - whether the schema rename happens before or alongside field cleanup
 - how much compatibility to keep in Python class and module names during the

--- a/docs/ingestion_lifecycle.md
+++ b/docs/ingestion_lifecycle.md
@@ -1,0 +1,118 @@
+# Ingestion Lifecycle Review
+
+Draft status: in progress
+
+This document captures the current Phase 1 decisions for moving scrape queue
+tables toward ingestion state tables. The implementation source of truth remains
+`cs2_analytics/storage/schema.sql` until schema changes are made.
+
+## Decisions So Far
+
+The current match and map scrape queue tables are acting as more than temporary
+work queues. They are durable records for discovered entities and their
+processing lifecycle.
+
+Agreed direction:
+
+- `match_scrape_queue` should move toward `match_ingestion_state`
+- `map_scrape_queue` should move toward `map_ingestion_state`
+- `demo_scrape_queue` should also move toward `demo_ingestion_state` for naming
+  consistency, even though the demo pipeline lifecycle is deferred
+
+The queue behavior should become a filtered view of ingestion state: rows that
+are ready for work are selected by status.
+
+## Table Names and Keys
+
+Planned ingestion state table names:
+
+- `match_ingestion_state`
+- `map_ingestion_state`
+- `demo_ingestion_state`
+
+Each table should use the source entity ID as its primary key:
+
+- `match_ingestion_state.match_id`
+- `map_ingestion_state.map_id`
+- `demo_ingestion_state.demo_id`
+
+These primary keys preserve duplicate-discovery protection. When the same
+entity is discovered again, the ingestion row should be refreshed instead of
+duplicated.
+
+Use table-specific URL fields for readability:
+
+- `match_url`
+- `map_url`
+- `demo_url`
+
+## Status Values
+
+Use the same status model across match, map, and demo ingestion state:
+
+- `pending`: discovered and ready to be processed
+- `processing`: actively being worked on
+- `processed`: fetched, parsed, and persisted successfully
+- `failed`: terminal failure under the current retry policy
+- `skipped`: intentionally not processed
+
+`pending` replaces queue-oriented language like `queued`.
+`processed` replaces parser-specific language like `parsed`, because a
+successful stage includes fetch, parse, and persistence.
+
+## Shared Fields
+
+Each ingestion state table should include:
+
+- table-specific ID field: `match_id`, `map_id`, or `demo_id`
+- table-specific URL field: `match_url`, `map_url`, or `demo_url`
+- `status`
+- `first_seen_at`
+- `last_seen_at`
+- `last_attempted_at`
+- `last_processed_at`
+- `last_failed_at`
+- `failure_count`
+- `last_error_message`
+- `source`
+- `priority`
+- `last_updated_at`
+
+Do not include `inserted_at` on these tables. `first_seen_at` is the row's
+creation/discovery timestamp, and `last_updated_at` captures later meaningful
+row changes.
+
+## Field Meanings
+
+- `match_id` / `map_id` / `demo_id`
+  Stable source identifier and primary key.
+- `match_url` / `map_url` / `demo_url`
+  Source URL used by the relevant stage.
+- `status`
+  Current ingestion lifecycle state.
+- `first_seen_at`
+  First time discovery saw the entity.
+- `last_seen_at`
+  Most recent time discovery saw the entity.
+- `last_attempted_at`
+  Most recent time processing was attempted.
+- `last_processed_at`
+  Most recent successful processing completion.
+- `last_failed_at`
+  Most recent failed processing completion.
+- `failure_count`
+  Count of failed processing attempts over the row lifetime.
+- `last_error_message`
+  Most recent failure or skipped reason.
+- `source`
+  Discovery source, such as `results_scraper` or `match_parser`.
+- `priority`
+  Ordering hint for pending work.
+- `last_updated_at`
+  Most recent meaningful update to the ingestion state row.
+
+## Still To Decide
+
+- whether the schema rename happens before or alongside field cleanup
+- how much compatibility to keep in Python class and module names during the
+  transition


### PR DESCRIPTION
## Summary

- Documented Phase 1 ingestion lifecycle decisions for scrape queue tables
- Defined the move from `*_scrape_queue` terminology to `*_ingestion_state`
- Captured agreed status values, field names, primary keys, and timestamp semantics
- Updated the backlog so Phase 1 is complete and Phase 2 is implementation-focused

## Notes

This PR intentionally does not update `schema.sql` or application code. Those changes are deferred to Phase 2, where the schema, Python classes, controllers, and tests can be updated together.