### PR TITLE
Add match context to discovered map ingestion rows

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -34,7 +34,7 @@ class MapController:
     def run(self, batch_size: int = 25) -> None:
         logger.info("Running MapController with batch size: %d", batch_size)
 
-        selected = self.state.fetch(batch_size)
+        selected = self.state.fetch_with_match_context(batch_size)
         logger.info("%d pending maps selected from ingestion state", len(selected))
 
         rotate_every = 8
@@ -47,7 +47,7 @@ class MapController:
 
         scraper = self.scraper
         try:
-            for map_id, map_url in selected:
+            for map_id, map_url, match_id in selected:
                 if processed_since_reset >= rotate_every:
                     logger.info(
                         "Rotating map scraper session after %d processed maps",
@@ -61,7 +61,10 @@ class MapController:
                 for attempt in range(1, max_attempts + 1):
                     try:
                         result = self.stage_service.process_item(
-                            map_id, map_url, scraper=scraper
+                            map_id,
+                            map_url,
+                            scraper=scraper,
+                            match_id=match_id,
                         )
                         if result.succeeded:
                             succeeded += 1

--- a/cs2_analytics/controllers/retry_utils.py
+++ b/cs2_analytics/controllers/retry_utils.py
@@ -70,7 +70,7 @@ def reset_scraper(
 
 def mark_item_failed(
     queue,
-    item_id: str,
+    item_id: int | str,
     error: Exception,
     *,
     logger,

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -29,6 +29,7 @@ class BaseIngestionState:
         self.id_field = id_field
         self.url_field = url_field
         self.error_cls = error_cls
+        self.db = db
 
     def fetch(self, limit: int = 25) -> list[tuple[int | str, str]]:
         """Fetches pending items from the ingestion state table."""
@@ -40,7 +41,7 @@ class BaseIngestionState:
         LIMIT %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (limit,))
                 return cur.fetchall()
         except Exception as e:
@@ -70,7 +71,7 @@ class BaseIngestionState:
             last_updated_at = EXCLUDED.last_updated_at;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (id_value, url, source, priority, now, now, now))
         except Exception as e:
             raise self.error_cls(
@@ -110,7 +111,7 @@ class BaseIngestionState:
         ]
 
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.executemany(query, values)
                 logger.info(
                     "Queued or refreshed %d items in %s", len(items), self.table_name
@@ -129,7 +130,7 @@ class BaseIngestionState:
         WHERE {self.id_field} = %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (now, now, id_value))
         except Exception as e:
             raise self.error_cls(
@@ -149,7 +150,7 @@ class BaseIngestionState:
         WHERE {self.id_field} = %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (now, now, id_value))
         except Exception as e:
             raise self.error_cls(
@@ -169,7 +170,7 @@ class BaseIngestionState:
         WHERE {self.id_field} = %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (now, now, reason, id_value))
         except Exception as e:
             raise self.error_cls(
@@ -187,7 +188,7 @@ class BaseIngestionState:
         WHERE {self.id_field} = %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (now, reason, id_value))
         except Exception as e:
             raise self.error_cls(

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -30,7 +30,7 @@ class BaseIngestionState:
         self.url_field = url_field
         self.error_cls = error_cls
 
-    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+    def fetch(self, limit: int = 25) -> list[tuple[int | str, str]]:
         """Fetches pending items from the ingestion state table."""
         query = f"""
         SELECT {self.id_field}, {self.url_field}
@@ -49,7 +49,7 @@ class BaseIngestionState:
             ) from e
 
     def queue(
-        self, id_value: str, url: str, source: str = "unknown", priority: int = 0
+        self, id_value: int | str, url: str, source: str = "unknown", priority: int = 0
     ) -> None:
         """Adds or refreshes a single ingestion state row."""
         now = dt.datetime.now()
@@ -78,7 +78,10 @@ class BaseIngestionState:
             ) from e
 
     def queue_many(
-        self, items: list[tuple[str, str]], source: str = "unknown", priority: int = 0
+        self,
+        items: list[tuple[int | str, str]],
+        source: str = "unknown",
+        priority: int = 0,
     ) -> None:
         """Adds or refreshes multiple ingestion state rows in batch."""
         if not items:
@@ -117,7 +120,7 @@ class BaseIngestionState:
                 f"Failed to queue ingestion state items in {self.table_name}."
             ) from e
 
-    def mark_as_processing(self, id_value: str) -> None:
+    def mark_as_processing(self, id_value: int | str) -> None:
         """Marks the item as actively being processed."""
         now = dt.datetime.now()
         query = f"""
@@ -133,11 +136,11 @@ class BaseIngestionState:
                 f"Failed to mark item as processing in {self.table_name}."
             ) from e
 
-    def mark_as_parsed(self, id_value: str) -> None:
+    def mark_as_parsed(self, id_value: int | str) -> None:
         """Compatibility method that marks the item as processed."""
         self.mark_as_processed(id_value)
 
-    def mark_as_processed(self, id_value: str) -> None:
+    def mark_as_processed(self, id_value: int | str) -> None:
         """Marks the item as successfully processed."""
         now = dt.datetime.now()
         query = f"""
@@ -153,7 +156,7 @@ class BaseIngestionState:
                 f"Failed to mark item as processed in {self.table_name}."
             ) from e
 
-    def mark_as_failed(self, id_value: str, reason: str = "unknown") -> None:
+    def mark_as_failed(self, id_value: int | str, reason: str = "unknown") -> None:
         """Marks the item as failed and stores the reason."""
         now = dt.datetime.now()
         query = f"""
@@ -173,7 +176,7 @@ class BaseIngestionState:
                 f"Failed to mark item as failed in {self.table_name}."
             ) from e
 
-    def mark_as_skipped(self, id_value: str, reason: str = "unknown") -> None:
+    def mark_as_skipped(self, id_value: int | str, reason: str = "unknown") -> None:
         """Marks the item as intentionally skipped."""
         now = dt.datetime.now()
         query = f"""

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -1,7 +1,10 @@
 """Map ingestion state manager."""
 
+import datetime as dt
+
 from cs2_analytics.exceptions import MapQueueError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
+from cs2_analytics.storage.db_instance import db
 
 
 class MapIngestionState(BaseIngestionState):
@@ -14,3 +17,61 @@ class MapIngestionState(BaseIngestionState):
             url_field="map_url",
             error_cls=MapQueueError,
         )
+
+    def fetch_with_match_context(
+        self, limit: int = 25
+    ) -> list[tuple[str, str, int | None]]:
+        """Fetch pending map rows with parent match context when available."""
+        query = """
+        SELECT map_id, map_url, match_id
+        FROM map_ingestion_state
+        WHERE status = 'pending'
+        ORDER BY priority DESC, first_seen_at ASC
+        LIMIT %s;
+        """
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(query, (limit,))
+                return cur.fetchall()
+        except Exception as e:
+            raise self.error_cls(
+                "Failed to fetch pending map items with match context."
+            ) from e
+
+    def queue(
+        self,
+        id_value: str,
+        url: str,
+        source: str = "unknown",
+        priority: int = 0,
+        match_id: int | str | None = None,
+    ) -> None:
+        """Add or refresh a map ingestion row with parent match context."""
+        now = dt.datetime.now()
+        query = """
+        INSERT INTO map_ingestion_state (
+            map_id, map_url, match_id, status, source, priority,
+            first_seen_at, last_seen_at, last_updated_at
+        )
+        VALUES (%s, %s, %s, 'pending', %s, %s, %s, %s, %s)
+        ON CONFLICT (map_id) DO UPDATE
+        SET map_url = EXCLUDED.map_url,
+            match_id = COALESCE(EXCLUDED.match_id, map_ingestion_state.match_id),
+            source = EXCLUDED.source,
+            priority = GREATEST(
+                COALESCE(map_ingestion_state.priority, 0),
+                EXCLUDED.priority
+            ),
+            last_seen_at = EXCLUDED.last_seen_at,
+            last_updated_at = EXCLUDED.last_updated_at;
+        """
+        try:
+            with db.get_cursor() as cur:
+                cur.execute(
+                    query,
+                    (id_value, url, match_id, source, priority, now, now, now),
+                )
+        except Exception as e:
+            raise self.error_cls(
+                "Failed to queue ingestion state item in map_ingestion_state."
+            ) from e

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -44,7 +44,7 @@ class MapIngestionState(BaseIngestionState):
         url: str,
         source: str = "unknown",
         priority: int = 0,
-        match_id: int | str | None = None,
+        match_id: int | None = None,
     ) -> None:
         """Add or refresh a map ingestion row with parent match context."""
         now = dt.datetime.now()

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -4,7 +4,6 @@ import datetime as dt
 
 from cs2_analytics.exceptions import MapQueueError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
-from cs2_analytics.storage.db_instance import db
 
 
 class MapIngestionState(BaseIngestionState):
@@ -30,7 +29,7 @@ class MapIngestionState(BaseIngestionState):
         LIMIT %s;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(query, (limit,))
                 return cur.fetchall()
         except Exception as e:
@@ -66,7 +65,7 @@ class MapIngestionState(BaseIngestionState):
             last_updated_at = EXCLUDED.last_updated_at;
         """
         try:
-            with db.get_cursor() as cur:
+            with self.db.get_cursor() as cur:
                 cur.execute(
                     query,
                     (id_value, url, match_id, source, priority, now, now, now),

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -19,7 +19,7 @@ class MapIngestionState(BaseIngestionState):
 
     def fetch_with_match_context(
         self, limit: int = 25
-    ) -> list[tuple[str, str, int | None]]:
+    ) -> list[tuple[int, str, int | None]]:
         """Fetch pending map rows with parent match context when available."""
         query = """
         SELECT map_id, map_url, match_id
@@ -39,7 +39,7 @@ class MapIngestionState(BaseIngestionState):
 
     def queue(
         self,
-        id_value: str,
+        id_value: int,
         url: str,
         source: str = "unknown",
         priority: int = 0,

--- a/cs2_analytics/models/match.py
+++ b/cs2_analytics/models/match.py
@@ -3,6 +3,10 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+type MatchDictValue = (
+    int | str | bool | datetime | list[tuple[int, str]] | list[tuple[str, str]]
+)
+
 
 @dataclass
 class Match:
@@ -10,7 +14,7 @@ class Match:
 
     match_id: int
     match_url: str
-    map_links: list[tuple[str, str]]
+    map_links: list[tuple[int, str]]
     demo_links: list[tuple[str, str]]
     team1: str
     team2: str
@@ -26,7 +30,7 @@ class Match:
     last_updated_at: datetime
     data_complete: bool
 
-    def to_dict(self) -> dict[str, int | str | bool | datetime | list[tuple[str, str]]]:
+    def to_dict(self) -> dict[str, MatchDictValue]:
         """Converts match object to a dictionary."""
         return {
             "match_id": self.match_id,

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -13,11 +13,11 @@ logger = get_logger(__name__)
 class MapParser:
     """Extracts player stats from a map stats page."""
 
-    def parse_map(self, soup, map_url: str, map_id: int | str) -> list[Player]:
+    def parse_map(self, soup, map_url: str, map_id: int) -> list[Player]:
         """Extracts player object from a map stats page."""
         logger.info("Parsing %s for player stats", map_url)
         try:
-            map_id_value = self._resolve_map_id(map_id, map_url)
+            map_id_value = self._resolve_map_id(map_id)
             map_name = self._extract_map_name(soup)
             players = self._extract_players_from_tables(
                 soup=soup,
@@ -34,12 +34,9 @@ class MapParser:
         logger.info("Extracted %s player stats from %s", len(players), map_url)
         return players
 
-    def _resolve_map_id(self, map_id: int | str, map_url: str) -> int:
+    def _resolve_map_id(self, map_id: int) -> int:
         """Resolves the numeric map identifier from the explicit id or URL."""
-        try:
-            return int(map_id)
-        except (TypeError, ValueError):
-            return self._extract_numeric_id(map_url)
+        return map_id
 
     def _iter_visible_stat_tables(self, soup):
         """Yields visible player stat tables from the map page."""

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -15,7 +15,7 @@ class MatchParser:
 
     def parse_match(
         self, soup, match_url: str
-    ) -> tuple[Match, list[tuple[str, str]], list[tuple[str, str]]]:
+    ) -> tuple[Match, list[tuple[int, str]], list[tuple[str, str]]]:
         """Parses match metadata and returns match data with extracted follow-up links."""
         try:
             match_id = self._extract_match_id(match_url)
@@ -45,7 +45,7 @@ class MatchParser:
 
     def _extract_follow_up_links(
         self, soup
-    ) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    ) -> tuple[list[tuple[int, str]], list[tuple[str, str]]]:
         """Extracts map and demo follow-up links from the match page."""
         map_links = self._extract_map_stats_links(soup)
         demo_links = self._extract_demo_links(soup)
@@ -85,7 +85,7 @@ class MatchParser:
         *,
         match_id: int,
         match_url: str,
-        map_links: list[tuple[str, str]],
+        map_links: list[tuple[int, str]],
         demo_links: list[tuple[str, str]],
         team1: str,
         team2: str,
@@ -144,7 +144,7 @@ class MatchParser:
             raise MatchParseError("Invalid demo link markup on match page.") from e
         return demo_links
 
-    def _extract_map_stats_links(self, soup) -> list[tuple[str, str]]:
+    def _extract_map_stats_links(self, soup) -> list[tuple[int, str]]:
         """Extracts map stats links from buttons with class='results-stats'."""
         map_links = []
         try:
@@ -152,7 +152,7 @@ class MatchParser:
             for btn in stats_buttons:
                 if btn.has_attr("href"):
                     url = f"https://www.hltv.org{btn['href']}"
-                    map_id = self._extract_id(url)
+                    map_id = self._extract_numeric_id(url)
                     map_links.append((map_id, url))
             logger.info("Found %s map stats links.", len(map_links))
         except (AttributeError, IndexError) as e:
@@ -163,6 +163,13 @@ class MatchParser:
         """Extracts the first numeric ID from a URL."""
         match = re.search(r"(\d+)", url)
         return match.group(1) if match else url
+
+    def _extract_numeric_id(self, url: str) -> int:
+        """Extracts the first numeric ID from a URL."""
+        match = re.search(r"(\d+)", url)
+        if not match:
+            raise MatchParseError("Failed to extract numeric id from URL.")
+        return int(match.group(1))
 
     def _extract_scores(self, soup) -> tuple[int, int]:
         """Extracts both team scores from the match page."""

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -127,7 +127,7 @@ class ResultsScraper:
 
         return matches, stop_scraping
 
-    def _extract_match_id(self, url: str) -> str:
+    def _extract_match_id(self, url: str) -> int | None:
         """
         Extracts numeric match ID from the match URL.
 
@@ -135,10 +135,10 @@ class ResultsScraper:
             url (str): HLTV match URL.
 
         Returns:
-            str: Match ID or "" if not found.
+            Match ID or None if not found.
         """
         match = re.search(r"/matches/(\d+)", url)
-        return match.group(1) if match else ""
+        return int(match.group(1)) if match else None
 
     def close(self) -> None:
         """Closes the SeleniumBase driver."""

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -28,7 +28,12 @@ class MapStageService:
         self.map_state = map_state
 
     def process_item(
-        self, map_id: str, map_url: str, *, scraper: MapScraper
+        self,
+        map_id: str,
+        map_url: str,
+        *,
+        scraper: MapScraper,
+        match_id: int | None = None,
     ) -> StageItemResult:
         """Process one map ingestion-state row.
 

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -29,7 +29,7 @@ class MapStageService:
 
     def process_item(
         self,
-        map_id: str,
+        map_id: int,
         map_url: str,
         *,
         scraper: MapScraper,

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -33,9 +33,11 @@ class MapStageService:
         map_url: str,
         *,
         scraper: MapScraper,
-        match_id: int | None = None,
+        match_id: int | None = None,  # noqa: ARG002
     ) -> StageItemResult:
         """Process one map ingestion-state row.
+
+        The parent match id is carried for Phase 3.5 map persistence.
 
         Returns the explicit per-item outcome after the service updates
         ingestion state.

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -52,17 +52,23 @@ class MatchStageService:
             return StageItemResult.failed(message)
 
         self.store_matches([match])
-        self._queue_followups(map_links, demo_links)
+        self._queue_followups(match_id, map_links, demo_links)
         self.match_state.mark_as_processed(match_id)
         return StageItemResult.processed()
 
     def _queue_followups(
         self,
+        match_id: str,
         map_links: list[tuple[str, str]],
         demo_links: list[tuple[str, str]],
     ) -> None:
         """Queue map and demo links returned by the parser."""
         for map_id, map_url in map_links:
-            self.map_state.queue(map_id, map_url, source="match_parser")
+            self.map_state.queue(
+                map_id,
+                map_url,
+                source="match_parser",
+                match_id=match_id,
+            )
         for demo_id, demo_url in demo_links:
             self.demo_state.queue(demo_id, demo_url, source="match_parser")

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -59,7 +59,7 @@ class MatchStageService:
     def _queue_followups(
         self,
         match_id: int,
-        map_links: list[tuple[str, str]],
+        map_links: list[tuple[int, str]],
         demo_links: list[tuple[str, str]],
     ) -> None:
         """Queue map and demo links returned by the parser."""

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -36,7 +36,7 @@ class MatchStageService:
         self.demo_state = demo_state
 
     def process_item(
-        self, match_id: str, match_url: str, *, scraper: MatchScraper
+        self, match_id: int, match_url: str, *, scraper: MatchScraper
     ) -> StageItemResult:
         """Process one match ingestion-state row.
 
@@ -58,7 +58,7 @@ class MatchStageService:
 
     def _queue_followups(
         self,
-        match_id: str,
+        match_id: int,
         map_links: list[tuple[str, str]],
         demo_links: list[tuple[str, str]],
     ) -> None:

--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -187,7 +187,7 @@ CREATE TABLE match_ingestion_state (
 -- Map Ingestion State Table
 -- Tracks discovery and processing lifecycle for maps.
 CREATE TABLE map_ingestion_state (
-    map_id TEXT PRIMARY KEY,
+    map_id INT PRIMARY KEY,
     map_url TEXT NOT NULL,
     match_id INT REFERENCES matches(match_id) ON DELETE CASCADE,
     status TEXT CHECK (

--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -189,6 +189,7 @@ CREATE TABLE match_ingestion_state (
 CREATE TABLE map_ingestion_state (
     map_id TEXT PRIMARY KEY,
     map_url TEXT NOT NULL,
+    match_id INT REFERENCES matches(match_id) ON DELETE CASCADE,
     status TEXT CHECK (
         status IN ('pending', 'processing', 'processed', 'failed', 'skipped')
     ) NOT NULL DEFAULT 'pending',

--- a/cs2_analytics/utils/queue_helpers.py
+++ b/cs2_analytics/utils/queue_helpers.py
@@ -4,7 +4,7 @@ from more_itertools import chunked
 
 
 def chunk_and_queue(
-    items: list[tuple[str, str]],
+    items: list[tuple[int | str, str]],
     queue_obj,
     chunk_size: int = 1000,
     source: str = "scraper",
@@ -14,7 +14,7 @@ def chunk_and_queue(
     Efficiently insert a large list of items into an ingestion-state table in chunks.
 
     Args:
-        items (List[Tuple[str, str]]): List of (id, url) tuples to insert.
+        items: List of (id, url) tuples to insert.
         queue_obj: Ingestion-state instance with a `queue_many()` method.
         chunk_size (int): Max number of rows per insert batch. Defaults to 1000.
         source (str): Source identifier string for logging/tracking. Defaults to "scraper".

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -145,7 +145,7 @@ remains the active schema source of truth.
 
 ### Planned work
 
-- [ ] Add match context to discovered map rows so each map can be tied back to
+- [x] Add match context to discovered map rows so each map can be tied back to
       its parent match without parsing stringified link fields
 - [ ] Decide whether `map_order`, `map_name`, map scores, and map winner come
       from match pages, map pages, or both
@@ -181,9 +181,14 @@ remains the active schema source of truth.
 Keep each branch focused and reviewable. Phase 3.5 should produce stable
 relational ingestion outputs without starting dbt models yet.
 
-1. [ ] `phase3.5-map-discovery-context`
+1. [x] `phase3.5-map-discovery-context`
    Add parent `match_id` context to discovered map ingestion rows and document
    which map fields are known at match-discovery time.
+
+   Match-discovery now records `match_id`, `map_id`, and `map_url` in
+   `map_ingestion_state`. Richer map identity fields such as `map_order`,
+   `map_name`, map scores, and map winner still need a separate source-of-truth
+   decision before the map stage writes relational `maps` rows.
 
 2. [ ] `phase3.5-map-storage-contract`
    Align the `maps` schema, model, parser output, and `store_maps` behavior so

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -7,25 +7,25 @@ from cs2_analytics.stage_services import StageItemResult
 
 class _FakeMapQueue:
     def __init__(self) -> None:
-        self.failed: list[tuple[str, str]] = []
-        self.processed: list[str] = []
-        self.processing: list[str] = []
+        self.failed: list[tuple[int, str]] = []
+        self.processed: list[int] = []
+        self.processing: list[int] = []
 
     def fetch_with_match_context(
         self, _limit: int = 25
-    ) -> list[tuple[str, str, int | None]]:
+    ) -> list[tuple[int, str, int | None]]:
         return [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101),
-            ("map-2", "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102),
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101),
+            (2, "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102),
         ]
 
-    def mark_as_failed(self, item_id: str, reason: str) -> None:
+    def mark_as_failed(self, item_id: int, reason: str) -> None:
         self.failed.append((item_id, reason))
 
-    def mark_as_processed(self, item_id: str) -> None:
+    def mark_as_processed(self, item_id: int) -> None:
         self.processed.append(item_id)
 
-    def mark_as_processing(self, item_id: str) -> None:
+    def mark_as_processing(self, item_id: int) -> None:
         self.processing.append(item_id)
 
 
@@ -56,15 +56,15 @@ class _RetryThenSucceedScraper(_SuccessfulScraper):
 class _TrackingStageService:
     def __init__(self) -> None:
         self.scrapers: list[object] = []
-        self.match_ids: list[object | None] = []
+        self.match_ids: list[int | None] = []
 
     def process_item(
         self,
-        _map_id: str,
+        _map_id: int,
         map_url: str,
         *,
         scraper: object,
-        match_id: object | None = None,
+        match_id: int | None = None,
     ) -> StageItemResult:
         self.scrapers.append(scraper)
         self.match_ids.append(match_id)
@@ -78,7 +78,7 @@ class _FailOnceThenSucceedParser:
         self.calls = 0
 
     def parse_map(
-        self, _soup: object, _map_url: str, _map_id: str
+        self, _soup: object, _map_url: str, _map_id: int
     ) -> list[object]:
         self.calls += 1
         if self.calls == 1:
@@ -88,7 +88,7 @@ class _FailOnceThenSucceedParser:
 
 class _SuccessfulParser:
     def parse_map(
-        self, _soup: object, _map_url: str, _map_id: str
+        self, _soup: object, _map_url: str, _map_id: int
     ) -> list[object]:
         return [object()]
 
@@ -133,9 +133,9 @@ def test_map_controller_continues_after_item_failure(
     controller = map_module.MapController()
     controller.run(batch_size=2)
 
-    assert controller.state.failed == [("map-1", "No player kills logged.")]
-    assert controller.state.processed == ["map-2"]
-    assert controller.state.processing == ["map-1", "map-2"]
+    assert controller.state.failed == [(1, "No player kills logged.")]
+    assert controller.state.processed == [2]
+    assert controller.state.processing == [1, 2]
     assert len(stored_players) == 1
     assert any(
         call_args[0]
@@ -175,14 +175,14 @@ def test_map_controller_retries_retryable_error_before_succeeding(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 
     controller.run(batch_size=1)
 
     assert controller.state.failed == []
-    assert controller.state.processed == ["map-1"]
+    assert controller.state.processed == [1]
     assert len(stored_players) == 1
     assert len(reset_calls) == 1
     assert any(
@@ -214,7 +214,7 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 
@@ -262,7 +262,7 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 
@@ -270,7 +270,7 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
 
     assert controller.state.failed == [
         (
-            "map-1",
+            1,
             "Failed to fetch map stats page: https://www.hltv.org/stats/matches/mapstatsid/1/test",
         )
     ]
@@ -280,7 +280,7 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
         (
             (
                 "Exhausted retries for map %s after %d attempts; marking failed and continuing.",
-                "map-1",
+                1,
                 3,
             ),
             {},

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -11,10 +11,12 @@ class _FakeMapQueue:
         self.processed: list[str] = []
         self.processing: list[str] = []
 
-    def fetch(self, _limit: int = 25) -> list[tuple[str, str]]:
+    def fetch_with_match_context(
+        self, _limit: int = 25
+    ) -> list[tuple[str, str, int | None]]:
         return [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test"),
-            ("map-2", "https://www.hltv.org/stats/matches/mapstatsid/2/test"),
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101),
+            ("map-2", "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102),
         ]
 
     def mark_as_failed(self, item_id: str, reason: str) -> None:
@@ -54,11 +56,18 @@ class _RetryThenSucceedScraper(_SuccessfulScraper):
 class _TrackingStageService:
     def __init__(self) -> None:
         self.scrapers: list[object] = []
+        self.match_ids: list[object | None] = []
 
     def process_item(
-        self, _map_id: str, map_url: str, *, scraper: object
+        self,
+        _map_id: str,
+        map_url: str,
+        *,
+        scraper: object,
+        match_id: object | None = None,
     ) -> StageItemResult:
         self.scrapers.append(scraper)
+        self.match_ids.append(match_id)
         if len(self.scrapers) == 1:
             raise SessionScrapeError(f"Failed to fetch map stats page: {map_url}")
         return StageItemResult.processed()
@@ -164,9 +173,9 @@ def test_map_controller_retries_retryable_error_before_succeeding(
     )
     monkeypatch.setattr(
         controller.state,
-        "fetch",
+        "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 
@@ -203,15 +212,16 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
     )
     monkeypatch.setattr(
         controller.state,
-        "fetch",
+        "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 
     controller.run(batch_size=1)
 
     assert stage_service.scrapers == [first_scraper, reset_scraper]
+    assert stage_service.match_ids == [123, 123]
     assert controller.state.failed == []
     assert controller.state.processed == []
 
@@ -250,9 +260,9 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
     )
     monkeypatch.setattr(
         controller.state,
-        "fetch",
+        "fetch_with_match_context",
         lambda _limit=25: [
-            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")
+            ("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
         ],
     )
 

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -26,10 +26,16 @@ class _FakeMatchQueue:
 
 class _FakeFollowupQueue:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str]] = []
+        self.queued: list[tuple[str, str, str, object | None]] = []
 
-    def queue(self, item_id: str, url: str, source: str = "unknown") -> None:
-        self.queued.append((item_id, url, source))
+    def queue(
+        self,
+        item_id: str,
+        url: str,
+        source: str = "unknown",
+        match_id: object | None = None,
+    ) -> None:
+        self.queued.append((item_id, url, source, match_id))
 
 
 class _PassiveScraper:

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -26,11 +26,11 @@ class _FakeMatchQueue:
 
 class _FakeFollowupQueue:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str, int | None]] = []
+        self.queued: list[tuple[int | str, str, str, int | None]] = []
 
     def queue(
         self,
-        item_id: str,
+        item_id: int | str,
         url: str,
         source: str = "unknown",
         match_id: int | None = None,

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -6,34 +6,34 @@ from cs2_analytics.exceptions import MatchParseError, SessionScrapeError
 
 class _FakeMatchQueue:
     def __init__(self) -> None:
-        self.failed: list[tuple[str, str]] = []
-        self.processed: list[str] = []
-        self.processing: list[str] = []
+        self.failed: list[tuple[int, str]] = []
+        self.processed: list[int] = []
+        self.processing: list[int] = []
 
-    def fetch(self, limit: int = 25) -> list[tuple[str, str]]:
+    def fetch(self, limit: int = 25) -> list[tuple[int, str]]:
         assert limit > 0
-        return [("match-1", "https://www.hltv.org/matches/1/test")]
+        return [(1, "https://www.hltv.org/matches/1/test")]
 
-    def mark_as_failed(self, item_id: str, reason: str) -> None:
+    def mark_as_failed(self, item_id: int, reason: str) -> None:
         self.failed.append((item_id, reason))
 
-    def mark_as_processed(self, item_id: str) -> None:
+    def mark_as_processed(self, item_id: int) -> None:
         self.processed.append(item_id)
 
-    def mark_as_processing(self, item_id: str) -> None:
+    def mark_as_processing(self, item_id: int) -> None:
         self.processing.append(item_id)
 
 
 class _FakeFollowupQueue:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str, object | None]] = []
+        self.queued: list[tuple[str, str, str, int | None]] = []
 
     def queue(
         self,
         item_id: str,
         url: str,
         source: str = "unknown",
-        match_id: object | None = None,
+        match_id: int | None = None,
     ) -> None:
         self.queued.append((item_id, url, source, match_id))
 
@@ -131,10 +131,10 @@ def test_match_controller_marks_non_retryable_parse_error_failed_immediately(
     controller.run(batch_size=1)
 
     assert controller.match_state.failed == [
-        ("match-1", "Missing team names on match page.")
+        (1, "Missing team names on match page.")
     ]
     assert controller.match_state.processed == []
-    assert controller.match_state.processing == ["match-1"]
+    assert controller.match_state.processing == [1]
     assert len(exception_calls) == 1
     assert reset_calls == []
 
@@ -176,7 +176,7 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
 
     assert len(controller.match_state.failed) == 1
     failed_id, reason = controller.match_state.failed[0]
-    assert failed_id == "match-1"
+    assert failed_id == 1
     assert "Failed to fetch match page" in reason
     assert len(exception_calls) == 1
     assert len(reset_calls) == 2
@@ -184,7 +184,7 @@ def test_match_controller_marks_failed_once_after_exhausting_retryable_scrape_er
         (
             (
                 "Exhausted retries for match %s after %d attempts; marking failed and continuing.",
-                "match-1",
+                1,
                 3,
             ),
             {},
@@ -214,11 +214,11 @@ def test_match_controller_continues_after_item_failure(
         lambda *args, **kwargs: info_calls.append((args, kwargs)),
     )
 
-    def _fetch_two_matches(limit: int = 25) -> list[tuple[str, str]]:
+    def _fetch_two_matches(limit: int = 25) -> list[tuple[int, str]]:
         assert limit == 2
         return [
-            ("match-1", "https://www.hltv.org/matches/1/test"),
-            ("match-2", "https://www.hltv.org/matches/2/test"),
+            (1, "https://www.hltv.org/matches/1/test"),
+            (2, "https://www.hltv.org/matches/2/test"),
         ]
 
     monkeypatch.setattr(
@@ -235,10 +235,10 @@ def test_match_controller_continues_after_item_failure(
     controller.run(batch_size=2)
 
     assert controller.match_state.failed == [
-        ("match-1", "Missing team names on match page.")
+        (1, "Missing team names on match page.")
     ]
-    assert controller.match_state.processed == ["match-2"]
-    assert controller.match_state.processing == ["match-1", "match-2"]
+    assert controller.match_state.processed == [2]
+    assert controller.match_state.processing == [1, 2]
     assert len(stored_matches) == 1
     assert any(
         call_args[0]
@@ -284,7 +284,7 @@ def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
     controller.run(batch_size=1)
 
     assert controller.match_state.failed == []
-    assert controller.match_state.processed == ["match-1"]
+    assert controller.match_state.processed == [1]
     assert len(stored_matches) == 1
     assert len(reset_calls) == 2
     assert 8.0 in sleep_calls

--- a/tests/controllers/test_retry_utils.py
+++ b/tests/controllers/test_retry_utils.py
@@ -33,7 +33,7 @@ class _Scraper:
 
 
 class _FailingQueue:
-    def mark_as_failed(self, item_id: str, reason: str) -> None:
+    def mark_as_failed(self, item_id: int, reason: str) -> None:
         raise MatchQueueError("Failed to mark item as failed in match_ingestion_state.")
 
 
@@ -93,7 +93,7 @@ def test_mark_item_failed_propagates_queue_errors(
     ):
         retry_utils.mark_item_failed(
             _FailingQueue(),
-            "match-1",
+            1,
             error,
             logger=logger,
             log_message="Error processing match %s on attempt %d/%d: %s",

--- a/tests/parsers/test_map_parser_manual.py
+++ b/tests/parsers/test_map_parser_manual.py
@@ -23,7 +23,9 @@ def main():
     total_players = []
 
     with MapScraper() as scraper:
-        for map_id, map_url in queued_maps:
+        for queued_map in queued_maps:
+            map_id = queued_map[0]
+            map_url = queued_map[1]
             soup = scraper.fetch_soup(map_url)
             players = parser.parse_map(soup, map_url, map_id)
             if players:

--- a/tests/parsers/test_map_parser_regression.py
+++ b/tests/parsers/test_map_parser_regression.py
@@ -69,7 +69,7 @@ def test_parse_map_prefers_visible_over_hidden_metric_cells() -> None:
     players = parser.parse_map(
         soup,
         map_url="https://www.hltv.org/stats/matches/mapstatsid/999999/test-vs-test",
-        map_id="999999",
+        map_id=999999,
     )
 
     assert len(players) == 1

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -107,7 +107,7 @@ def test_match_parser_returns_numeric_match_id() -> None:
 
     assert match.match_id == 123456
     assert isinstance(match.match_id, int)
-    assert map_links == [("2", "https://www.hltv.org/stats/matches/mapstatsid/2/test-map")]
+    assert map_links == [(2, "https://www.hltv.org/stats/matches/mapstatsid/2/test-map")]
     assert demo_links == []
 
 
@@ -173,7 +173,7 @@ def test_map_parser_raises_typed_error_for_missing_kills() -> None:
         parser.parse_map(
             soup,
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
-            map_id="2",
+            map_id=2,
         )
 
 
@@ -375,7 +375,7 @@ def test_map_parser_raises_typed_error_for_missing_map_name() -> None:
         parser.parse_map(
             soup,
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
-            map_id="2",
+            map_id=2,
         )
 
 
@@ -432,7 +432,7 @@ def test_map_parser_raises_typed_error_for_missing_player_name() -> None:
         parser.parse_map(
             soup,
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
-            map_id="2",
+            map_id=2,
         )
 
 
@@ -487,5 +487,5 @@ def test_map_parser_raises_typed_error_for_missing_deaths() -> None:
         parser.parse_map(
             soup,
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
-            map_id="2",
+            map_id=2,
         )

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -55,7 +55,7 @@ def test_match_queue_wraps_db_failures_in_typed_exception(
         MatchQueueError,
         match="Failed to queue ingestion state items in match_ingestion_state.",
     ):
-        queue.queue_many([("1", "https://www.hltv.org/matches/1/test")])
+        queue.queue_many([(1, "https://www.hltv.org/matches/1/test")])
 
 
 def test_ingestion_state_classes_use_ingestion_state_tables() -> None:
@@ -94,7 +94,7 @@ def test_match_ingestion_state_refreshes_existing_rows_on_rediscovery(
     monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
     state = MatchIngestionState()
 
-    state.queue("1", "https://www.hltv.org/matches/1/test", source="results")
+    state.queue(1, "https://www.hltv.org/matches/1/test", source="results")
 
     assert cursor.execute_query is not None
     assert "match_ingestion_state" in cursor.execute_query
@@ -105,7 +105,7 @@ def test_match_ingestion_state_refreshes_existing_rows_on_rediscovery(
     assert "last_seen_at = EXCLUDED.last_seen_at" in cursor.execute_query
     assert cursor.execute_values is not None
     assert cursor.execute_values[:4] == (
-        "1",
+        1,
         "https://www.hltv.org/matches/1/test",
         "results",
         0,
@@ -119,7 +119,7 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
     state = MatchIngestionState()
 
-    state.mark_as_failed("1", "boom")
+    state.mark_as_failed(1, "boom")
 
     assert cursor.execute_query is not None
     assert "status = 'failed'" in cursor.execute_query
@@ -127,7 +127,7 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     assert "last_error_message" in cursor.execute_query
     assert "failure_count = COALESCE(failure_count, 0) + 1" in cursor.execute_query
     assert cursor.execute_values is not None
-    assert cursor.execute_values[2:] == ("boom", "1")
+    assert cursor.execute_values[2:] == ("boom", 1)
 
 
 def test_map_ingestion_state_queues_parent_match_context(
@@ -138,7 +138,7 @@ def test_map_ingestion_state_queues_parent_match_context(
     state = MapIngestionState()
 
     state.queue(
-        "map-1",
+        1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         source="match_parser",
         match_id=1,
@@ -152,7 +152,7 @@ def test_map_ingestion_state_queues_parent_match_context(
     )
     assert cursor.execute_values is not None
     assert cursor.execute_values[:5] == (
-        "map-1",
+        1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         1,
         "match_parser",

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -7,6 +7,7 @@ from cs2_analytics import ingestion_state as ingestion_state_package
 from cs2_analytics.ingestion_state import MatchIngestionState
 from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
 from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
+from cs2_analytics.ingestion_state import map_ingestion_state as map_state_module
 from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
 from cs2_analytics.ingestion_state.match_ingestion_state import (
     MatchIngestionState as ConcreteMatchIngestionState,
@@ -128,3 +129,33 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     assert "failure_count = COALESCE(failure_count, 0) + 1" in cursor.execute_query
     assert cursor.execute_values is not None
     assert cursor.execute_values[2:] == ("boom", "1")
+
+
+def test_map_ingestion_state_queues_parent_match_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(map_state_module, "db", _RecordingQueueDb(cursor))
+    state = MapIngestionState()
+
+    state.queue(
+        "map-1",
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        source="match_parser",
+        match_id="match-1",
+    )
+
+    assert cursor.execute_query is not None
+    assert "map_ingestion_state" in cursor.execute_query
+    assert "match_id" in cursor.execute_query
+    assert "match_id = COALESCE(EXCLUDED.match_id, map_ingestion_state.match_id)" in (
+        cursor.execute_query
+    )
+    assert cursor.execute_values is not None
+    assert cursor.execute_values[:5] == (
+        "map-1",
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        "match-1",
+        "match_parser",
+        0,
+    )

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -142,7 +142,7 @@ def test_map_ingestion_state_queues_parent_match_context(
         "map-1",
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         source="match_parser",
-        match_id="match-1",
+        match_id=1,
     )
 
     assert cursor.execute_query is not None
@@ -155,7 +155,7 @@ def test_map_ingestion_state_queues_parent_match_context(
     assert cursor.execute_values[:5] == (
         "map-1",
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
-        "match-1",
+        1,
         "match_parser",
         0,
     )

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -7,7 +7,6 @@ from cs2_analytics import ingestion_state as ingestion_state_package
 from cs2_analytics.ingestion_state import MatchIngestionState
 from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
 from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
-from cs2_analytics.ingestion_state import map_ingestion_state as map_state_module
 from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
 from cs2_analytics.ingestion_state.match_ingestion_state import (
     MatchIngestionState as ConcreteMatchIngestionState,
@@ -135,7 +134,7 @@ def test_map_ingestion_state_queues_parent_match_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(map_state_module, "db", _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
     state = MapIngestionState()
 
     state.queue(

--- a/tests/scrapers/test_map_scraper_manual.py
+++ b/tests/scrapers/test_map_scraper_manual.py
@@ -19,7 +19,9 @@ def main():
         return
 
     with MapScraper() as scraper:
-        for map_id, map_url in queued_maps:
+        for queued_map in queued_maps:
+            map_id = queued_map[0]
+            map_url = queued_map[1]
             soup = scraper.fetch_soup(map_url)
             print(f"Scraped map {map_id} from {map_url}. Soup length: {len(soup.text)}")
 

--- a/tests/stage_services/test_map_stage_service.py
+++ b/tests/stage_services/test_map_stage_service.py
@@ -13,26 +13,26 @@ class _FakeScraper:
 class _FakeParser:
     def __init__(self, players: list[object]) -> None:
         self.players = players
-        self.calls: list[tuple[str, str]] = []
+        self.calls: list[tuple[str, int]] = []
 
-    def parse_map(self, _soup: object, map_url: str, map_id: str) -> list[object]:
+    def parse_map(self, _soup: object, map_url: str, map_id: int) -> list[object]:
         self.calls.append((map_url, map_id))
         return self.players
 
 
 class _FakeMapState:
     def __init__(self) -> None:
-        self.processing: list[str] = []
-        self.processed: list[str] = []
-        self.failed: list[tuple[str, str]] = []
+        self.processing: list[int] = []
+        self.processed: list[int] = []
+        self.failed: list[tuple[int, str]] = []
 
-    def mark_as_processing(self, item_id: str) -> None:
+    def mark_as_processing(self, item_id: int) -> None:
         self.processing.append(item_id)
 
-    def mark_as_processed(self, item_id: str) -> None:
+    def mark_as_processed(self, item_id: int) -> None:
         self.processed.append(item_id)
 
-    def mark_as_failed(self, item_id: str, reason: str) -> None:
+    def mark_as_failed(self, item_id: int, reason: str) -> None:
         self.failed.append((item_id, reason))
 
 
@@ -48,7 +48,7 @@ def test_map_stage_service_processes_success() -> None:
     )
 
     result = service.process_item(
-        "map-1",
+        1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
     )
@@ -56,10 +56,10 @@ def test_map_stage_service_processes_success() -> None:
     assert result.succeeded is True
     assert result.status == "processed"
     assert parser.calls == [
-        ("https://www.hltv.org/stats/matches/mapstatsid/1/test", "map-1")
+        ("https://www.hltv.org/stats/matches/mapstatsid/1/test", 1)
     ]
     assert map_state.processing == []
-    assert map_state.processed == ["map-1"]
+    assert map_state.processed == [1]
     assert map_state.failed == []
     assert stored_players == [players]
 
@@ -74,7 +74,7 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
     )
 
     result = service.process_item(
-        "map-1",
+        1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
     )
@@ -84,7 +84,7 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
     assert result.message == "Parsing returned no player records"
     assert map_state.processing == []
     assert map_state.processed == []
-    assert map_state.failed == [("map-1", "Parsing returned no player records")]
+    assert map_state.failed == [(1, "Parsing returned no player records")]
     assert stored_players == []
 
 
@@ -97,7 +97,7 @@ def test_map_stage_service_processes_with_attempt_scraper() -> None:
     )
 
     service.process_item(
-        "map-1",
+        1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=attempt_scraper,
     )

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -14,7 +14,7 @@ class _FakeParser:
     def __init__(
         self,
         match: object | None,
-        map_links: list[tuple[str, str]] | None = None,
+        map_links: list[tuple[int, str]] | None = None,
         demo_links: list[tuple[str, str]] | None = None,
     ) -> None:
         self.match = match
@@ -24,7 +24,7 @@ class _FakeParser:
 
     def parse_match(
         self, _soup: object, match_url: str
-    ) -> tuple[object | None, list[tuple[str, str]], list[tuple[str, str]]]:
+    ) -> tuple[object | None, list[tuple[int, str]], list[tuple[str, str]]]:
         self.calls.append(match_url)
         return self.match, self.map_links, self.demo_links
 
@@ -47,11 +47,11 @@ class _FakeMatchState:
 
 class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str, int | None]] = []
+        self.queued: list[tuple[int | str, str, str, int | None]] = []
 
     def queue(
         self,
-        item_id: str,
+        item_id: int | str,
         url: str,
         source: str = "unknown",
         match_id: int | None = None,
@@ -68,7 +68,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     service = MatchStageService(
         parser=_FakeParser(
             match=match,
-            map_links=[("map-1", "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
+            map_links=[(1, "https://www.hltv.org/stats/matches/mapstatsid/1/test")],
             demo_links=[("demo-1", "https://www.hltv.org/download/demo/test")],
         ),
         store_matches=lambda matches: stored_matches.append(matches),
@@ -89,7 +89,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     assert stored_matches == [[match]]
     assert map_state.queued == [
         (
-            "map-1",
+            1,
             "https://www.hltv.org/stats/matches/mapstatsid/1/test",
             "match_parser",
             1,

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -31,30 +31,30 @@ class _FakeParser:
 
 class _FakeMatchState:
     def __init__(self) -> None:
-        self.processing: list[str] = []
-        self.processed: list[str] = []
-        self.failed: list[tuple[str, str]] = []
+        self.processing: list[int] = []
+        self.processed: list[int] = []
+        self.failed: list[tuple[int, str]] = []
 
-    def mark_as_processing(self, item_id: str) -> None:
+    def mark_as_processing(self, item_id: int) -> None:
         self.processing.append(item_id)
 
-    def mark_as_processed(self, item_id: str) -> None:
+    def mark_as_processed(self, item_id: int) -> None:
         self.processed.append(item_id)
 
-    def mark_as_failed(self, item_id: str, reason: str) -> None:
+    def mark_as_failed(self, item_id: int, reason: str) -> None:
         self.failed.append((item_id, reason))
 
 
 class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str, object | None]] = []
+        self.queued: list[tuple[str, str, str, int | None]] = []
 
     def queue(
         self,
         item_id: str,
         url: str,
         source: str = "unknown",
-        match_id: object | None = None,
+        match_id: int | None = None,
     ) -> None:
         self.queued.append((item_id, url, source, match_id))
 
@@ -78,13 +78,13 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     )
 
     result = service.process_item(
-        "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
+        1, "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
     )
 
     assert result.succeeded is True
     assert result.status == "processed"
     assert match_state.processing == []
-    assert match_state.processed == ["match-1"]
+    assert match_state.processed == [1]
     assert match_state.failed == []
     assert stored_matches == [[match]]
     assert map_state.queued == [
@@ -92,7 +92,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
             "map-1",
             "https://www.hltv.org/stats/matches/mapstatsid/1/test",
             "match_parser",
-            "match-1",
+            1,
         )
     ]
     assert demo_state.queued == [
@@ -117,7 +117,7 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
     )
 
     result = service.process_item(
-        "match-1", "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
+        1, "https://www.hltv.org/matches/1/test", scraper=_FakeScraper()
     )
 
     assert result.succeeded is False
@@ -125,7 +125,7 @@ def test_match_stage_service_marks_failed_when_parser_returns_none() -> None:
     assert result.message == "Parsing returned None"
     assert match_state.processing == []
     assert match_state.processed == []
-    assert match_state.failed == [("match-1", "Parsing returned None")]
+    assert match_state.failed == [(1, "Parsing returned None")]
     assert stored_matches == []
 
 
@@ -140,7 +140,7 @@ def test_match_stage_service_processes_with_attempt_scraper() -> None:
     )
 
     service.process_item(
-        "match-1", "https://www.hltv.org/matches/1/test", scraper=attempt_scraper
+        1, "https://www.hltv.org/matches/1/test", scraper=attempt_scraper
     )
 
     assert attempt_scraper.urls == ["https://www.hltv.org/matches/1/test"]

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -47,10 +47,16 @@ class _FakeMatchState:
 
 class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[str, str, str]] = []
+        self.queued: list[tuple[str, str, str, object | None]] = []
 
-    def queue(self, item_id: str, url: str, source: str = "unknown") -> None:
-        self.queued.append((item_id, url, source))
+    def queue(
+        self,
+        item_id: str,
+        url: str,
+        source: str = "unknown",
+        match_id: object | None = None,
+    ) -> None:
+        self.queued.append((item_id, url, source, match_id))
 
 
 def test_match_stage_service_processes_success_and_queues_followups() -> None:
@@ -86,10 +92,16 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
             "map-1",
             "https://www.hltv.org/stats/matches/mapstatsid/1/test",
             "match_parser",
+            "match-1",
         )
     ]
     assert demo_state.queued == [
-        ("demo-1", "https://www.hltv.org/download/demo/test", "match_parser")
+        (
+            "demo-1",
+            "https://www.hltv.org/download/demo/test",
+            "match_parser",
+            None,
+        )
     ]
 
 

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -38,7 +38,7 @@ class TestDatabase(unittest.TestCase):
         test_match = Match(
             match_id=999999,
             match_url="https://www.hltv.org/matches/999999/test-match",
-            map_links=["https://www.hltv.org/matches/999999/test-map"],
+            map_links=[(999999, "https://www.hltv.org/matches/999999/test-map")],
             demo_links=[],
             team1="Test Team A",
             team2="Test Team B",

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -158,3 +158,6 @@ def test_schema_defines_ingestion_state_tables() -> None:
         for status_value in required_status_values:
             assert status_value in table_sql
         assert "retry_count" not in table_sql
+
+    map_table_sql = _table_definition(schema_sql, "map_ingestion_state")
+    assert "match_id INT REFERENCES matches(match_id) ON DELETE CASCADE" in map_table_sql

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -160,4 +160,5 @@ def test_schema_defines_ingestion_state_tables() -> None:
         assert "retry_count" not in table_sql
 
     map_table_sql = _table_definition(schema_sql, "map_ingestion_state")
+    assert "map_id INT PRIMARY KEY" in map_table_sql
     assert "match_id INT REFERENCES matches(match_id) ON DELETE CASCADE" in map_table_sql


### PR DESCRIPTION
## Summary

- Add `match_id` context to `map_ingestion_state`
- Queue discovered map rows with their parent match id from `MatchStageService`
- Add `MapIngestionState.fetch_with_match_context()` for map-stage reads
- Pass match context through `MapController` into `MapStageService`
- Update tests and mark `phase3.5-map-discovery-context` complete in the backlog

## Verification

- `.venv\Scripts\python.exe -m pytest`
- Result: `55 passed, 3 skipped`