### PR TITLE
Phase 3: Ingestion Stage Boundary Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,163 +1,107 @@
-# **Counter-Strike 2 Pro Match Analytics Tool**
+# Counter-Strike 2 Pro Match Analytics Tool
 
-## **Project Overview**
+## Project Overview
 
-This project is a **Counter-Strike 2 (CS2) analytics tool** focused on collecting professional **match, map, and player data** and turning it into reliable, queryable analytics data. The current development focus is the ingestion pipeline: discovery, match/map processing, relational storage, and thinner controller boundaries around the active ingestion stages.
+This project is a Counter-Strike 2 analytics tool focused on collecting professional match, map, and player data and turning it into reliable, queryable analytics data.
 
----
+The current ingestion architecture uses PostgreSQL-backed ingestion-state tables, thin controllers for batch orchestration, and stage services for per-item match/map/demo workflow boundaries.
 
-## **Features**
+## Features
 
-### **Data Scraping**
+### Data Ingestion
 
-- **Match Data:** Scrapes CS2 professional match results (teams, scores, events, etc.).
-- **Game Data:** Extracts detailed round-by-round statistics.
-- **Player Stats:** Collects individual player performance metrics (kills, deaths, assists, ADR, KAST, opening duels, multi-kills, clutches, round swing, etc.).
-- **Ingestion Hardening:** Uses retry/backoff, browser session recovery, and PostgreSQL-backed lifecycle tracking for resilient scraping runs.
+- Results discovery refreshes match ingestion-state rows.
+- Match processing collects match metadata and discovers downstream map/demo links.
+- Map processing collects player performance metrics such as kills, deaths, assists, ADR, KAST, opening duels, multi-kills, clutches, and round swing.
+- Ingestion hardening uses retry/backoff, browser session recovery, and lifecycle tracking for resilient scraping runs.
 
-### **Deferred / Later-Phase Work**
+### Deferred / Later-Phase Work
 
-- **Demo Processing:** Demo download and parsing remain deferred until the active match/map ingestion stages have cleaner lifecycle semantics and thinner controllers.
-- **dbt Transformation Layer:** dbt will be added after ingestion/state semantics are stable.
-- **Airflow Orchestration:** Airflow comes after dbt and after stage boundaries are cleaner.
+- Demo processing: demo download and parsing remain deferred, though `DemoStageService` preserves the stage boundary.
+- dbt transformation layer: dbt comes after ingestion/state semantics and active stage boundaries are stable.
+- Airflow orchestration: Airflow comes after dbt and clean stage boundaries.
 
----
+## Tech Stack
 
-## **Tech Stack**
+- Python 3.11+
+- SeleniumBase and BeautifulSoup for web scraping
+- PostgreSQL for structured data storage
+- Pandas and NumPy for analytics/data processing
+- FastAPI for API work
 
-- **Python 3.11+**
-- **Seleniumbase & BeautifulSoup** (for web scraping)
-- **PostgreSQL** (for structured data storage)
-- **Pandas & NumPy** (for analytics and data processing)
-- **Web scraping + demo parsing tools**
+## Project Structure
 
----
-
-## **Project Structure**
-
-```
+```text
 CS2-Analytics/
-├── main.py
-├── run_api.py
-├── README.md
-├── pyproject.toml
-├── api/
-|   ├── main.py
-|   ├── routes/
-|   ├── schemas/
-|   └── services/
-├── cs2_analytics/
-|   ├── config/
-|   ├── controllers/
-|   ├── ingestion_state/
-|   ├── models/
-|   ├── parsers/
-|   ├── pipeline/
-|   ├── scrapers/
-|   ├── stage_services/
-|   ├── services/
-|   ├── storage/
-|   └── utils/
-├── logs/
-|   └── app.log
-├── tests/
-|   ├── parsers/
-|   ├── scrapers/
-|   └── storage/
-├── demos/
-├── parsed_data/
-└── frontend/
+|-- main.py
+|-- run_api.py
+|-- README.md
+|-- pyproject.toml
+|-- api/
+|   |-- main.py
+|   |-- routes/
+|   |-- schemas/
+|   `-- services/
+|-- cs2_analytics/
+|   |-- config/
+|   |-- controllers/
+|   |-- ingestion_state/
+|   |-- models/
+|   |-- parsers/
+|   |-- pipeline/
+|   |-- scrapers/
+|   |-- stage_services/
+|   |-- services/
+|   |-- storage/
+|   `-- utils/
+|-- docs/
+|-- logs/
+|-- tests/
+|-- demos/
+|-- parsed_data/
+`-- frontend/
 ```
 
----
+## Installation & Setup
 
-## **Installation & Setup**
-
-### **1. Clone the Repository**
+### 1. Clone the Repository
 
 ```sh
 git clone https://github.com/dardenkyle/CS2-analytics.git
 cd CS2-Analytics
 ```
 
-### **2. Create a Virtual Environment**
+### 2. Create a Virtual Environment
 
 ```sh
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 
-### **3. Install Dependencies**
+### 3. Install Dependencies
 
 ```sh
 pip install -e .
-# Optional (recommended for local development)
 pip install -e ".[dev]"
 ```
 
-### **4. Set Up Database**
+### 4. Set Up Database
 
-Ensure you have **PostgreSQL installed** and update `cs2_analytics/config/config.py` with your database credentials.
-
-```python
-DB_NAME = "cs2_db"
-DB_USER = "your_user"
-DB_PASS = "your_password"
-DB_HOST = "localhost"
-DB_PORT = "5432"
-```
+Ensure PostgreSQL is installed and configure database credentials through your local environment or `cs2_analytics/config/config.py`.
 
 Run:
 
 ```sh
-# Run this once to set up your database schema
 python -m cs2_analytics.storage.initialize_db
 ```
 
-### **5. Run the Scraper**
+### 5. Run the Pipeline
 
 ```sh
 python main.py
 ```
 
-### **6. Run the API**
-
-```sh
-python run_api.py
-```
-
-### **7. Run Tests**
-
-```sh
-pytest -q
-```
-
-Run the map parser hidden-vs-visible regression test directly:
-
-```sh
-pytest tests/parsers/test_map_parser_regression.py -v
-```
-
-Note: Demo processing is still deferred and is intentionally excluded from standard test runs.
-
----
-
-## **Quick Start Workflows**
-
-### **Pipeline Mode (Scrape + Processing)**
-
-```sh
-python main.py
-```
-
-Current focus:
-
-- results discovery
-- match and map processing
-- relational persistence
-- stage-service extraction from active controllers
-
-### **API Mode (FastAPI)**
+### 6. Run the API
 
 ```sh
 python run_api.py
@@ -165,71 +109,63 @@ python run_api.py
 
 Then open: `http://127.0.0.1:8000/docs`
 
----
+### 7. Run Tests
 
-## **Data Insights & Usage (planned)**
+```sh
+python -m pytest
+```
 
-### **Match & Player Stats**
+Note: Demo processing is still deferred and intentionally remains outside the active ingestion pipeline.
 
-- View **per-match player performance**.
-- Compare **teams' win rates on specific maps**.
-- Identify **key players in matchups**.
+## Architecture Notes
 
-### **Demo Analysis**
+Current stage boundaries:
 
-- **Heatmaps** of player movements.
-- **Grenade usage patterns** and efficiency.
-- **Kill zone maps** showing key engagements.
+- Controllers coordinate batches, retry policy, scraper reset/rotation, and summaries.
+- Stage services own per-item fetch, parse, persist, and lifecycle outcome work.
+- Scrapers fetch remote content only.
+- Parsers convert fetched content into structured outputs only.
+- Storage modules centralize relational writes.
+- Ingestion-state tables track lifecycle for discovered matches, maps, and demos.
 
-### **Future Improvements**
+Current active flow:
 
-- AI-based **predictive modeling** for player performance.
-- **Automated video highlight generation** from demos.
-- **Cloud database integration** for long-term data storage.
+```text
+results discovery
+-> match_ingestion_state refresh
+-> MatchController batch
+-> MatchStageService per-item workflow
+-> map/demo ingestion-state refresh
+-> MapController batch
+-> MapStageService per-item workflow
+-> relational storage
+```
 
----
+## Data Insights & Usage (planned)
 
-## **License**
-
-This project is licensed under the **MIT License** – feel free to contribute and modify!
-
----
-
-## **Contributing**
-
-### **Want to help improve this project?**
-
-1. **Fork the repository** on GitHub.
-2. **Create a feature branch** (`git checkout -b new-feature`).
-3. **Commit changes** (`git commit -m "Added new feature"`).
-4. **Push to GitHub** (`git push origin new-feature`).
-5. **Submit a Pull Request** – we review & merge!
-
----
+- View per-match player performance.
+- Compare teams' win rates on specific maps.
+- Identify key players in matchups.
+- Add transformed analytics models through dbt.
+- Expand API read paths over trusted transformed tables.
 
 ## Developer Notes
 
-See `docs/` for:
-
-- architecture overview
-- development roadmap
+See `docs/` for architecture and roadmap details.
 
 Current architecture direction:
 
-- the main cleanup target is `MatchController` and `MapController`, not `main.py`
-- `match_ingestion_state` and `map_ingestion_state` are the active ingestion/discovery lifecycle tables
-- Phase 2 ingestion-state migration is complete; the next refactor introduces thinner controllers plus `MatchStageService` and `MapStageService`
-- demo service-layer work remains lower priority even though `DemoStageService` is expected later
-- dbt comes after ingestion/state semantics are stable
-- Airflow comes after dbt and clean stage boundaries
+- Phase 2 ingestion-state migration is complete.
+- Phase 3 controller thinning is complete.
+- The next major architecture phase is dbt, not more controller refactoring.
+- Demo pipeline implementation remains deferred.
+- Airflow comes after dbt and clean transformation boundaries.
 
-These documents are used to keep development planning and implementation direction aligned.
+## License
 
-## **Contact & Support**
+This project is licensed under the MIT License.
 
-Have questions or want to contribute? Reach out!
+## Contact & Support
 
 - GitHub Issues: [CS2-analytics Issues](https://github.com/dardenkyle/CS2-analytics/issues)
 - Email: [dardenkyle@example.com](mailto:dardenkyle@example.com)
-
-**Happy Analyzing!**

--- a/cs2_analytics/controllers/__init__.py
+++ b/cs2_analytics/controllers/__init__.py
@@ -1,14 +1,9 @@
 """
-The `controllers` package contains orchestration logic that coordinates
-scraping, parsing, and storage for each stage of the CS2 data pipeline.
+Controller orchestration for each stage of the CS2 data pipeline.
 
-Each controller:
-- Pulls ready items from its respective ingestion-state table
-- Uses a scraper to fetch HTML or raw content
-- Uses a parser to extract structured data
-- Stores the results and updates ingestion lifecycle state
-
-Controllers enable modular batch processing for automation or scheduled runs.
+Controllers own batch-level flow, retry policy, scraper reset/rotation, and
+summary logging. Per-item fetch, parse, persist, and lifecycle outcome work
+belongs in stage services.
 """
 
 from .map_controller import MapController

--- a/cs2_analytics/controllers/demo_controller.py
+++ b/cs2_analytics/controllers/demo_controller.py
@@ -12,46 +12,52 @@ class DemoController:
     def __init__(self) -> None:
         self.scraper = DemoScraper()
         self.parser = DemoParser()
-        self.queue = DemoIngestionState()
+        self.state = DemoIngestionState()
         self.stage_service = DemoStageService(
             scraper=self.scraper,
             parser=self.parser,
             store_demo_file=store_demo_file,
-            demo_state=self.queue,
+            demo_state=self.state,
         )
 
     def run(self, batch_size: int = 25) -> None:
-        logger.info("🕹️ Running DemoController with batch size: %d", batch_size)
+        logger.info("Running DemoController with batch size: %d", batch_size)
 
-        queued = self.queue.fetch(batch_size)
-        logger.info("📥 %d demo URLs pulled from queue", len(queued))
+        selected = self.state.fetch(batch_size)
+        logger.info("%d pending demos selected from ingestion state", len(selected))
         succeeded = 0
         failed = 0
+        skipped = 0
 
-        for demo_id, demo_url in queued:
+        for demo_id, demo_url in selected:
             try:
-                self.queue.mark_as_processing(demo_id)
-                stored = self.stage_service.process_item(demo_id, demo_url)
+                self.state.mark_as_processing(demo_id)
+                result = self.stage_service.process_item(demo_id, demo_url)
 
-                if stored:
+                if result.succeeded:
                     succeeded += 1
-                    logger.info("✅ Stored demo: %s", demo_id)
+                    logger.info("Stored demo: %s", demo_id)
+                elif result.status == "skipped":
+                    skipped += 1
+                    logger.info("Demo %s skipped: %s", demo_id, result.message)
                 else:
                     failed += 1
                     logger.info(
-                        "Demo %s was not stored by the demo stage service",
+                        "Demo %s was not processed: %s",
                         demo_id,
+                        result.message,
                     )
 
             except Exception as e:
                 failed += 1
-                self.queue.mark_as_failed(demo_id, str(e))
-                logger.exception("❌ Error processing demo %s: %s", demo_id, e)
+                self.state.mark_as_failed(demo_id, str(e))
+                logger.exception("Error processing demo %s: %s", demo_id, e)
 
         logger.info(
-            "DemoController summary: queued=%d succeeded=%d failed=%d",
-            len(queued),
+            "DemoController summary: selected=%d succeeded=%d failed=%d skipped=%d",
+            len(selected),
             succeeded,
             failed,
+            skipped,
         )
-        logger.info("🏁 DemoController complete.")
+        logger.info("DemoController complete.")

--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -19,23 +19,23 @@ logger = get_logger("map_controller")
 
 
 class MapController:
-    """Orchestrates map scraping, parsing, and player storage."""
+    """Coordinates map batches, retry policy, and scraper lifecycle."""
 
     def __init__(self) -> None:
         self.scraper = MapScraper()
         self.parser = MapParser()
-        self.queue = MapIngestionState()
+        self.state = MapIngestionState()
         self.stage_service = MapStageService(
             parser=self.parser,
             store_players=store_players,
-            map_state=self.queue,
+            map_state=self.state,
         )
 
     def run(self, batch_size: int = 25) -> None:
         logger.info("Running MapController with batch size: %d", batch_size)
 
-        queued = self.queue.fetch(batch_size)
-        logger.info("%d map URLs pulled from queue", len(queued))
+        selected = self.state.fetch(batch_size)
+        logger.info("%d pending maps selected from ingestion state", len(selected))
 
         rotate_every = 8
         inter_map_delay_seconds = 0.75
@@ -47,7 +47,7 @@ class MapController:
 
         scraper = self.scraper
         try:
-            for map_id, map_url in queued:
+            for map_id, map_url in selected:
                 if processed_since_reset >= rotate_every:
                     logger.info(
                         "Rotating map scraper session after %d processed maps",
@@ -56,18 +56,23 @@ class MapController:
                     scraper = self._reset_scraper(scraper)
                     processed_since_reset = 0
 
-                self.queue.mark_as_processing(map_id)
+                self.state.mark_as_processing(map_id)
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        if self.stage_service.process_item(
+                        result = self.stage_service.process_item(
                             map_id, map_url, scraper=scraper
-                        ):
+                        )
+                        if result.succeeded:
                             succeeded += 1
                             logger.info("Stored map: %s", map_id)
                         else:
                             failed += 1
-                            logger.warning("Map %s returned no parsed data", map_id)
+                            logger.warning(
+                                "Map %s was not processed: %s",
+                                map_id,
+                                result.message,
+                            )
 
                         processed_since_reset += 1
                         time.sleep(inter_map_delay_seconds)
@@ -102,7 +107,7 @@ class MapController:
                                 max_attempts,
                             )
                         mark_item_failed(
-                            self.queue,
+                            self.state,
                             map_id,
                             e,
                             logger=logger,
@@ -117,8 +122,8 @@ class MapController:
                 scraper.close()
 
         logger.info(
-            "MapController summary: queued=%d succeeded=%d failed=%d retries=%d",
-            len(queued),
+            "MapController summary: selected=%d succeeded=%d failed=%d retries=%d",
+            len(selected),
             succeeded,
             failed,
             retries,

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -23,28 +23,28 @@ logger = get_logger("match_controller")
 
 
 class MatchController:
-    """Orchestrates match scraping, parsing, queueing, and storage."""
+    """Coordinates match batches, retry policy, and scraper lifecycle."""
 
     def __init__(self) -> None:
         self.scraper = MatchScraper()
         self.parser = MatchParser()
-        self.match_queue = MatchIngestionState()
-        self.map_queue = MapIngestionState()
-        self.demo_queue = DemoIngestionState()
+        self.match_state = MatchIngestionState()
+        self.map_state = MapIngestionState()
+        self.demo_state = DemoIngestionState()
         self.stage_service = MatchStageService(
             parser=self.parser,
             store_matches=store_matches,
-            match_state=self.match_queue,
-            map_state=self.map_queue,
-            demo_state=self.demo_queue,
+            match_state=self.match_state,
+            map_state=self.map_state,
+            demo_state=self.demo_state,
         )
 
     def run(self, batch_size: int = 25) -> None:
         """Runs the match stage for a batch of pending match URLs."""
         logger.info("Running MatchController with batch size: %d", batch_size)
 
-        queued = self.match_queue.fetch(limit=batch_size)
-        logger.info("%d matches pulled from queue", len(queued))
+        selected = self.match_state.fetch(limit=batch_size)
+        logger.info("%d pending matches selected from ingestion state", len(selected))
 
         rotate_every = 8
         inter_match_delay_seconds = 1.1
@@ -57,7 +57,7 @@ class MatchController:
 
         scraper = self.scraper
         try:
-            for match_id, match_url in queued:
+            for match_id, match_url in selected:
                 if processed_since_reset >= rotate_every:
                     logger.info(
                         "Rotating scraper session after %d processed matches",
@@ -66,18 +66,23 @@ class MatchController:
                     scraper = self._reset_scraper(scraper)
                     processed_since_reset = 0
 
-                self.match_queue.mark_as_processing(match_id)
+                self.match_state.mark_as_processing(match_id)
                 max_attempts = 3
                 for attempt in range(1, max_attempts + 1):
                     try:
-                        if self.stage_service.process_item(
+                        result = self.stage_service.process_item(
                             match_id, match_url, scraper=scraper
-                        ):
+                        )
+                        if result.succeeded:
                             succeeded += 1
                             logger.info("Stored match: %s", match_id)
                         else:
                             failed += 1
-                            logger.warning("Match %s returned no parsed data", match_id)
+                            logger.warning(
+                                "Match %s was not processed: %s",
+                                match_id,
+                                result.message,
+                            )
 
                         consecutive_recoverable_errors = 0
                         processed_since_reset += 1
@@ -122,7 +127,7 @@ class MatchController:
                                 max_attempts,
                             )
                         mark_item_failed(
-                            self.match_queue,
+                            self.match_state,
                             match_id,
                             e,
                             logger=logger,
@@ -140,8 +145,8 @@ class MatchController:
                 scraper.close()
 
         logger.info(
-            "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d",
-            len(queued),
+            "MatchController summary: selected=%d succeeded=%d failed=%d retries=%d",
+            len(selected),
             succeeded,
             failed,
             retries,

--- a/cs2_analytics/stage_services/__init__.py
+++ b/cs2_analytics/stage_services/__init__.py
@@ -3,9 +3,11 @@
 from .demo_stage_service import DemoStageService
 from .map_stage_service import MapStageService
 from .match_stage_service import MatchStageService
+from .stage_result import StageItemResult
 
 __all__ = [
     "DemoStageService",
     "MapStageService",
     "MatchStageService",
+    "StageItemResult",
 ]

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -32,14 +32,13 @@ class DemoStageService:
         self.store_demo_file = store_demo_file
         self.demo_state = demo_state
 
-    def process_item(self, demo_id: str, demo_url: str) -> StageItemResult:
+    def process_item(self, demo_id: str, _demo_url: str) -> StageItemResult:
         """Process one demo ingestion-state row.
 
         Demo ingestion is intentionally deferred. Returning an explicit skipped
         result keeps controller summaries honest without expanding the
         non-operational demo pipeline in this branch.
         """
-        _ = demo_url
         message = "Demo ingestion is deferred until the demo pipeline is operational"
         self.demo_state.mark_as_skipped(
             demo_id,

--- a/cs2_analytics/stage_services/demo_stage_service.py
+++ b/cs2_analytics/stage_services/demo_stage_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from cs2_analytics.stage_services.stage_result import StageItemResult
+
 if TYPE_CHECKING:
     from cs2_analytics.ingestion_state import DemoIngestionState
     from cs2_analytics.parsers.demo_parser import DemoParser
@@ -30,16 +32,17 @@ class DemoStageService:
         self.store_demo_file = store_demo_file
         self.demo_state = demo_state
 
-    def process_item(self, demo_id: str, demo_url: str) -> bool:
+    def process_item(self, demo_id: str, demo_url: str) -> StageItemResult:
         """Process one demo ingestion-state row.
 
-        Demo ingestion is intentionally deferred. Returning False lets the
-        controller preserve the same per-item service boundary as match/map
-        without expanding the non-operational demo pipeline in this branch.
+        Demo ingestion is intentionally deferred. Returning an explicit skipped
+        result keeps controller summaries honest without expanding the
+        non-operational demo pipeline in this branch.
         """
         _ = demo_url
+        message = "Demo ingestion is deferred until the demo pipeline is operational"
         self.demo_state.mark_as_skipped(
             demo_id,
-            "Demo ingestion is deferred until the demo pipeline is operational",
+            message,
         )
-        return False
+        return StageItemResult.skipped(message)

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from cs2_analytics.stage_services.stage_result import StageItemResult
+
 if TYPE_CHECKING:
     from cs2_analytics.ingestion_state import MapIngestionState
     from cs2_analytics.models.player import Player
@@ -25,19 +27,22 @@ class MapStageService:
         self.store_players = store_players
         self.map_state = map_state
 
-    def process_item(self, map_id: str, map_url: str, *, scraper: MapScraper) -> bool:
+    def process_item(
+        self, map_id: str, map_url: str, *, scraper: MapScraper
+    ) -> StageItemResult:
         """Process one map ingestion-state row.
 
-        Returns True when player stats were stored successfully and False when
-        parsing returned no player records.
+        Returns the explicit per-item outcome after the service updates
+        ingestion state.
         """
         soup = scraper.fetch_soup(map_url)
         players = self.parser.parse_map(soup, map_url, map_id)
 
         if not players:
-            self.map_state.mark_as_failed(map_id, "Parsing returned no player records")
-            return False
+            message = "Parsing returned no player records"
+            self.map_state.mark_as_failed(map_id, message)
+            return StageItemResult.failed(message)
 
         self.store_players(players)
         self.map_state.mark_as_processed(map_id)
-        return True
+        return StageItemResult.processed()

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from cs2_analytics.stage_services.stage_result import StageItemResult
+
 if TYPE_CHECKING:
     from cs2_analytics.ingestion_state import (
         DemoIngestionState,
@@ -35,23 +37,24 @@ class MatchStageService:
 
     def process_item(
         self, match_id: str, match_url: str, *, scraper: MatchScraper
-    ) -> bool:
+    ) -> StageItemResult:
         """Process one match ingestion-state row.
 
-        Returns True when the match was stored successfully and False when
-        parsing returned no match object.
+        Returns the explicit per-item outcome after the service updates
+        ingestion state.
         """
         soup = scraper.fetch_soup(match_url)
         match, map_links, demo_links = self.parser.parse_match(soup, match_url)
 
         if not match:
-            self.match_state.mark_as_failed(match_id, "Parsing returned None")
-            return False
+            message = "Parsing returned None"
+            self.match_state.mark_as_failed(match_id, message)
+            return StageItemResult.failed(message)
 
         self.store_matches([match])
         self._queue_followups(map_links, demo_links)
         self.match_state.mark_as_processed(match_id)
-        return True
+        return StageItemResult.processed()
 
     def _queue_followups(
         self,

--- a/cs2_analytics/stage_services/stage_result.py
+++ b/cs2_analytics/stage_services/stage_result.py
@@ -1,0 +1,32 @@
+"""Shared result contract for per-item stage services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+StageItemStatus = Literal["processed", "failed", "skipped"]
+
+
+@dataclass(frozen=True)
+class StageItemResult:
+    """Outcome returned by a per-item stage workflow."""
+
+    status: StageItemStatus
+    message: str | None = None
+
+    @classmethod
+    def processed(cls, message: str | None = None) -> StageItemResult:
+        return cls(status="processed", message=message)
+
+    @classmethod
+    def failed(cls, message: str | None = None) -> StageItemResult:
+        return cls(status="failed", message=message)
+
+    @classmethod
+    def skipped(cls, message: str | None = None) -> StageItemResult:
+        return cls(status="skipped", message=message)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status == "processed"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-This project is moving from an older queue-oriented scraping design toward a cleaner ingestion-state-driven architecture.
+This project has moved from an older queue-oriented scraping design toward a cleaner ingestion-state-driven architecture.
 
-The schema now uses PostgreSQL ingestion-state tables directly, while the active controllers still own more per-item workflow than the desired design. This document describes the current direction and the next cleanup target.
+The schema uses PostgreSQL ingestion-state tables directly, and the active match, map, and demo stages now separate batch orchestration from per-item workflow through stage services.
 
 ## Current Architectural Focus
 
-- `main.py` and the top-level pipeline are not the main architectural problem
-- the main cleanup target is `MatchController` and `MapController`
-- the priority is to clarify ingestion/discovery state semantics before adding dbt or Airflow
-- demo processing remains deferred until the match/map stages have cleaner boundaries
+- `main.py` and the top-level pipeline remain intentionally thin
+- `MatchController`, `MapController`, and `DemoController` own batch-level concerns
+- stage services own per-item fetch, parse, persist, and lifecycle outcome work
+- demo processing remains deferred even though it now has a placeholder stage service boundary
+- dbt and Airflow remain later phases
 
 ## Current Flow
 
@@ -51,7 +52,7 @@ Primary responsibility:
 Current implementation note:
 
 - `ResultsScraper` currently performs discovery-time lifecycle-row refreshes in `match_ingestion_state`
-- dedicated stage services are still the next refactor, but rediscovery refreshes already happen in the current implementation
+- rediscovery refreshes already happen in the current implementation
 
 This stage should not parse match detail pages or write match records directly.
 
@@ -60,20 +61,20 @@ This stage should not parse match detail pages or write match records directly.
 Primary responsibility:
 
 - select match lifecycle rows that are ready for processing
-- fetch match detail pages
-- parse match metadata and follow-up links
-- persist match records and discovered downstream references
-- update match lifecycle state and create or refresh map/demo follow-up state
+- delegate one-match workflow to `MatchStageService`
+- apply retry, reset, rotation, and summary policy at the batch level
+
+`MatchStageService` owns match detail fetch, parsing, match persistence, follow-up map/demo discovery refreshes, and normal lifecycle outcomes.
 
 ### Map Stage
 
 Primary responsibility:
 
 - select map lifecycle rows that are ready for processing
-- fetch map pages
-- parse map-level player statistics
-- persist parsed outputs through centralized storage modules
-- update map lifecycle state
+- delegate one-map workflow to `MapStageService`
+- apply retry, reset, rotation, and summary policy at the batch level
+
+`MapStageService` owns map fetch, parsing, player persistence, and normal lifecycle outcomes.
 
 This is still the last active stage in the current hardened pipeline.
 
@@ -97,19 +98,17 @@ Controllers should mainly handle:
 - run-level summary logging
 - stage-level failure policy
 
-Controllers should not remain the long-term home for per-item fetch -> parse -> persist -> state-transition logic.
+Controllers should not own per-item fetch -> parse -> persist -> state-transition logic.
 
 ### Stage Services
 
-The next refactor should introduce `MatchStageService` and `MapStageService`.
+Stage services own per-item stage workflow, including:
 
-Those services should own per-item stage workflow, including:
-
-- reading one lifecycle row
 - calling the scraper
 - calling the parser
 - calling storage/persistence modules
-- applying lifecycle updates for success, retryable failure, or terminal failure
+- applying normal lifecycle updates for processed, failed, or skipped outcomes
+- returning `StageItemResult` to controllers for summary counting
 
 ### Scrapers
 
@@ -151,7 +150,7 @@ Demo support exists in the codebase, but end-to-end demo processing is not part 
 Current reality:
 
 - demo URLs are discovered during match processing
-- demo-specific scraper, parser, storage, and queue components exist
+- demo-specific scraper, parser, storage, ingestion-state, and stage-service components exist
 - the production path still stops after the map stage
 
 Demo work stays separate because it introduces different operational concerns:
@@ -161,17 +160,15 @@ Demo work stays separate because it introduces different operational concerns:
 - event-level extraction with a larger output surface
 - cleanup requirements for local demo artifacts
 
-The demo stage should stay deferred until:
+The demo processing implementation should stay deferred until:
 
 - match/map lifecycle semantics are stable
-- controller responsibilities are reduced
-- stage services exist for active stages
 - downstream storage and transformation needs are clearer
 
 ## Recommended Implementation Sequence
 
-1. Keep the current `*_ingestion_state` tables stable while stage responsibilities move into services.
-2. Refactor `MatchController` and `MapController` by introducing `MatchStageService` and `MapStageService`.
+1. Keep the current `*_ingestion_state` tables stable.
+2. Keep controller/stage-service responsibilities clean as ingestion evolves.
 3. Implement dbt models after active stage boundaries are stable.
 4. Implement Airflow after dbt exists and the stage boundaries are clean.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -73,15 +73,19 @@ Complete. The active schema, controllers, and tests now use `*_ingestion_state` 
 Goal:
 Thin the active controllers by separating batch concerns from per-item stage workflow.
 
+Status:
+Complete. Match, map, and demo controllers now delegate per-item workflow to stage services and consume an explicit per-item result contract for controller summaries.
+
 ### Planned work
 
-- [ ] Introduce `MatchStageService`
-- [ ] Introduce `MapStageService`
-- [ ] Introduce `DemoStageService` (even though demo service layer development is paused)
-- [ ] Move per-item fetch -> parse -> persist -> state-transition logic into stage services
-- [ ] Keep controller ownership of batch coordination, retry policy, scraper reset/rotation, and summary logging
-- [ ] Keep scrapers fetch-only, parsers parse-only, and persistence centralized
-- [ ] Add or update tests around per-item stage outcomes and controller summaries
+- [x] Introduce `MatchStageService`
+- [x] Introduce `MapStageService`
+- [x] Introduce `DemoStageService` (even though demo service layer development is paused)
+- [x] Move per-item fetch -> parse -> persist -> state-transition logic into stage services
+- [x] Keep controller ownership of batch coordination, retry policy, scraper reset/rotation, and summary logging
+- [x] Keep scrapers fetch-only, parsers parse-only, and persistence centralized
+- [x] Add or update tests around per-item stage outcomes and controller summaries
+- [x] Normalize stage service outcomes with an explicit result contract
 
 ### Suggested branch sequence
 
@@ -89,25 +93,25 @@ Keep each branch small enough to review independently, and keep the active
 pipeline runnable after every merge. Phase 3 should avoid schema changes unless
 a later branch proves they are necessary.
 
-1. `phase3-stage-service-shells`
+1. [x] `phase3-stage-service-shells`
    Add `cs2_analytics/stage_services/`, lightweight service classes, package
    exports, and import-level tests. Do not change controller behavior yet.
 
-2. `phase3-match-stage-service`
+2. [x] `phase3-match-stage-service`
    Move one-match fetch -> parse -> persist -> follow-up state refresh ->
    lifecycle update behavior into `MatchStageService`. Keep `MatchController`
    responsible for batch fetching, retry policy, scraper reset/rotation, and
    summary logging.
 
-3. `phase3-map-stage-service`
+3. [x] `phase3-map-stage-service`
    Move one-map fetch -> parse -> persist -> lifecycle update behavior into
    `MapStageService`. Preserve existing controller retry and summary behavior.
 
-4. `phase3-demo-stage-placeholder`
+4. [x] `phase3-demo-stage-placeholder`
    Add a minimal `DemoStageService` that reflects current demo behavior without
    expanding the deferred demo pipeline scope.
 
-5. `phase3-controller-thinning-cleanup`
+5. [x] `phase3-controller-thinning-cleanup`
    Remove controller helper code made obsolete by the services, normalize any
    service result contracts, and update docs to reflect the completed Phase 3
    boundary.
@@ -116,10 +120,10 @@ a later branch proves they are necessary.
 
 Before merging each Phase 3 branch:
 
-- [ ] Run `python -m pytest` from the venv
-- [ ] Smoke test `python main.py` when the local scraper/database environment is available
-- [ ] Confirm controllers still own batch concerns and services own only per-item workflow
-- [ ] Confirm no dbt, Airflow, or schema work slipped into the branch
+- [x] Run `python -m pytest` from the venv
+- [x] Smoke test `python main.py` when the local scraper/database environment is available
+- [x] Confirm controllers still own batch concerns and services own only per-item workflow
+- [x] Confirm no dbt, Airflow, or schema work slipped into the branch
 
 ---
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -25,13 +25,15 @@ Current implementation note:
 
 - Own per-item stage workflow
 - Call scrapers, parsers, and storage modules in order
-- Apply lifecycle updates for success, retryable failure, and terminal failure
+- Apply normal lifecycle updates for processed, failed, and skipped outcomes
+- Return `StageItemResult` so controllers can count outcomes explicitly
 - Keep stage-specific processing rules out of controllers
 
-Planned near-term services:
+Implemented services:
 
 - `MatchStageService`
 - `MapStageService`
+- `DemoStageService`
 
 ## Controllers
 
@@ -40,6 +42,8 @@ Planned near-term services:
 - Own scraper reset and rotation behavior
 - Own run-level summaries and terminal logging
 - Avoid owning detailed per-item fetch -> parse -> persist workflow
+- Mark items as `processing` at the attempt boundary
+- Mark terminal exception failures when retry policy is exhausted
 
 ## Pipelines
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -2,18 +2,21 @@
 
 This document describes the planned dbt model structure for the CS2 Analytics project.
 
-dbt is a later-phase transformation layer. It should be introduced only after match/map ingestion semantics are stable and the active stage boundaries are clearer.
+dbt is a later-phase transformation layer. It should be introduced only after match/map ingestion semantics are stable and the active stage boundaries are clear.
 
 At this stage, dbt is planned work, not an active part of the ingestion pipeline.
 
 Note:
 Planned raw snapshot tables (for example `raw_matches` and `raw_maps`) are expected to be introduced around dbt rollout time, not before.
 
-Near-term dependency order:
+Completed prerequisite order:
 
 1. review lifecycle semantics for the current match/map discovery tables
 2. update the current state tables and their audit fields
 3. thin `MatchController` and `MapController` by introducing stage services
+
+Next dependency:
+
 4. add dbt after the ingestion contract is stable
 
 ---
@@ -61,7 +64,7 @@ dbt is not responsible for:
 
 Those concerns belong elsewhere in the system.
 
-dbt should consume stable ingestion outputs, not compensate for unclear controller or lifecycle semantics.
+dbt should consume stable ingestion outputs, not compensate for ingestion-state or lifecycle problems.
 
 ---
 
@@ -699,14 +702,12 @@ dbt should be introduced only after lifecycle semantics and active-stage respons
 
 Recommended rollout order:
 
-1. complete lifecycle/state-table review and updates
-2. introduce `MatchStageService` and `MapStageService`
-3. add dbt project scaffolding
-4. create staging models for matches, maps, and players
-5. add basic tests
-6. create intermediate reusable joins
-7. create fact and dimension marts
-8. update API/data consumers to use trusted marts where appropriate
+1. add dbt project scaffolding
+2. create staging models for matches, maps, and players
+3. add basic tests
+4. create intermediate reusable joins
+5. create fact and dimension marts
+6. update API/data consumers to use trusted marts where appropriate
 
 ---
 

--- a/docs/ingestion_lifecycle.md
+++ b/docs/ingestion_lifecycle.md
@@ -111,12 +111,14 @@ row changes.
 - `last_updated_at`
   Most recent meaningful update to the ingestion state row.
 
-## Implemented Phase 2 Behavior
+## Implemented Behavior
 
 - the schema now creates only `match_ingestion_state`, `map_ingestion_state`,
   and `demo_ingestion_state`
 - Python managers live under `cs2_analytics/ingestion_state/`.
-- controllers mark rows as `processing`, `processed`, `failed`, or `skipped`
-  using the shared lifecycle helpers
+- controllers mark rows as `processing` when a batch attempt begins
+- stage services mark normal per-item outcomes as `processed`, `failed`, or
+  `skipped` using the shared lifecycle helpers
+- controllers mark terminal exception failures when retry policy is exhausted
 - rediscovery refreshes `last_seen_at`, keeps source IDs as primary keys, and
   preserves `first_seen_at`

--- a/tests/controllers/test_demo_controller.py
+++ b/tests/controllers/test_demo_controller.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cs2_analytics.controllers import demo_controller as demo_module
+from cs2_analytics.stage_services import StageItemResult
 
 
 class _FakeDemoQueue:
@@ -38,11 +39,11 @@ class _TrackingStageService:
     def __init__(self, *_args, **_kwargs) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    def process_item(self, demo_id: str, demo_url: str) -> bool:
+    def process_item(self, demo_id: str, demo_url: str) -> StageItemResult:
         self.calls.append((demo_id, demo_url))
         if demo_id == "demo-1":
             raise RuntimeError("demo parse exploded")
-        return True
+        return StageItemResult.processed()
 
 
 def test_demo_controller_delegates_per_item_work_and_continues(
@@ -73,12 +74,13 @@ def test_demo_controller_delegates_per_item_work_and_continues(
         ("demo-1", "https://www.hltv.org/download/demo/1"),
         ("demo-2", "https://www.hltv.org/download/demo/2"),
     ]
-    assert controller.queue.processing == ["demo-1", "demo-2"]
-    assert controller.queue.failed == [("demo-1", "demo parse exploded")]
-    assert controller.queue.processed == []
+    assert controller.state.processing == ["demo-1", "demo-2"]
+    assert controller.state.failed == [("demo-1", "demo parse exploded")]
+    assert controller.state.processed == []
     assert len(exception_calls) == 1
     assert any(
-        call_args[0] == "DemoController summary: queued=%d succeeded=%d failed=%d"
-        and call_args[1:] == (2, 1, 1)
+        call_args[0]
+        == "DemoController summary: selected=%d succeeded=%d failed=%d skipped=%d"
+        and call_args[1:] == (2, 1, 1, 0)
         for call_args, _ in info_calls
     )

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -2,6 +2,7 @@ import pytest
 
 from cs2_analytics.controllers import map_controller as map_module
 from cs2_analytics.exceptions import MapParseError, SessionScrapeError
+from cs2_analytics.stage_services import StageItemResult
 
 
 class _FakeMapQueue:
@@ -10,7 +11,7 @@ class _FakeMapQueue:
         self.processed: list[str] = []
         self.processing: list[str] = []
 
-    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+    def fetch(self, _limit: int = 25) -> list[tuple[str, str]]:
         return [
             ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test"),
             ("map-2", "https://www.hltv.org/stats/matches/mapstatsid/2/test"),
@@ -27,7 +28,7 @@ class _FakeMapQueue:
 
 
 class _SuccessfulScraper:
-    def fetch_soup(self, url: str) -> object:
+    def fetch_soup(self, _url: str) -> object:
         return object()
 
     def close(self) -> None:
@@ -54,18 +55,22 @@ class _TrackingStageService:
     def __init__(self) -> None:
         self.scrapers: list[object] = []
 
-    def process_item(self, map_id: str, map_url: str, *, scraper: object) -> bool:
+    def process_item(
+        self, _map_id: str, map_url: str, *, scraper: object
+    ) -> StageItemResult:
         self.scrapers.append(scraper)
         if len(self.scrapers) == 1:
             raise SessionScrapeError(f"Failed to fetch map stats page: {map_url}")
-        return True
+        return StageItemResult.processed()
 
 
 class _FailOnceThenSucceedParser:
     def __init__(self) -> None:
         self.calls = 0
 
-    def parse_map(self, soup: object, map_url: str, map_id: str) -> list[object]:
+    def parse_map(
+        self, _soup: object, _map_url: str, _map_id: str
+    ) -> list[object]:
         self.calls += 1
         if self.calls == 1:
             raise MapParseError("No player kills logged.")
@@ -73,7 +78,9 @@ class _FailOnceThenSucceedParser:
 
 
 class _SuccessfulParser:
-    def parse_map(self, soup: object, map_url: str, map_id: str) -> list[object]:
+    def parse_map(
+        self, _soup: object, _map_url: str, _map_id: str
+    ) -> list[object]:
         return [object()]
 
 
@@ -88,7 +95,7 @@ def _build_map_controller(
     monkeypatch.setattr(
         map_module,
         "store_players",
-        lambda players: None,
+        lambda _players: None,
     )
     monkeypatch.setattr(map_module.time, "sleep", lambda *_args, **_kwargs: None)
     return map_module.MapController()
@@ -117,13 +124,13 @@ def test_map_controller_continues_after_item_failure(
     controller = map_module.MapController()
     controller.run(batch_size=2)
 
-    assert controller.queue.failed == [("map-1", "No player kills logged.")]
-    assert controller.queue.processed == ["map-2"]
-    assert controller.queue.processing == ["map-1", "map-2"]
+    assert controller.state.failed == [("map-1", "No player kills logged.")]
+    assert controller.state.processed == ["map-2"]
+    assert controller.state.processing == ["map-1", "map-2"]
     assert len(stored_players) == 1
     assert any(
         call_args[0]
-        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MapController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (2, 1, 1, 0)
         for call_args, _ in info_calls
     )
@@ -156,22 +163,22 @@ def test_map_controller_retries_retryable_error_before_succeeding(
         lambda scraper: reset_calls.append(scraper) or scraper,
     )
     monkeypatch.setattr(
-        controller.queue,
+        controller.state,
         "fetch",
-        lambda limit=25: [
+        lambda _limit=25: [
             ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
         ],
     )
 
     controller.run(batch_size=1)
 
-    assert controller.queue.failed == []
-    assert controller.queue.processed == ["map-1"]
+    assert controller.state.failed == []
+    assert controller.state.processed == ["map-1"]
     assert len(stored_players) == 1
     assert len(reset_calls) == 1
     assert any(
         call_args[0]
-        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MapController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (1, 1, 0, 1)
         for call_args, _ in info_calls
     )
@@ -192,12 +199,12 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
     monkeypatch.setattr(
         controller,
         "_reset_scraper",
-        lambda scraper: reset_scraper,
+        lambda _scraper: reset_scraper,
     )
     monkeypatch.setattr(
-        controller.queue,
+        controller.state,
         "fetch",
-        lambda limit=25: [
+        lambda _limit=25: [
             ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
         ],
     )
@@ -205,8 +212,8 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
     controller.run(batch_size=1)
 
     assert stage_service.scrapers == [first_scraper, reset_scraper]
-    assert controller.queue.failed == []
-    assert controller.queue.processed == []
+    assert controller.state.failed == []
+    assert controller.state.processed == []
 
 
 def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
@@ -242,22 +249,22 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
         lambda scraper: reset_calls.append(scraper) or scraper,
     )
     monkeypatch.setattr(
-        controller.queue,
+        controller.state,
         "fetch",
-        lambda limit=25: [
+        lambda _limit=25: [
             ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
         ],
     )
 
     controller.run(batch_size=1)
 
-    assert controller.queue.failed == [
+    assert controller.state.failed == [
         (
             "map-1",
             "Failed to fetch map stats page: https://www.hltv.org/stats/matches/mapstatsid/1/test",
         )
     ]
-    assert controller.queue.processed == []
+    assert controller.state.processed == []
     assert len(reset_calls) == 2
     assert error_calls == [
         (
@@ -272,7 +279,7 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
     assert len(exception_calls) == 1
     assert any(
         call_args[0]
-        == "MapController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MapController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (1, 0, 1, 2)
         for call_args, _ in info_calls
     )

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -11,6 +11,7 @@ class _FakeMatchQueue:
         self.processing: list[str] = []
 
     def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+        assert limit > 0
         return [("match-1", "https://www.hltv.org/matches/1/test")]
 
     def mark_as_failed(self, item_id: str, reason: str) -> None:
@@ -54,16 +55,21 @@ class _RetryTwiceThenSucceedScraper(_PassiveScraper):
 
 class _SuccessfulScraper(_PassiveScraper):
     def fetch_soup(self, url: str) -> object:
+        assert url
         return object()
 
 
 class _ParseFailureParser:
-    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+    def parse_match(
+        self, _soup: object, _match_url: str
+    ) -> tuple[object, list, list]:
         raise MatchParseError("Missing team names on match page.")
 
 
 class _SuccessfulParser:
-    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+    def parse_match(
+        self, _soup: object, _match_url: str
+    ) -> tuple[object, list, list]:
         return object(), [], []
 
 
@@ -71,7 +77,9 @@ class _FailOnceThenSucceedParser:
     def __init__(self) -> None:
         self.calls = 0
 
-    def parse_match(self, soup: object, match_url: str) -> tuple[object, list, list]:
+    def parse_match(
+        self, _soup: object, _match_url: str
+    ) -> tuple[object, list, list]:
         self.calls += 1
         if self.calls == 1:
             raise MatchParseError("Missing team names on match page.")
@@ -88,7 +96,7 @@ def _build_match_controller(
     monkeypatch.setattr(match_module, "MatchIngestionState", _FakeMatchQueue)
     monkeypatch.setattr(match_module, "MapIngestionState", _FakeFollowupQueue)
     monkeypatch.setattr(match_module, "DemoIngestionState", _FakeFollowupQueue)
-    monkeypatch.setattr(match_module, "store_matches", lambda matches: None)
+    monkeypatch.setattr(match_module, "store_matches", lambda _matches: None)
     monkeypatch.setattr(match_module.time, "sleep", lambda *_args, **_kwargs: None)
     return match_module.MatchController()
 
@@ -116,11 +124,11 @@ def test_match_controller_marks_non_retryable_parse_error_failed_immediately(
 
     controller.run(batch_size=1)
 
-    assert controller.match_queue.failed == [
+    assert controller.match_state.failed == [
         ("match-1", "Missing team names on match page.")
     ]
-    assert controller.match_queue.processed == []
-    assert controller.match_queue.processing == ["match-1"]
+    assert controller.match_state.processed == []
+    assert controller.match_state.processing == ["match-1"]
     assert len(exception_calls) == 1
     assert reset_calls == []
 
@@ -160,8 +168,8 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
 
     controller.run(batch_size=1)
 
-    assert len(controller.match_queue.failed) == 1
-    failed_id, reason = controller.match_queue.failed[0]
+    assert len(controller.match_state.failed) == 1
+    failed_id, reason = controller.match_state.failed[0]
     assert failed_id == "match-1"
     assert "Failed to fetch match page" in reason
     assert len(exception_calls) == 1
@@ -178,7 +186,7 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
     ]
     assert any(
         call_args[0]
-        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MatchController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (1, 0, 1, 2)
         for call_args, _ in info_calls
     )
@@ -199,13 +207,18 @@ def test_match_controller_continues_after_item_failure(
         "info",
         lambda *args, **kwargs: info_calls.append((args, kwargs)),
     )
-    monkeypatch.setattr(
-        controller.match_queue,
-        "fetch",
-        lambda limit=25: [
+
+    def _fetch_two_matches(limit: int = 25) -> list[tuple[str, str]]:
+        assert limit == 2
+        return [
             ("match-1", "https://www.hltv.org/matches/1/test"),
             ("match-2", "https://www.hltv.org/matches/2/test"),
-        ],
+        ]
+
+    monkeypatch.setattr(
+        controller.match_state,
+        "fetch",
+        _fetch_two_matches,
     )
     monkeypatch.setattr(
         controller.stage_service,
@@ -215,15 +228,15 @@ def test_match_controller_continues_after_item_failure(
 
     controller.run(batch_size=2)
 
-    assert controller.match_queue.failed == [
+    assert controller.match_state.failed == [
         ("match-1", "Missing team names on match page.")
     ]
-    assert controller.match_queue.processed == ["match-2"]
-    assert controller.match_queue.processing == ["match-1", "match-2"]
+    assert controller.match_state.processed == ["match-2"]
+    assert controller.match_state.processing == ["match-1", "match-2"]
     assert len(stored_matches) == 1
     assert any(
         call_args[0]
-        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MatchController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (2, 1, 1, 0)
         for call_args, _ in info_calls
     )
@@ -264,8 +277,8 @@ def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
 
     controller.run(batch_size=1)
 
-    assert controller.match_queue.failed == []
-    assert controller.match_queue.processed == ["match-1"]
+    assert controller.match_state.failed == []
+    assert controller.match_state.processed == ["match-1"]
     assert len(stored_matches) == 1
     assert len(reset_calls) == 2
     assert 8.0 in sleep_calls
@@ -276,7 +289,7 @@ def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
     )
     assert any(
         call_args[0]
-        == "MatchController summary: queued=%d succeeded=%d failed=%d retries=%d"
+        == "MatchController summary: selected=%d succeeded=%d failed=%d retries=%d"
         and call_args[1:] == (1, 1, 0, 2)
         for call_args, _ in info_calls
     )

--- a/tests/stage_services/test_demo_stage_service.py
+++ b/tests/stage_services/test_demo_stage_service.py
@@ -26,9 +26,11 @@ def test_demo_stage_service_marks_demo_ingestion_deferred() -> None:
         demo_state=demo_state,
     )
 
-    processed = service.process_item("demo-1", "https://www.hltv.org/download/demo/1")
+    result = service.process_item("demo-1", "https://www.hltv.org/download/demo/1")
 
-    assert processed is False
+    assert result.succeeded is False
+    assert result.status == "skipped"
+    assert result.message == "Demo ingestion is deferred until the demo pipeline is operational"
     assert demo_state.processed == []
     assert demo_state.failed == []
     assert demo_state.skipped == [

--- a/tests/stage_services/test_map_stage_service.py
+++ b/tests/stage_services/test_map_stage_service.py
@@ -47,13 +47,14 @@ def test_map_stage_service_processes_success() -> None:
         map_state=map_state,
     )
 
-    processed = service.process_item(
+    result = service.process_item(
         "map-1",
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
     )
 
-    assert processed is True
+    assert result.succeeded is True
+    assert result.status == "processed"
     assert parser.calls == [
         ("https://www.hltv.org/stats/matches/mapstatsid/1/test", "map-1")
     ]
@@ -72,13 +73,15 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
         map_state=map_state,
     )
 
-    processed = service.process_item(
+    result = service.process_item(
         "map-1",
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
     )
 
-    assert processed is False
+    assert result.succeeded is False
+    assert result.status == "failed"
+    assert result.message == "Parsing returned no player records"
     assert map_state.processing == []
     assert map_state.processed == []
     assert map_state.failed == [("map-1", "Parsing returned no player records")]

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -71,11 +71,12 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
         demo_state=demo_state,
     )
 
-    processed = service.process_item(
+    result = service.process_item(
         "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
     )
 
-    assert processed is True
+    assert result.succeeded is True
+    assert result.status == "processed"
     assert match_state.processing == []
     assert match_state.processed == ["match-1"]
     assert match_state.failed == []
@@ -103,11 +104,13 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
         demo_state=_FakeFollowupState(),
     )
 
-    processed = service.process_item(
+    result = service.process_item(
         "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
     )
 
-    assert processed is False
+    assert result.succeeded is False
+    assert result.status == "failed"
+    assert result.message == "Parsing returned None"
     assert match_state.processing == []
     assert match_state.processed == []
     assert match_state.failed == [("match-1", "Parsing returned None")]

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -3,6 +3,7 @@ from cs2_analytics.stage_services import (
     DemoStageService,
     MapStageService,
     MatchStageService,
+    StageItemResult,
 )
 from cs2_analytics.stage_services.demo_stage_service import (
     DemoStageService as ConcreteDemoStageService,
@@ -12,6 +13,9 @@ from cs2_analytics.stage_services.map_stage_service import (
 )
 from cs2_analytics.stage_services.match_stage_service import (
     MatchStageService as ConcreteMatchStageService,
+)
+from cs2_analytics.stage_services.stage_result import (
+    StageItemResult as ConcreteStageItemResult,
 )
 
 
@@ -23,11 +27,27 @@ def test_stage_services_package_re_exports_concrete_classes() -> None:
     assert stage_services_package.MatchStageService is ConcreteMatchStageService
     assert stage_services_package.MapStageService is ConcreteMapStageService
     assert stage_services_package.DemoStageService is ConcreteDemoStageService
+    assert stage_services_package.StageItemResult is ConcreteStageItemResult
     assert stage_services_package.__all__ == [
         "DemoStageService",
         "MapStageService",
         "MatchStageService",
+        "StageItemResult",
     ]
+
+
+def test_stage_item_result_exposes_named_outcomes() -> None:
+    processed = StageItemResult.processed()
+    failed = StageItemResult.failed("parser returned nothing")
+    skipped = StageItemResult.skipped("deferred")
+
+    assert processed.status == "processed"
+    assert processed.succeeded is True
+    assert failed.status == "failed"
+    assert failed.message == "parser returned nothing"
+    assert failed.succeeded is False
+    assert skipped.status == "skipped"
+    assert skipped.message == "deferred"
 
 
 def test_match_stage_service_records_constructor_dependencies() -> None:


### PR DESCRIPTION
## Summary
- Added explicit `StageItemResult` outcomes for stage services
- Updated controllers to consume processed/failed/skipped results
- Cleaned controller ingestion-state naming and summary logs
- Updated tests and docs to mark Phase 3 boundaries complete

## Tests
- `python -m pytest` inside the venv