### PR TITLE
Move map item workflow into MapStageService

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -11,6 +11,7 @@ from cs2_analytics.controllers.retry_utils import (
 from cs2_analytics.ingestion_state import MapIngestionState
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.scrapers.map_scraper import MapScraper
+from cs2_analytics.stage_services import MapStageService
 from cs2_analytics.storage.player_storage import store_players
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -24,6 +25,11 @@ class MapController:
         self.scraper = MapScraper()
         self.parser = MapParser()
         self.queue = MapIngestionState()
+        self.stage_service = MapStageService(
+            parser=self.parser,
+            store_players=store_players,
+            map_state=self.queue,
+        )
 
     def run(self, batch_size: int = 25) -> None:
         logger.info("Running MapController with batch size: %d", batch_size)
@@ -54,16 +60,12 @@ class MapController:
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        soup = scraper.fetch_soup(map_url)
-                        player_obj = self.parser.parse_map(soup, map_url, map_id)
-
-                        if player_obj:
-                            store_players(player_obj)
-                            self.queue.mark_as_processed(map_id)
+                        if self.stage_service.process_item(
+                            map_id, map_url, scraper=scraper
+                        ):
                             succeeded += 1
                             logger.info("Stored map: %s", map_id)
                         else:
-                            self.queue.mark_as_failed(map_id, "Parsing returned None")
                             failed += 1
                             logger.warning("Map %s returned no parsed data", map_id)
 

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -13,24 +13,31 @@ if TYPE_CHECKING:
 
 
 class MapStageService:
-    """Coordinates one map ingestion item.
-
-    Branch 1 defines the dependency boundary only. Controller wiring and
-    workflow migration happen in later Phase 3 branches.
-    """
+    """Coordinates one map ingestion item."""
 
     def __init__(
         self,
-        scraper: MapScraper,
         parser: MapParser,
         store_players: Callable[[list[Player]], None],
         map_state: MapIngestionState,
     ) -> None:
-        self.scraper = scraper
         self.parser = parser
         self.store_players = store_players
         self.map_state = map_state
 
-    def process_item(self, map_id: str, map_url: str) -> None:
-        """Process one map ingestion-state row."""
-        raise NotImplementedError
+    def process_item(self, map_id: str, map_url: str, *, scraper: MapScraper) -> bool:
+        """Process one map ingestion-state row.
+
+        Returns True when player stats were stored successfully and False when
+        parsing returned no player records.
+        """
+        soup = scraper.fetch_soup(map_url)
+        players = self.parser.parse_map(soup, map_url, map_id)
+
+        if not players:
+            self.map_state.mark_as_failed(map_id, "Parsing returned None")
+            return False
+
+        self.store_players(players)
+        self.map_state.mark_as_processed(map_id)
+        return True

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -35,7 +35,7 @@ class MapStageService:
         players = self.parser.parse_map(soup, map_url, map_id)
 
         if not players:
-            self.map_state.mark_as_failed(map_id, "Parsing returned None")
+            self.map_state.mark_as_failed(map_id, "Parsing returned no player records")
             return False
 
         self.store_players(players)

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -50,6 +50,17 @@ class _RetryThenSucceedScraper(_SuccessfulScraper):
         return object()
 
 
+class _TrackingStageService:
+    def __init__(self) -> None:
+        self.scrapers: list[object] = []
+
+    def process_item(self, map_id: str, map_url: str, *, scraper: object) -> bool:
+        self.scrapers.append(scraper)
+        if len(self.scrapers) == 1:
+            raise SessionScrapeError(f"Failed to fetch map stats page: {map_url}")
+        return True
+
+
 class _FailOnceThenSucceedParser:
     def __init__(self) -> None:
         self.calls = 0
@@ -130,7 +141,7 @@ def test_map_controller_retries_retryable_error_before_succeeding(
     )
     stored_players: list[list[object]] = []
     monkeypatch.setattr(
-        map_module,
+        controller.stage_service,
         "store_players",
         lambda players: stored_players.append(players),
     )
@@ -164,6 +175,38 @@ def test_map_controller_retries_retryable_error_before_succeeding(
         and call_args[1:] == (1, 1, 0, 1)
         for call_args, _ in info_calls
     )
+
+
+def test_map_controller_passes_reset_scraper_to_stage_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_map_controller(
+        monkeypatch,
+        _SuccessfulScraper,
+        _SuccessfulParser,
+    )
+    first_scraper = controller.scraper
+    reset_scraper = _SuccessfulScraper()
+    stage_service = _TrackingStageService()
+    monkeypatch.setattr(controller, "stage_service", stage_service)
+    monkeypatch.setattr(
+        controller,
+        "_reset_scraper",
+        lambda scraper: reset_scraper,
+    )
+    monkeypatch.setattr(
+        controller.queue,
+        "fetch",
+        lambda limit=25: [
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
+        ],
+    )
+
+    controller.run(batch_size=1)
+
+    assert stage_service.scrapers == [first_scraper, reset_scraper]
+    assert controller.queue.failed == []
+    assert controller.queue.processed == []
 
 
 def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(

--- a/tests/stage_services/test_map_stage_service.py
+++ b/tests/stage_services/test_map_stage_service.py
@@ -1,0 +1,104 @@
+from cs2_analytics.stage_services import MapStageService
+
+
+class _FakeScraper:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def fetch_soup(self, url: str) -> object:
+        self.urls.append(url)
+        return object()
+
+
+class _FakeParser:
+    def __init__(self, players: list[object]) -> None:
+        self.players = players
+        self.calls: list[tuple[str, str]] = []
+
+    def parse_map(self, _soup: object, map_url: str, map_id: str) -> list[object]:
+        self.calls.append((map_url, map_id))
+        return self.players
+
+
+class _FakeMapState:
+    def __init__(self) -> None:
+        self.processing: list[str] = []
+        self.processed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    def mark_as_processing(self, item_id: str) -> None:
+        self.processing.append(item_id)
+
+    def mark_as_processed(self, item_id: str) -> None:
+        self.processed.append(item_id)
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+
+def test_map_stage_service_processes_success() -> None:
+    stored_players: list[list[object]] = []
+    players = [object()]
+    map_state = _FakeMapState()
+    parser = _FakeParser(players=players)
+    service = MapStageService(
+        parser=parser,
+        store_players=lambda parsed_players: stored_players.append(parsed_players),
+        map_state=map_state,
+    )
+
+    processed = service.process_item(
+        "map-1",
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        scraper=_FakeScraper(),
+    )
+
+    assert processed is True
+    assert parser.calls == [
+        ("https://www.hltv.org/stats/matches/mapstatsid/1/test", "map-1")
+    ]
+    assert map_state.processing == []
+    assert map_state.processed == ["map-1"]
+    assert map_state.failed == []
+    assert stored_players == [players]
+
+
+def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None:
+    stored_players: list[list[object]] = []
+    map_state = _FakeMapState()
+    service = MapStageService(
+        parser=_FakeParser(players=[]),
+        store_players=lambda parsed_players: stored_players.append(parsed_players),
+        map_state=map_state,
+    )
+
+    processed = service.process_item(
+        "map-1",
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        scraper=_FakeScraper(),
+    )
+
+    assert processed is False
+    assert map_state.processing == []
+    assert map_state.processed == []
+    assert map_state.failed == [("map-1", "Parsing returned None")]
+    assert stored_players == []
+
+
+def test_map_stage_service_processes_with_attempt_scraper() -> None:
+    attempt_scraper = _FakeScraper()
+    service = MapStageService(
+        parser=_FakeParser(players=[object()]),
+        store_players=lambda _players: None,
+        map_state=_FakeMapState(),
+    )
+
+    service.process_item(
+        "map-1",
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        scraper=attempt_scraper,
+    )
+
+    assert attempt_scraper.urls == [
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test"
+    ]

--- a/tests/stage_services/test_map_stage_service.py
+++ b/tests/stage_services/test_map_stage_service.py
@@ -81,7 +81,7 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
     assert processed is False
     assert map_state.processing == []
     assert map_state.processed == []
-    assert map_state.failed == [("map-1", "Parsing returned None")]
+    assert map_state.failed == [("map-1", "Parsing returned no player records")]
     assert stored_players == []
 
 

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -54,23 +54,18 @@ def test_match_stage_service_records_constructor_dependencies() -> None:
 
 
 def test_map_stage_service_records_constructor_dependencies() -> None:
-    scraper = object()
     parser = object()
     map_state = object()
 
     service = MapStageService(
-        scraper=scraper,
         parser=parser,
         store_players=_store_stub,
         map_state=map_state,
     )
 
-    assert service.scraper is scraper
     assert service.parser is parser
     assert service.store_players is _store_stub
     assert service.map_state is map_state
-    with pytest.raises(NotImplementedError):
-        service.process_item("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
 
 
 def test_demo_stage_service_records_constructor_dependencies() -> None:


### PR DESCRIPTION
## Summary
- Move per-map fetch, parse, persist, and lifecycle updates into `MapStageService`
- Keep `MapController` responsible for batch coordination, retries, scraper resets, pacing, and summary logging
- Add service coverage plus a regression test to ensure reset scraper instances are passed into the stage service on retry

## Tests
- `python -m pytest` in the venv
