### PR TITLE
Add ingestion state aliases for scrape queues

### DIFF
--- a/cs2_analytics/queues/__init__.py
+++ b/cs2_analytics/queues/__init__.py
@@ -1,8 +1,9 @@
 """
-Initializes scrape queue managers for matches, maps, and demos.
+Initializes scrape queue managers and ingestion-state compatibility exports.
 
 This allows direct imports like:
     from cs2_analytics.queues import match_queue, map_queue, demo_queue
+    from cs2_analytics.queues import MatchIngestionState
 """
 
 from cs2_analytics.queues.demo_ingestion_state import DemoIngestionState

--- a/cs2_analytics/queues/__init__.py
+++ b/cs2_analytics/queues/__init__.py
@@ -5,12 +5,25 @@ This allows direct imports like:
     from cs2_analytics.queues import match_queue, map_queue, demo_queue
 """
 
-from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
-from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+from cs2_analytics.queues.demo_ingestion_state import DemoIngestionState
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
+from cs2_analytics.queues.map_ingestion_state import MapIngestionState
+from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+from cs2_analytics.queues.match_ingestion_state import MatchIngestionState
+from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 
 match_queue = MatchScrapeQueue()
 map_queue = MapScrapeQueue()
 demo_queue = DemoScrapeQueue()
 
-__all__ = ["match_queue", "map_queue", "demo_queue"]
+__all__ = [
+    "DemoIngestionState",
+    "DemoScrapeQueue",
+    "MapIngestionState",
+    "MapScrapeQueue",
+    "MatchIngestionState",
+    "MatchScrapeQueue",
+    "demo_queue",
+    "map_queue",
+    "match_queue",
+]

--- a/cs2_analytics/queues/demo_ingestion_state.py
+++ b/cs2_analytics/queues/demo_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for demo ingestion state management."""
+
+from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
+
+
+class DemoIngestionState(DemoScrapeQueue):
+    """Alias class for the current demo scrape queue implementation."""

--- a/cs2_analytics/queues/map_ingestion_state.py
+++ b/cs2_analytics/queues/map_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for map ingestion state management."""
+
+from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+
+
+class MapIngestionState(MapScrapeQueue):
+    """Alias class for the current map scrape queue implementation."""

--- a/cs2_analytics/queues/match_ingestion_state.py
+++ b/cs2_analytics/queues/match_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for match ingestion state management."""
+
+from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
+
+
+class MatchIngestionState(MatchScrapeQueue):
+    """Alias class for the current match scrape queue implementation."""

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -40,12 +40,6 @@ Complete. The project will move from scrape queue terminology toward ingestion s
 Goal:
 Rename and update the current scrape queue tables so they clearly support ingestion/lifecycle tracking.
 
-### Suggested PR sequence:
-
-1. Compatibility: introduce ingestion-state schema/classes while keeping existing queue paths working.
-2. Migration: switch controllers, tests, and docs from scrape queue names to ingestion state names.
-3. Lifecycle behavior: implement new statuses, timestamps, failure counts, and rediscovery refreshes.
-
 ### Planned work
 
 - [ ] Update `cs2_analytics/storage/schema.sql` to match the Phase 1 ingestion state decisions

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -52,6 +52,17 @@ Rename and update the current scrape queue tables so they clearly support ingest
 - [ ] Keep demo behavior minimal while aligning its table name and schema with ingestion state naming
 - [ ] Document success, retryable failure, terminal failure, skipped, and rediscovery semantics
 
+### Suggested PR sequence
+
+1. Compatibility:
+   Add `MatchIngestionState`, `MapIngestionState`, and `DemoIngestionState` while keeping the existing `queues/` package, scrape queue classes, table names, statuses, and behavior working.
+2. Schema:
+   Update `cs2_analytics/storage/schema.sql` to create the `*_ingestion_state` tables with the agreed Phase 1 fields and status values.
+3. Migration/package rename:
+   Move ingestion state modules out of `cs2_analytics/queues/` into a better-suited package such as `cs2_analytics/ingestion_state/`, then update controllers, tests, and imports. Keep temporary `queues/` compatibility wrappers only if needed.
+4. Lifecycle behavior:
+   Implement rediscovery refreshes, processing transitions, lifecycle timestamps, failure counts, and skipped semantics.
+
 ---
 
 ## Phase 3: Match and Map Stage Service Refactor

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -4,6 +4,11 @@ import pytest
 
 from cs2_analytics.exceptions import MatchQueueError
 from cs2_analytics.queues import base_scrape_queue as base_queue_module
+from cs2_analytics.queues.demo_ingestion_state import DemoIngestionState
+from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
+from cs2_analytics.queues.map_ingestion_state import MapIngestionState
+from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+from cs2_analytics.queues.match_ingestion_state import MatchIngestionState
 from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 
 
@@ -22,3 +27,24 @@ def test_match_queue_wraps_db_failures_in_typed_exception(
 
     with pytest.raises(MatchQueueError, match="Failed to queue items in match_scrape_queue."):
         queue.queue_many([("1", "https://www.hltv.org/matches/1/test")])
+
+
+def test_ingestion_state_classes_keep_existing_queue_behavior() -> None:
+    match_state = MatchIngestionState()
+    map_state = MapIngestionState()
+    demo_state = DemoIngestionState()
+
+    assert isinstance(match_state, MatchScrapeQueue)
+    assert match_state.table_name == "match_scrape_queue"
+    assert match_state.id_field == "match_id"
+    assert match_state.url_field == "match_url"
+
+    assert isinstance(map_state, MapScrapeQueue)
+    assert map_state.table_name == "map_scrape_queue"
+    assert map_state.id_field == "map_id"
+    assert map_state.url_field == "map_url"
+
+    assert isinstance(demo_state, DemoScrapeQueue)
+    assert demo_state.table_name == "demo_scrape_queue"
+    assert demo_state.id_field == "demo_id"
+    assert demo_state.url_field == "demo_url"

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -2,13 +2,16 @@ from contextlib import contextmanager
 
 import pytest
 
+import cs2_analytics.queues as queues
 from cs2_analytics.exceptions import MatchQueueError
+from cs2_analytics.queues import (
+    DemoIngestionState,
+    MapIngestionState,
+    MatchIngestionState,
+)
 from cs2_analytics.queues import base_scrape_queue as base_queue_module
-from cs2_analytics.queues.demo_ingestion_state import DemoIngestionState
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
-from cs2_analytics.queues.map_ingestion_state import MapIngestionState
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
-from cs2_analytics.queues.match_ingestion_state import MatchIngestionState
 from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 
 
@@ -30,6 +33,10 @@ def test_match_queue_wraps_db_failures_in_typed_exception(
 
 
 def test_ingestion_state_classes_keep_existing_queue_behavior() -> None:
+    assert "MatchIngestionState" in queues.__all__
+    assert "MapIngestionState" in queues.__all__
+    assert "DemoIngestionState" in queues.__all__
+
     match_state = MatchIngestionState()
     map_state = MapIngestionState()
     demo_state = DemoIngestionState()


### PR DESCRIPTION
## Summary

- Added `MatchIngestionState`, `MapIngestionState`, and `DemoIngestionState` as new names for the existing scrape queue implementations
- Exported the new names from `cs2_analytics.queues`
- Added tests confirming the new names still use the current scrape queue tables and behavior

## Notes

This PR is a naming bridge only. It does not change `schema.sql`, database table names, status values, lifecycle fields, controllers, or rediscovery behavior.