### PR TITLE
Add Phase 3 stage service shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ CS2-Analytics/
 |   ├── parsers/
 |   ├── pipeline/
 |   ├── scrapers/
+|   ├── stage_services/
 |   ├── services/
 |   ├── storage/
 |   └── utils/

--- a/cs2_analytics/__init__.py
+++ b/cs2_analytics/__init__.py
@@ -11,6 +11,7 @@ Submodules:
 - parsers: HTML and demo file parsing into structured formats
 - controllers: Pipeline orchestration and ingestion-stage coordination
 - ingestion_state: Lifecycle tracking for discovered matches, maps, and demos
+- stage_services: Per-item ingestion workflow services
 - services: Business logic and analytical processing
 - storage: Database access layer
 - pipeline: Main orchestration logic

--- a/cs2_analytics/stage_services/__init__.py
+++ b/cs2_analytics/stage_services/__init__.py
@@ -1,0 +1,11 @@
+"""Stage services for per-item ingestion workflows."""
+
+from .demo_stage_service import DemoStageService
+from .map_stage_service import MapStageService
+from .match_stage_service import MatchStageService
+
+__all__ = [
+    "DemoStageService",
+    "MapStageService",
+    "MatchStageService",
+]

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -22,7 +22,7 @@ class DemoStageService:
         self,
         scraper: DemoScraper,
         parser: DemoParser,
-        store_demo_file: Callable[..., None],
+        store_demo_file: Callable[[int, str, str | None, bool, bool, bool], None],
         demo_state: DemoIngestionState,
     ) -> None:
         self.scraper = scraper

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -1,0 +1,35 @@
+"""Per-item demo stage workflow service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cs2_analytics.ingestion_state import DemoIngestionState
+    from cs2_analytics.parsers.demo_parser import DemoParser
+    from cs2_analytics.scrapers.demo_scraper import DemoScraper
+
+
+class DemoStageService:
+    """Coordinates one demo ingestion item.
+
+    Demo processing remains deferred; this shell keeps Phase 3 structure aligned
+    without expanding the active demo pipeline scope.
+    """
+
+    def __init__(
+        self,
+        scraper: DemoScraper,
+        parser: DemoParser,
+        store_demo_file: Callable[..., None],
+        demo_state: DemoIngestionState,
+    ) -> None:
+        self.scraper = scraper
+        self.parser = parser
+        self.store_demo_file = store_demo_file
+        self.demo_state = demo_state
+
+    def process_item(self, demo_id: str, demo_url: str) -> None:
+        """Process one demo ingestion-state row."""
+        raise NotImplementedError

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -1,0 +1,36 @@
+"""Per-item map stage workflow service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cs2_analytics.ingestion_state import MapIngestionState
+    from cs2_analytics.models.player import Player
+    from cs2_analytics.parsers.map_parser import MapParser
+    from cs2_analytics.scrapers.map_scraper import MapScraper
+
+
+class MapStageService:
+    """Coordinates one map ingestion item.
+
+    Branch 1 defines the dependency boundary only. Controller wiring and
+    workflow migration happen in later Phase 3 branches.
+    """
+
+    def __init__(
+        self,
+        scraper: MapScraper,
+        parser: MapParser,
+        store_players: Callable[[list[Player]], None],
+        map_state: MapIngestionState,
+    ) -> None:
+        self.scraper = scraper
+        self.parser = parser
+        self.store_players = store_players
+        self.map_state = map_state
+
+    def process_item(self, map_id: str, map_url: str) -> None:
+        """Process one map ingestion-state row."""
+        raise NotImplementedError

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -1,0 +1,44 @@
+"""Per-item match stage workflow service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cs2_analytics.ingestion_state import (
+        DemoIngestionState,
+        MapIngestionState,
+        MatchIngestionState,
+    )
+    from cs2_analytics.models.match import Match
+    from cs2_analytics.parsers.match_parser import MatchParser
+    from cs2_analytics.scrapers.match_scraper import MatchScraper
+
+
+class MatchStageService:
+    """Coordinates one match ingestion item.
+
+    Branch 1 defines the dependency boundary only. Controller wiring and
+    workflow migration happen in later Phase 3 branches.
+    """
+
+    def __init__(
+        self,
+        scraper: MatchScraper,
+        parser: MatchParser,
+        store_matches: Callable[[list[Match]], None],
+        match_state: MatchIngestionState,
+        map_state: MapIngestionState,
+        demo_state: DemoIngestionState,
+    ) -> None:
+        self.scraper = scraper
+        self.parser = parser
+        self.store_matches = store_matches
+        self.match_state = match_state
+        self.map_state = map_state
+        self.demo_state = demo_state
+
+    def process_item(self, match_id: str, match_url: str) -> None:
+        """Process one match ingestion-state row."""
+        raise NotImplementedError

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -1,0 +1,98 @@
+import pytest
+
+from cs2_analytics import stage_services as stage_services_package
+from cs2_analytics.stage_services import (
+    DemoStageService,
+    MapStageService,
+    MatchStageService,
+)
+from cs2_analytics.stage_services.demo_stage_service import (
+    DemoStageService as ConcreteDemoStageService,
+)
+from cs2_analytics.stage_services.map_stage_service import (
+    MapStageService as ConcreteMapStageService,
+)
+from cs2_analytics.stage_services.match_stage_service import (
+    MatchStageService as ConcreteMatchStageService,
+)
+
+
+def _store_stub(*_args, **_kwargs) -> None:
+    return None
+
+
+def test_stage_services_package_re_exports_concrete_classes() -> None:
+    assert stage_services_package.MatchStageService is ConcreteMatchStageService
+    assert stage_services_package.MapStageService is ConcreteMapStageService
+    assert stage_services_package.DemoStageService is ConcreteDemoStageService
+    assert stage_services_package.__all__ == [
+        "DemoStageService",
+        "MapStageService",
+        "MatchStageService",
+    ]
+
+
+def test_match_stage_service_records_constructor_dependencies() -> None:
+    scraper = object()
+    parser = object()
+    match_state = object()
+    map_state = object()
+    demo_state = object()
+
+    service = MatchStageService(
+        scraper=scraper,
+        parser=parser,
+        store_matches=_store_stub,
+        match_state=match_state,
+        map_state=map_state,
+        demo_state=demo_state,
+    )
+
+    assert service.scraper is scraper
+    assert service.parser is parser
+    assert service.store_matches is _store_stub
+    assert service.match_state is match_state
+    assert service.map_state is map_state
+    assert service.demo_state is demo_state
+    with pytest.raises(NotImplementedError):
+        service.process_item("match-1", "https://www.hltv.org/matches/1/test")
+
+
+def test_map_stage_service_records_constructor_dependencies() -> None:
+    scraper = object()
+    parser = object()
+    map_state = object()
+
+    service = MapStageService(
+        scraper=scraper,
+        parser=parser,
+        store_players=_store_stub,
+        map_state=map_state,
+    )
+
+    assert service.scraper is scraper
+    assert service.parser is parser
+    assert service.store_players is _store_stub
+    assert service.map_state is map_state
+    with pytest.raises(NotImplementedError):
+        service.process_item("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
+
+
+def test_demo_stage_service_records_constructor_dependencies() -> None:
+    scraper = object()
+    parser = object()
+    demo_state = object()
+
+    service = DemoStageService(
+        scraper=scraper,
+        parser=parser,
+        store_demo_file=_store_stub,
+        demo_state=demo_state,
+    )
+
+    assert service.scraper is scraper
+    assert service.parser is parser
+    assert service.store_demo_file is _store_stub
+    assert service.demo_state is demo_state
+    with pytest.raises(NotImplementedError):
+        service.process_item("demo-1", "https://www.hltv.org/download/demo/test")


### PR DESCRIPTION
## Summary

- Add `cs2_analytics.stage_services` package
- Add `MatchStageService`, `MapStageService`, and `DemoStageService` shells
- Define constructor dependencies without wiring controllers
- Add tests for package exports, dependency assignment, and placeholder `process_item` behavior

## Validation

- `python -m pytest` from the venv