### PR TITLE
Move ingestion state classes to dedicated package

### DIFF
--- a/cs2_analytics/ingestion_state/__init__.py
+++ b/cs2_analytics/ingestion_state/__init__.py
@@ -1,0 +1,11 @@
+"""Ingestion state managers for discovered matches, maps, and demos."""
+
+from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
+from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
+from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
+
+__all__ = [
+    "DemoIngestionState",
+    "MapIngestionState",
+    "MatchIngestionState",
+]

--- a/cs2_analytics/ingestion_state/demo_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/demo_ingestion_state.py
@@ -1,7 +1,7 @@
-"""Compatibility name for demo ingestion state management."""
+"""Demo ingestion state manager."""
 
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
 
 
 class DemoIngestionState(DemoScrapeQueue):
-    """Alias class for the current demo scrape queue implementation."""
+    """Primary ingestion-state alias for current demo queue behavior."""

--- a/cs2_analytics/ingestion_state/demo_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/demo_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for demo ingestion state management."""
+
+from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
+
+
+class DemoIngestionState(DemoScrapeQueue):
+    """Alias class for the current demo scrape queue implementation."""

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -1,7 +1,7 @@
-"""Compatibility name for map ingestion state management."""
+"""Map ingestion state manager."""
 
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
 
 
 class MapIngestionState(MapScrapeQueue):
-    """Alias class for the current map scrape queue implementation."""
+    """Primary ingestion-state alias for current map queue behavior."""

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for map ingestion state management."""
+
+from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+
+
+class MapIngestionState(MapScrapeQueue):
+    """Alias class for the current map scrape queue implementation."""

--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -1,0 +1,7 @@
+"""Compatibility name for match ingestion state management."""
+
+from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
+
+
+class MatchIngestionState(MatchScrapeQueue):
+    """Alias class for the current match scrape queue implementation."""

--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -1,7 +1,7 @@
-"""Compatibility name for match ingestion state management."""
+"""Match ingestion state manager."""
 
 from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 
 
 class MatchIngestionState(MatchScrapeQueue):
-    """Alias class for the current match scrape queue implementation."""
+    """Primary ingestion-state alias for current match queue behavior."""

--- a/cs2_analytics/queues/__init__.py
+++ b/cs2_analytics/queues/__init__.py
@@ -6,11 +6,13 @@ This allows direct imports like:
     from cs2_analytics.queues import MatchIngestionState
 """
 
-from cs2_analytics.queues.demo_ingestion_state import DemoIngestionState
+from cs2_analytics.ingestion_state import (
+    DemoIngestionState,
+    MapIngestionState,
+    MatchIngestionState,
+)
 from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
-from cs2_analytics.queues.map_ingestion_state import MapIngestionState
 from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
-from cs2_analytics.queues.match_ingestion_state import MatchIngestionState
 from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
 
 match_queue = MatchScrapeQueue()

--- a/cs2_analytics/queues/demo_ingestion_state.py
+++ b/cs2_analytics/queues/demo_ingestion_state.py
@@ -1,7 +1,5 @@
-"""Compatibility name for demo ingestion state management."""
+"""Backward-compatible import for demo ingestion state."""
 
-from cs2_analytics.queues.demo_scrape_queue import DemoScrapeQueue
+from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
 
-
-class DemoIngestionState(DemoScrapeQueue):
-    """Alias class for the current demo scrape queue implementation."""
+__all__ = ["DemoIngestionState"]

--- a/cs2_analytics/queues/map_ingestion_state.py
+++ b/cs2_analytics/queues/map_ingestion_state.py
@@ -1,7 +1,5 @@
-"""Compatibility name for map ingestion state management."""
+"""Backward-compatible import for map ingestion state."""
 
-from cs2_analytics.queues.map_scrape_queue import MapScrapeQueue
+from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
 
-
-class MapIngestionState(MapScrapeQueue):
-    """Alias class for the current map scrape queue implementation."""
+__all__ = ["MapIngestionState"]

--- a/cs2_analytics/queues/match_ingestion_state.py
+++ b/cs2_analytics/queues/match_ingestion_state.py
@@ -1,7 +1,5 @@
-"""Compatibility name for match ingestion state management."""
+"""Backward-compatible import for match ingestion state."""
 
-from cs2_analytics.queues.match_scrape_queue import MatchScrapeQueue
+from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
 
-
-class MatchIngestionState(MatchScrapeQueue):
-    """Alias class for the current match scrape queue implementation."""
+__all__ = ["MatchIngestionState"]

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -4,6 +4,15 @@ import pytest
 
 import cs2_analytics.queues as queues
 from cs2_analytics.exceptions import MatchQueueError
+from cs2_analytics.ingestion_state import (
+    DemoIngestionState as PackageDemoIngestionState,
+)
+from cs2_analytics.ingestion_state import (
+    MapIngestionState as PackageMapIngestionState,
+)
+from cs2_analytics.ingestion_state import (
+    MatchIngestionState as PackageMatchIngestionState,
+)
 from cs2_analytics.queues import (
     DemoIngestionState,
     MapIngestionState,
@@ -36,6 +45,9 @@ def test_ingestion_state_classes_keep_existing_queue_behavior() -> None:
     assert "MatchIngestionState" in queues.__all__
     assert "MapIngestionState" in queues.__all__
     assert "DemoIngestionState" in queues.__all__
+    assert MatchIngestionState is PackageMatchIngestionState
+    assert MapIngestionState is PackageMapIngestionState
+    assert DemoIngestionState is PackageDemoIngestionState
 
     match_state = MatchIngestionState()
     map_state = MapIngestionState()


### PR DESCRIPTION
## Summary

- Added `cs2_analytics.ingestion_state` as the dedicated package for ingestion state classes
- Moved `MatchIngestionState`, `MapIngestionState`, and `DemoIngestionState` exports to the new package
- Kept `cs2_analytics.queues.*_ingestion_state` modules as compatibility wrappers
- Kept `cs2_analytics.queues` package-level exports working
- Updated queue tests to verify the old queue exports point to the new ingestion state package classes

## Notes

This PR only moves the ingestion-state alias classes into a better-suited package. It does not change queue behavior, database table names, lifecycle statuses, schema, controllers, or rediscovery behavior.