### PR TITLE
Add deferred demo stage service placeholder

### DIFF
--- a/cs2_analytics/controllers/demo_controller.py
+++ b/cs2_analytics/controllers/demo_controller.py
@@ -1,6 +1,7 @@
 from cs2_analytics.ingestion_state import DemoIngestionState
 from cs2_analytics.parsers.demo_parser import DemoParser
 from cs2_analytics.scrapers.demo_scraper import DemoScraper
+from cs2_analytics.stage_services import DemoStageService
 from cs2_analytics.storage.demo_storage import store_demo_file
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -12,29 +13,42 @@ class DemoController:
         self.scraper = DemoScraper()
         self.parser = DemoParser()
         self.queue = DemoIngestionState()
+        self.stage_service = DemoStageService(
+            scraper=self.scraper,
+            parser=self.parser,
+            store_demo_file=store_demo_file,
+            demo_state=self.queue,
+        )
 
     def run(self, batch_size: int = 25) -> None:
         logger.info("🕹️ Running DemoController with batch size: %d", batch_size)
 
         queued = self.queue.fetch(batch_size)
         logger.info("📥 %d demo URLs pulled from queue", len(queued))
+        succeeded = 0
+        failed = 0
 
         for demo_id, demo_url in queued:
             try:
                 self.queue.mark_as_processing(demo_id)
-                demo_path = self.scraper.download(demo_url)
-                demo_obj = self.parser.parse_demo(demo_path, demo_url)
+                stored = self.stage_service.process_item(demo_id, demo_url)
 
-                if demo_obj:
-                    store_demo_file([demo_obj])
-                    self.queue.mark_as_processed(demo_id)
+                if stored:
+                    succeeded += 1
                     logger.info("✅ Stored demo: %s", demo_id)
                 else:
-                    self.queue.mark_as_failed(demo_id, "Parsing returned None")
+                    failed += 1
                     logger.warning("❌ Demo %s returned None", demo_id)
 
             except Exception as e:
+                failed += 1
                 self.queue.mark_as_failed(demo_id, str(e))
                 logger.exception("❌ Error processing demo %s: %s", demo_id, e)
 
+        logger.info(
+            "DemoController summary: queued=%d succeeded=%d failed=%d",
+            len(queued),
+            succeeded,
+            failed,
+        )
         logger.info("🏁 DemoController complete.")

--- a/cs2_analytics/controllers/demo_controller.py
+++ b/cs2_analytics/controllers/demo_controller.py
@@ -38,7 +38,10 @@ class DemoController:
                     logger.info("✅ Stored demo: %s", demo_id)
                 else:
                     failed += 1
-                    logger.warning("❌ Demo %s returned None", demo_id)
+                    logger.info(
+                        "Demo %s was not stored by the demo stage service",
+                        demo_id,
+                    )
 
             except Exception as e:
                 failed += 1

--- a/cs2_analytics/scrapers/demo_scraper.py
+++ b/cs2_analytics/scrapers/demo_scraper.py
@@ -121,7 +121,13 @@ class DemoScraper:
                                 file.read()
                             )  # ✅ Store in memory
 
-            elif rarfile is not None and rarfile.is_rarfile(archive_buffer):
+            elif rarfile is None:
+                logger.warning(
+                    "RAR demo extraction requires the optional demo dependency: rarfile."
+                )
+                return None
+
+            elif rarfile.is_rarfile(archive_buffer):
                 with rarfile.RarFile(archive_buffer) as archive:
                     for file_name in archive.namelist():
                         with archive.open(file_name) as file:

--- a/cs2_analytics/scrapers/demo_scraper.py
+++ b/cs2_analytics/scrapers/demo_scraper.py
@@ -10,12 +10,16 @@ import os
 import time
 import zipfile
 
-import rarfile
 from selenium.webdriver.chrome.options import Options
 from seleniumbase import Driver
 
 from cs2_analytics.exceptions import DemoScrapeError
 from cs2_analytics.utils.log_manager import get_logger
+
+try:
+    import rarfile
+except ImportError:  # pragma: no cover - exercised only without the demo extra.
+    rarfile = None
 
 logger = get_logger(__name__)
 
@@ -117,7 +121,7 @@ class DemoScraper:
                                 file.read()
                             )  # ✅ Store in memory
 
-            elif rarfile.is_rarfile(archive_buffer):
+            elif rarfile is not None and rarfile.is_rarfile(archive_buffer):
                 with rarfile.RarFile(archive_buffer) as archive:
                     for file_name in archive.namelist():
                         with archive.open(file_name) as file:

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -30,6 +30,16 @@ class DemoStageService:
         self.store_demo_file = store_demo_file
         self.demo_state = demo_state
 
-    def process_item(self, demo_id: str, demo_url: str) -> None:
-        """Process one demo ingestion-state row."""
-        raise NotImplementedError
+    def process_item(self, demo_id: str, demo_url: str) -> bool:
+        """Process one demo ingestion-state row.
+
+        Demo ingestion is intentionally deferred. Returning False lets the
+        controller preserve the same per-item service boundary as match/map
+        without expanding the non-operational demo pipeline in this branch.
+        """
+        _ = demo_url
+        self.demo_state.mark_as_failed(
+            demo_id,
+            "Demo ingestion is deferred until the demo pipeline is operational",
+        )
+        return False

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -38,7 +38,7 @@ class DemoStageService:
         without expanding the non-operational demo pipeline in this branch.
         """
         _ = demo_url
-        self.demo_state.mark_as_failed(
+        self.demo_state.mark_as_skipped(
             demo_id,
             "Demo ingestion is deferred until the demo pipeline is operational",
         )

--- a/tests/controllers/test_demo_controller.py
+++ b/tests/controllers/test_demo_controller.py
@@ -1,0 +1,84 @@
+import pytest
+
+from cs2_analytics.controllers import demo_controller as demo_module
+
+
+class _FakeDemoQueue:
+    def __init__(self) -> None:
+        self.failed: list[tuple[str, str]] = []
+        self.processed: list[str] = []
+        self.processing: list[str] = []
+
+    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+        assert limit == 2
+        return [
+            ("demo-1", "https://www.hltv.org/download/demo/1"),
+            ("demo-2", "https://www.hltv.org/download/demo/2"),
+        ]
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+    def mark_as_processed(self, item_id: str) -> None:
+        self.processed.append(item_id)
+
+    def mark_as_processing(self, item_id: str) -> None:
+        self.processing.append(item_id)
+
+
+class _PassiveScraper:
+    pass
+
+
+class _PassiveParser:
+    pass
+
+
+class _TrackingStageService:
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def process_item(self, demo_id: str, demo_url: str) -> bool:
+        self.calls.append((demo_id, demo_url))
+        if demo_id == "demo-1":
+            raise RuntimeError("demo parse exploded")
+        return True
+
+
+def test_demo_controller_delegates_per_item_work_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(demo_module, "DemoScraper", _PassiveScraper)
+    monkeypatch.setattr(demo_module, "DemoParser", _PassiveParser)
+    monkeypatch.setattr(demo_module, "DemoIngestionState", _FakeDemoQueue)
+    monkeypatch.setattr(demo_module, "DemoStageService", _TrackingStageService)
+    monkeypatch.setattr(demo_module, "store_demo_file", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        demo_module.logger,
+        "info",
+        lambda *args, **kwargs: info_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        demo_module.logger,
+        "exception",
+        lambda *args, **kwargs: exception_calls.append((args, kwargs)),
+    )
+
+    controller = demo_module.DemoController()
+    controller.run(batch_size=2)
+
+    assert controller.stage_service.calls == [
+        ("demo-1", "https://www.hltv.org/download/demo/1"),
+        ("demo-2", "https://www.hltv.org/download/demo/2"),
+    ]
+    assert controller.queue.processing == ["demo-1", "demo-2"]
+    assert controller.queue.failed == [("demo-1", "demo parse exploded")]
+    assert controller.queue.processed == []
+    assert len(exception_calls) == 1
+    assert any(
+        call_args[0] == "DemoController summary: queued=%d succeeded=%d failed=%d"
+        and call_args[1:] == (2, 1, 1)
+        for call_args, _ in info_calls
+    )

--- a/tests/stage_services/test_demo_stage_service.py
+++ b/tests/stage_services/test_demo_stage_service.py
@@ -1,0 +1,34 @@
+from cs2_analytics.stage_services import DemoStageService
+
+
+class _FakeDemoState:
+    def __init__(self) -> None:
+        self.processed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    def mark_as_processed(self, item_id: str) -> None:
+        self.processed.append(item_id)
+
+    def mark_as_failed(self, item_id: str, reason: str) -> None:
+        self.failed.append((item_id, reason))
+
+
+def test_demo_stage_service_marks_demo_ingestion_deferred() -> None:
+    demo_state = _FakeDemoState()
+    service = DemoStageService(
+        scraper=object(),
+        parser=object(),
+        store_demo_file=lambda *_args: None,
+        demo_state=demo_state,
+    )
+
+    processed = service.process_item("demo-1", "https://www.hltv.org/download/demo/1")
+
+    assert processed is False
+    assert demo_state.processed == []
+    assert demo_state.failed == [
+        (
+            "demo-1",
+            "Demo ingestion is deferred until the demo pipeline is operational",
+        )
+    ]

--- a/tests/stage_services/test_demo_stage_service.py
+++ b/tests/stage_services/test_demo_stage_service.py
@@ -5,12 +5,16 @@ class _FakeDemoState:
     def __init__(self) -> None:
         self.processed: list[str] = []
         self.failed: list[tuple[str, str]] = []
+        self.skipped: list[tuple[str, str]] = []
 
     def mark_as_processed(self, item_id: str) -> None:
         self.processed.append(item_id)
 
     def mark_as_failed(self, item_id: str, reason: str) -> None:
         self.failed.append((item_id, reason))
+
+    def mark_as_skipped(self, item_id: str, reason: str) -> None:
+        self.skipped.append((item_id, reason))
 
 
 def test_demo_stage_service_marks_demo_ingestion_deferred() -> None:
@@ -26,7 +30,8 @@ def test_demo_stage_service_marks_demo_ingestion_deferred() -> None:
 
     assert processed is False
     assert demo_state.processed == []
-    assert demo_state.failed == [
+    assert demo_state.failed == []
+    assert demo_state.skipped == [
         (
             "demo-1",
             "Demo ingestion is deferred until the demo pipeline is operational",

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -1,5 +1,3 @@
-import pytest
-
 from cs2_analytics import stage_services as stage_services_package
 from cs2_analytics.stage_services import (
     DemoStageService,
@@ -84,5 +82,4 @@ def test_demo_stage_service_records_constructor_dependencies() -> None:
     assert service.parser is parser
     assert service.store_demo_file is _store_stub
     assert service.demo_state is demo_state
-    with pytest.raises(NotImplementedError):
-        service.process_item("demo-1", "https://www.hltv.org/download/demo/test")
+


### PR DESCRIPTION
## Summary

- Add `DemoStageService` as the Phase 3 demo-stage boundary
- Update `DemoController` to delegate per-item work to the demo stage service
- Keep demo ingestion explicitly deferred instead of expanding the non-operational demo pipeline
- Make optional `rarfile` import non-fatal when the demo extra is not installed
- Add tests for demo controller delegation and deferred demo-stage behavior

## Notes

Demo processing is still intentionally not operational. This PR mirrors the match/map stage-service structure while preserving the current Phase 3 boundary.

## Verification

## Summary

- Add `DemoStageService` as the Phase 3 demo-stage boundary
- Update `DemoController` to delegate per-item work to the demo stage service
- Keep demo ingestion explicitly deferred instead of expanding the non-operational demo pipeline
- Make optional `rarfile` import non-fatal when the demo extra is not installed
- Add tests for demo controller delegation and deferred demo-stage behavior

## Notes

Demo processing is still intentionally not operational. This PR mirrors the match/map stage-service structure while preserving the current Phase 3 boundary.

## Verification

- Ran the full test suite with the project virtual environment: `python -m pytest`
- Ran lint checks against the changed files with Ruff
