### PR TITLE
Move match item workflow into MatchStageService

### DIFF
--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -67,6 +67,7 @@ class MatchController:
                     scraper = self._reset_scraper(scraper)
                     processed_since_reset = 0
 
+                self.match_queue.mark_as_processing(match_id)
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -15,6 +15,7 @@ from cs2_analytics.ingestion_state import (
 )
 from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.scrapers.match_scraper import MatchScraper
+from cs2_analytics.stage_services import MatchStageService
 from cs2_analytics.storage.match_storage import store_matches
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -30,6 +31,14 @@ class MatchController:
         self.match_queue = MatchIngestionState()
         self.map_queue = MapIngestionState()
         self.demo_queue = DemoIngestionState()
+        self.stage_service = MatchStageService(
+            scraper=self.scraper,
+            parser=self.parser,
+            store_matches=store_matches,
+            match_state=self.match_queue,
+            map_state=self.map_queue,
+            demo_state=self.demo_queue,
+        )
 
     def run(self, batch_size: int = 25) -> None:
         """Runs the match stage for a batch of pending match URLs."""
@@ -58,25 +67,14 @@ class MatchController:
                     scraper = self._reset_scraper(scraper)
                     processed_since_reset = 0
 
-                self.match_queue.mark_as_processing(match_id)
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        soup = scraper.fetch_soup(match_url)
-                        match, map_links, demo_links = self.parser.parse_match(
-                            soup, match_url
-                        )
-
-                        if match:
-                            store_matches([match])
-                            self._queue_followups(map_links, demo_links)
-                            self.match_queue.mark_as_processed(match_id)
+                        self.stage_service.scraper = scraper
+                        if self.stage_service.process_item(match_id, match_url):
                             succeeded += 1
                             logger.info("Stored match: %s", match_id)
                         else:
-                            self.match_queue.mark_as_failed(
-                                match_id, "Parsing returned None"
-                            )
                             failed += 1
                             logger.warning("Match %s returned no parsed data", match_id)
 
@@ -185,13 +183,3 @@ class MatchController:
             logger.warning("Scraper session health check failed: %s", e)
             return False
 
-    def _queue_followups(
-        self,
-        map_links: list[tuple[str, str]],
-        demo_links: list[tuple[str, str]],
-    ) -> None:
-        """Queues map and demo links returned by the parser."""
-        for map_id, map_url in map_links:
-            self.map_queue.queue(map_id, map_url, source="match_parser")
-        for demo_id, demo_url in demo_links:
-            self.demo_queue.queue(demo_id, demo_url, source="match_parser")

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -32,7 +32,6 @@ class MatchController:
         self.map_queue = MapIngestionState()
         self.demo_queue = DemoIngestionState()
         self.stage_service = MatchStageService(
-            scraper=self.scraper,
             parser=self.parser,
             store_matches=store_matches,
             match_state=self.match_queue,
@@ -71,8 +70,9 @@ class MatchController:
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        self.stage_service.scraper = scraper
-                        if self.stage_service.process_item(match_id, match_url):
+                        if self.stage_service.process_item(
+                            match_id, match_url, scraper=scraper
+                        ):
                             succeeded += 1
                             logger.info("Stored match: %s", match_id)
                         else:
@@ -150,7 +150,7 @@ class MatchController:
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         """Returns True for transient scraper failures worth retrying."""
-        return is_retryable_scraper_error(error)
+        return bool(is_retryable_scraper_error(error))
 
     def _reset_scraper(self, scraper: MatchScraper) -> MatchScraper:
         """Closes and recreates the scraper so the next attempt gets a fresh session."""

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -17,11 +17,7 @@ if TYPE_CHECKING:
 
 
 class MatchStageService:
-    """Coordinates one match ingestion item.
-
-    Branch 1 defines the dependency boundary only. Controller wiring and
-    workflow migration happen in later Phase 3 branches.
-    """
+    """Coordinates one match ingestion item."""
 
     def __init__(
         self,
@@ -39,6 +35,32 @@ class MatchStageService:
         self.map_state = map_state
         self.demo_state = demo_state
 
-    def process_item(self, match_id: str, match_url: str) -> None:
-        """Process one match ingestion-state row."""
-        raise NotImplementedError
+    def process_item(self, match_id: str, match_url: str) -> bool:
+        """Process one match ingestion-state row.
+
+        Returns True when the match was stored successfully and False when
+        parsing returned no match object.
+        """
+        self.match_state.mark_as_processing(match_id)
+        soup = self.scraper.fetch_soup(match_url)
+        match, map_links, demo_links = self.parser.parse_match(soup, match_url)
+
+        if not match:
+            self.match_state.mark_as_failed(match_id, "Parsing returned None")
+            return False
+
+        self.store_matches([match])
+        self._queue_followups(map_links, demo_links)
+        self.match_state.mark_as_processed(match_id)
+        return True
+
+    def _queue_followups(
+        self,
+        map_links: list[tuple[str, str]],
+        demo_links: list[tuple[str, str]],
+    ) -> None:
+        """Queue map and demo links returned by the parser."""
+        for map_id, map_url in map_links:
+            self.map_state.queue(map_id, map_url, source="match_parser")
+        for demo_id, demo_url in demo_links:
+            self.demo_state.queue(demo_id, demo_url, source="match_parser")

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -41,7 +41,6 @@ class MatchStageService:
         Returns True when the match was stored successfully and False when
         parsing returned no match object.
         """
-        self.match_state.mark_as_processing(match_id)
         soup = self.scraper.fetch_soup(match_url)
         match, map_links, demo_links = self.parser.parse_match(soup, match_url)
 

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -21,27 +21,27 @@ class MatchStageService:
 
     def __init__(
         self,
-        scraper: MatchScraper,
         parser: MatchParser,
         store_matches: Callable[[list[Match]], None],
         match_state: MatchIngestionState,
         map_state: MapIngestionState,
         demo_state: DemoIngestionState,
     ) -> None:
-        self.scraper = scraper
         self.parser = parser
         self.store_matches = store_matches
         self.match_state = match_state
         self.map_state = map_state
         self.demo_state = demo_state
 
-    def process_item(self, match_id: str, match_url: str) -> bool:
+    def process_item(
+        self, match_id: str, match_url: str, *, scraper: MatchScraper
+    ) -> bool:
         """Process one match ingestion-state row.
 
         Returns True when the match was stored successfully and False when
         parsing returned no match object.
         """
-        soup = self.scraper.fetch_soup(match_url)
+        soup = scraper.fetch_soup(match_url)
         match, map_links, demo_links = self.parser.parse_match(soup, match_url)
 
         if not match:

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -208,7 +208,7 @@ def test_match_controller_continues_after_item_failure(
         ],
     )
     monkeypatch.setattr(
-        match_module,
+        controller.stage_service,
         "store_matches",
         lambda matches: stored_matches.append(matches),
     )
@@ -257,7 +257,7 @@ def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
         lambda scraper: reset_calls.append(scraper) or scraper,
     )
     monkeypatch.setattr(
-        match_module,
+        controller.stage_service,
         "store_matches",
         lambda matches: stored_matches.append(matches),
     )

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -75,7 +75,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
 
     assert processed is True
-    assert match_state.processing == ["match-1"]
+    assert match_state.processing == []
     assert match_state.processed == ["match-1"]
     assert match_state.failed == []
     assert stored_matches == [[match]]
@@ -106,7 +106,7 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
     processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
 
     assert processed is False
-    assert match_state.processing == ["match-1"]
+    assert match_state.processing == []
     assert match_state.processed == []
     assert match_state.failed == [("match-1", "Parsing returned None")]
     assert stored_matches == []

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -1,0 +1,112 @@
+from cs2_analytics.stage_services import MatchStageService
+
+
+class _FakeScraper:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def fetch_soup(self, url: str) -> object:
+        self.urls.append(url)
+        return object()
+
+
+class _FakeParser:
+    def __init__(
+        self,
+        match: object | None,
+        map_links: list[tuple[str, str]] | None = None,
+        demo_links: list[tuple[str, str]] | None = None,
+    ) -> None:
+        self.match = match
+        self.map_links = map_links or []
+        self.demo_links = demo_links or []
+        self.calls: list[str] = []
+
+    def parse_match(
+        self, soup: object, match_url: str
+    ) -> tuple[object | None, list[tuple[str, str]], list[tuple[str, str]]]:
+        self.calls.append(match_url)
+        return self.match, self.map_links, self.demo_links
+
+
+class _FakeMatchState:
+    def __init__(self) -> None:
+        self.processing: list[str] = []
+        self.processed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    def mark_as_processing(self, item_id: str) -> None:
+        self.processing.append(item_id)
+
+    def mark_as_processed(self, item_id: str) -> None:
+        self.processed.append(item_id)
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+
+class _FakeFollowupState:
+    def __init__(self) -> None:
+        self.queued: list[tuple[str, str, str]] = []
+
+    def queue(self, item_id: str, url: str, source: str = "unknown") -> None:
+        self.queued.append((item_id, url, source))
+
+
+def test_match_stage_service_processes_success_and_queues_followups() -> None:
+    stored_matches: list[list[object]] = []
+    match = object()
+    match_state = _FakeMatchState()
+    map_state = _FakeFollowupState()
+    demo_state = _FakeFollowupState()
+    service = MatchStageService(
+        scraper=_FakeScraper(),
+        parser=_FakeParser(
+            match=match,
+            map_links=[("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
+            demo_links=[("demo-1", "https://www.hltv.org/download/demo/test")],
+        ),
+        store_matches=lambda matches: stored_matches.append(matches),
+        match_state=match_state,
+        map_state=map_state,
+        demo_state=demo_state,
+    )
+
+    processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
+
+    assert processed is True
+    assert match_state.processing == ["match-1"]
+    assert match_state.processed == ["match-1"]
+    assert match_state.failed == []
+    assert stored_matches == [[match]]
+    assert map_state.queued == [
+        (
+            "map-1",
+            "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+            "match_parser",
+        )
+    ]
+    assert demo_state.queued == [
+        ("demo-1", "https://www.hltv.org/download/demo/test", "match_parser")
+    ]
+
+
+def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
+    stored_matches: list[list[object]] = []
+    match_state = _FakeMatchState()
+    service = MatchStageService(
+        scraper=_FakeScraper(),
+        parser=_FakeParser(match=None),
+        store_matches=lambda matches: stored_matches.append(matches),
+        match_state=match_state,
+        map_state=_FakeFollowupState(),
+        demo_state=_FakeFollowupState(),
+    )
+
+    processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
+
+    assert processed is False
+    assert match_state.processing == ["match-1"]
+    assert match_state.processed == []
+    assert match_state.failed == [("match-1", "Parsing returned None")]
+    assert stored_matches == []

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -23,7 +23,7 @@ class _FakeParser:
         self.calls: list[str] = []
 
     def parse_match(
-        self, soup: object, match_url: str
+        self, _soup: object, match_url: str
     ) -> tuple[object | None, list[tuple[str, str]], list[tuple[str, str]]]:
         self.calls.append(match_url)
         return self.match, self.map_links, self.demo_links
@@ -60,7 +60,6 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     map_state = _FakeFollowupState()
     demo_state = _FakeFollowupState()
     service = MatchStageService(
-        scraper=_FakeScraper(),
         parser=_FakeParser(
             match=match,
             map_links=[("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
@@ -72,7 +71,9 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
         demo_state=demo_state,
     )
 
-    processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
+    processed = service.process_item(
+        "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
+    )
 
     assert processed is True
     assert match_state.processing == []
@@ -95,7 +96,6 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
     stored_matches: list[list[object]] = []
     match_state = _FakeMatchState()
     service = MatchStageService(
-        scraper=_FakeScraper(),
         parser=_FakeParser(match=None),
         store_matches=lambda matches: stored_matches.append(matches),
         match_state=match_state,
@@ -103,10 +103,29 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
         demo_state=_FakeFollowupState(),
     )
 
-    processed = service.process_item("match-1", "https://www.hltv.org/matches/1/test")
+    processed = service.process_item(
+        "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
+    )
 
     assert processed is False
     assert match_state.processing == []
     assert match_state.processed == []
     assert match_state.failed == [("match-1", "Parsing returned None")]
     assert stored_matches == []
+
+
+def test_match_stage_service_processes_with_attempt_scraper() -> None:
+    attempt_scraper = _FakeScraper()
+    service = MatchStageService(
+        parser=_FakeParser(match=object()),
+        store_matches=lambda _matches: None,
+        match_state=_FakeMatchState(),
+        map_state=_FakeFollowupState(),
+        demo_state=_FakeFollowupState(),
+    )
+
+    service.process_item(
+        "match-1", "https://www.hltv.org/matches/1/test", scraper=attempt_scraper
+    )
+
+    assert attempt_scraper.urls == ["https://www.hltv.org/matches/1/test"]

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -33,14 +33,12 @@ def test_stage_services_package_re_exports_concrete_classes() -> None:
 
 
 def test_match_stage_service_records_constructor_dependencies() -> None:
-    scraper = object()
     parser = object()
     match_state = object()
     map_state = object()
     demo_state = object()
 
     service = MatchStageService(
-        scraper=scraper,
         parser=parser,
         store_matches=_store_stub,
         match_state=match_state,
@@ -48,7 +46,6 @@ def test_match_stage_service_records_constructor_dependencies() -> None:
         demo_state=demo_state,
     )
 
-    assert service.scraper is scraper
     assert service.parser is parser
     assert service.store_matches is _store_stub
     assert service.match_state is match_state

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -54,8 +54,6 @@ def test_match_stage_service_records_constructor_dependencies() -> None:
     assert service.match_state is match_state
     assert service.map_state is map_state
     assert service.demo_state is demo_state
-    with pytest.raises(NotImplementedError):
-        service.process_item("match-1", "https://www.hltv.org/matches/1/test")
 
 
 def test_map_stage_service_records_constructor_dependencies() -> None:


### PR DESCRIPTION
## Summary

- Move per-match fetch, parse, persist, follow-up queueing, and lifecycle updates into `MatchStageService`
- Wire `MatchController` to delegate per-item match processing to the service
- Keep controller ownership of batch coordination, retry policy, scraper reset/rotation, delays, and summary logging
- Add focused `MatchStageService` tests for success and parser-empty outcomes
- Update affected controller tests to patch the service dependency directly

## Validation

- `python -m pytest`