### PR TITLE
Phase 3.5: Map Storage Contract

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -12,6 +12,7 @@ from cs2_analytics.ingestion_state import MapIngestionState
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.scrapers.map_scraper import MapScraper
 from cs2_analytics.stage_services import MapStageService
+from cs2_analytics.storage.map_storage import store_maps
 from cs2_analytics.storage.player_storage import store_players
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -27,6 +28,7 @@ class MapController:
         self.state = MapIngestionState()
         self.stage_service = MapStageService(
             parser=self.parser,
+            store_maps=store_maps,
             store_players=store_players,
             map_state=self.state,
         )
@@ -47,7 +49,7 @@ class MapController:
 
         scraper = self.scraper
         try:
-            for map_id, map_url, match_id in selected:
+            for map_id, map_url, match_id, map_order in selected:
                 if processed_since_reset >= rotate_every:
                     logger.info(
                         "Rotating map scraper session after %d processed maps",
@@ -65,6 +67,7 @@ class MapController:
                             map_url,
                             scraper=scraper,
                             match_id=match_id,
+                            map_order=map_order,
                         )
                         if result.succeeded:
                             succeeded += 1

--- a/cs2_analytics/exceptions.py
+++ b/cs2_analytics/exceptions.py
@@ -69,6 +69,10 @@ class MatchStorageError(StorageError):
     """Raised when match records cannot be stored."""
 
 
+class MapStorageError(StorageError):
+    """Raised when map records cannot be stored."""
+
+
 class PlayerStorageError(StorageError):
     """Raised when player records cannot be stored."""
 

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -19,10 +19,10 @@ class MapIngestionState(BaseIngestionState):
 
     def fetch_with_match_context(
         self, limit: int = 25
-    ) -> list[tuple[int, str, int | None]]:
-        """Fetch pending map rows with parent match context when available."""
+    ) -> list[tuple[int, str, int | None, int | None]]:
+        """Fetch pending map rows with parent match and map-order context."""
         query = """
-        SELECT map_id, map_url, match_id
+        SELECT map_id, map_url, match_id, map_order
         FROM map_ingestion_state
         WHERE status = 'pending'
         ORDER BY priority DESC, first_seen_at ASC
@@ -44,18 +44,20 @@ class MapIngestionState(BaseIngestionState):
         source: str = "unknown",
         priority: int = 0,
         match_id: int | None = None,
+        map_order: int | None = None,
     ) -> None:
         """Add or refresh a map ingestion row with parent match context."""
         now = dt.datetime.now()
         query = """
         INSERT INTO map_ingestion_state (
-            map_id, map_url, match_id, status, source, priority,
+            map_id, map_url, match_id, map_order, status, source, priority,
             first_seen_at, last_seen_at, last_updated_at
         )
-        VALUES (%s, %s, %s, 'pending', %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, 'pending', %s, %s, %s, %s, %s)
         ON CONFLICT (map_id) DO UPDATE
         SET map_url = EXCLUDED.map_url,
             match_id = COALESCE(EXCLUDED.match_id, map_ingestion_state.match_id),
+            map_order = COALESCE(EXCLUDED.map_order, map_ingestion_state.map_order),
             source = EXCLUDED.source,
             priority = GREATEST(
                 COALESCE(map_ingestion_state.priority, 0),
@@ -68,7 +70,17 @@ class MapIngestionState(BaseIngestionState):
             with self.db.get_cursor() as cur:
                 cur.execute(
                     query,
-                    (id_value, url, match_id, source, priority, now, now, now),
+                    (
+                        id_value,
+                        url,
+                        match_id,
+                        map_order,
+                        source,
+                        priority,
+                        now,
+                        now,
+                        now,
+                    ),
                 )
         except Exception as e:
             raise self.error_cls(

--- a/cs2_analytics/models/map.py
+++ b/cs2_analytics/models/map.py
@@ -1,6 +1,9 @@
 """This module contains the Map class, which is used to represent a single map in a match."""
 
 from dataclasses import dataclass
+from datetime import datetime
+
+type MapDictValue = int | str | bool | datetime
 
 
 @dataclass
@@ -9,24 +12,32 @@ class Map:
 
     map_id: int
     match_id: int
+    map_url: str
     map_name: str
     map_order: int
     team1_score: int
     team2_score: int
-    winner: str
+    map_winner: str
     date: str
+    inserted_at: datetime
+    last_scraped_at: datetime
+    last_updated_at: datetime
     data_complete: bool
 
-    def to_dict(self) -> dict[str, int | str | bool]:
+    def to_dict(self) -> dict[str, MapDictValue]:
         """ "Converts the object to a dictionary for database insertion."""
         return {
             "map_id": self.map_id,
             "match_id": self.match_id,
+            "map_url": self.map_url,
             "map_name": self.map_name,
             "map_order": self.map_order,
             "team1_score": self.team1_score,
             "team2_score": self.team2_score,
-            "winner": self.winner,
+            "map_winner": self.map_winner,
             "date": self.date,
+            "inserted_at": self.inserted_at,
+            "last_scraped_at": self.last_scraped_at,
+            "last_updated_at": self.last_updated_at,
             "data_complete": self.data_complete,
         }

--- a/cs2_analytics/models/map.py
+++ b/cs2_analytics/models/map.py
@@ -25,7 +25,7 @@ class Map:
     data_complete: bool
 
     def to_dict(self) -> dict[str, MapDictValue]:
-        """ "Converts the object to a dictionary for database insertion."""
+        """Converts the object to a dictionary for database insertion."""
         return {
             "map_id": self.map_id,
             "match_id": self.match_id,

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -2,12 +2,22 @@
 
 import datetime as dt
 import re
+from dataclasses import dataclass
 
 from cs2_analytics.exceptions import MapParseError
+from cs2_analytics.models.map import Map
 from cs2_analytics.models.player import Player
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ParsedMap:
+    """Map-level metadata and player rows parsed from one map stats page."""
+
+    map: Map
+    players: list[Player]
 
 
 class MapParser:
@@ -33,6 +43,45 @@ class MapParser:
 
         logger.info("Extracted %s player stats from %s", len(players), map_url)
         return players
+
+    def parse_map_details(
+        self,
+        soup,
+        map_url: str,
+        map_id: int,
+        *,
+        match_id: int | None,
+        map_order: int | None,
+    ) -> ParsedMap:
+        """Extracts map metadata and player objects from a map stats page."""
+        logger.info("Parsing %s for player stats", map_url)
+        try:
+            map_id_value = self._resolve_map_id(map_id)
+            map_name = self._extract_map_name(soup)
+            team_scores = self._extract_map_team_scores(soup)
+            players = self._extract_players_from_tables(
+                soup=soup,
+                map_url=map_url,
+                map_id_value=map_id_value,
+                map_name=map_name,
+            )
+            parsed_map = self._build_map(
+                soup=soup,
+                map_id_value=map_id_value,
+                map_url=map_url,
+                match_id=match_id,
+                map_order=map_order,
+                map_name=map_name,
+                team_scores=team_scores,
+            )
+
+        except MapParseError:
+            raise
+        except Exception as e:
+            raise MapParseError(f"Failed to parse map stats page: {map_url}") from e
+
+        logger.info("Extracted %s player stats from %s", len(players), map_url)
+        return ParsedMap(map=parsed_map, players=players)
 
     def _resolve_map_id(self, map_id: int) -> int:
         """Resolves the numeric map identifier from the explicit id or URL."""
@@ -140,6 +189,46 @@ class MapParser:
             map_name=map_name,
             team_name=team_name,
             stats=stats,
+        )
+
+    def _build_map(
+        self,
+        *,
+        soup,
+        map_id_value: int,
+        map_url: str,
+        match_id: int | None,
+        map_order: int | None,
+        map_name: str,
+        team_scores: tuple[tuple[str, int], tuple[str, int]],
+    ) -> Map:
+        """Builds one relational map row from parsed map-level metadata."""
+        if match_id is None:
+            raise MapParseError("Missing parent match id for map persistence.")
+
+        resolved_map_order = map_order or self._extract_map_order(
+            soup=soup,
+            map_url=map_url,
+            map_id_value=map_id_value,
+        )
+        (team1_name, team1_score), (team2_name, team2_score) = team_scores
+        map_winner = team1_name if team1_score > team2_score else team2_name
+        now = dt.datetime.now(dt.UTC)
+
+        return Map(
+            map_id=map_id_value,
+            match_id=match_id,
+            map_url=map_url,
+            map_name=map_name,
+            map_order=resolved_map_order,
+            team1_score=team1_score,
+            team2_score=team2_score,
+            map_winner=map_winner,
+            date=self._extract_map_date(soup),
+            inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
         )
 
     def _extract_player_identity(self, cols) -> tuple[str, str, int]:
@@ -347,6 +436,96 @@ class MapParser:
                     return map_name
 
         raise MapParseError("Failed to extract map name from map stats page.")
+
+    def _extract_map_date(self, soup) -> str:
+        """Extracts the map date as a timestamp-compatible string."""
+        date_tag = soup.find("div", class_="date")
+        if date_tag and date_tag.has_attr("data-unix"):
+            try:
+                return dt.datetime.fromtimestamp(
+                    int(date_tag["data-unix"]) / 1000,
+                    tz=dt.UTC,
+                ).strftime("%Y-%m-%d %H:%M:%S")
+            except (TypeError, ValueError, OSError, OverflowError) as e:
+                raise MapParseError("Failed to extract map date from map stats page.") from e
+
+        page_text = soup.get_text(" ", strip=True)
+        date_match = re.search(
+            r"\b(\d{4}-\d{2}-\d{2})(?:\s+(\d{1,2}:\d{2}))?\b",
+            page_text,
+        )
+        if date_match:
+            if date_match.group(2):
+                return f"{date_match.group(1)} {date_match.group(2)}:00"
+            return date_match.group(1)
+
+        raise MapParseError("Failed to extract map date from map stats page.")
+
+    def _extract_map_team_scores(self, soup) -> tuple[tuple[str, int], tuple[str, int]]:
+        """Extracts the two map teams and scores in page order."""
+        match_box = soup.find("div", class_="match-info-box")
+        if not match_box:
+            raise MapParseError("Failed to extract map scores from map stats page.")
+
+        team_names = self._extract_distinct_team_names(soup)
+        if len(team_names) < 2:
+            raise MapParseError("Failed to extract map teams from map stats page.")
+
+        tokens = [text.strip() for text in match_box.stripped_strings if text.strip()]
+        scores: list[tuple[str, int]] = []
+        for team_name in team_names[:2]:
+            score = self._find_score_after_team(tokens, team_name)
+            scores.append((team_name, score))
+
+        return scores[0], scores[1]
+
+    def _extract_distinct_team_names(self, soup) -> list[str]:
+        """Returns distinct team names from visible stat tables in page order."""
+        team_names: list[str] = []
+        for table in self._iter_visible_stat_tables(soup):
+            team_name = self._extract_team_name(table)
+            if team_name != "Unknown" and team_name not in team_names:
+                team_names.append(team_name)
+        return team_names
+
+    def _find_score_after_team(self, tokens: list[str], team_name: str) -> int:
+        """Finds the first standalone integer token after a team name token."""
+        try:
+            start_index = tokens.index(team_name)
+        except ValueError as e:
+            raise MapParseError("Failed to extract map scores from map stats page.") from e
+
+        for token in tokens[start_index + 1 :]:
+            if re.fullmatch(r"\d+", token):
+                return int(token)
+            if token in ("Breakdown", "Team rating 2.1", "First kills", "Clutches won"):
+                break
+
+        raise MapParseError("Failed to extract map scores from map stats page.")
+
+    def _extract_map_order(self, *, soup, map_url: str, map_id_value: int) -> int:
+        """Infers map order from mapstats links when discovery did not provide it."""
+        map_ids: list[int] = []
+        for link in soup.select('a[href*="/stats/matches/mapstatsid/"]'):
+            href = link.get("href", "")
+            map_id = self._extract_map_id_from_url(href)
+            if map_id is not None and map_id not in map_ids:
+                map_ids.append(map_id)
+
+        if map_id_value in map_ids:
+            return map_ids.index(map_id_value) + 1
+
+        map_id_from_url = self._extract_map_id_from_url(map_url)
+        if map_id_from_url and map_id_from_url in map_ids:
+            return map_ids.index(map_id_from_url) + 1
+
+        raise MapParseError("Failed to extract map order from map stats page.")
+
+    def _extract_map_id_from_url(self, url: str) -> int | None:
+        match = re.search(r"/mapstatsid/(\d+)", url)
+        if match:
+            return int(match.group(1))
+        return None
 
     def _build_column_map(self, table) -> dict[str, int]:
         """Builds a normalized header->index map from table headers."""

--- a/cs2_analytics/stage_services/map_stage_service.py
+++ b/cs2_analytics/stage_services/map_stage_service.py
@@ -9,6 +9,7 @@ from cs2_analytics.stage_services.stage_result import StageItemResult
 
 if TYPE_CHECKING:
     from cs2_analytics.ingestion_state import MapIngestionState
+    from cs2_analytics.models.map import Map
     from cs2_analytics.models.player import Player
     from cs2_analytics.parsers.map_parser import MapParser
     from cs2_analytics.scrapers.map_scraper import MapScraper
@@ -20,10 +21,12 @@ class MapStageService:
     def __init__(
         self,
         parser: MapParser,
+        store_maps: Callable[[list[Map]], None],
         store_players: Callable[[list[Player]], None],
         map_state: MapIngestionState,
     ) -> None:
         self.parser = parser
+        self.store_maps = store_maps
         self.store_players = store_players
         self.map_state = map_state
 
@@ -33,7 +36,8 @@ class MapStageService:
         map_url: str,
         *,
         scraper: MapScraper,
-        match_id: int | None = None,  # noqa: ARG002
+        match_id: int | None = None,
+        map_order: int | None = None,
     ) -> StageItemResult:
         """Process one map ingestion-state row.
 
@@ -43,13 +47,20 @@ class MapStageService:
         ingestion state.
         """
         soup = scraper.fetch_soup(map_url)
-        players = self.parser.parse_map(soup, map_url, map_id)
+        parsed_map = self.parser.parse_map_details(
+            soup,
+            map_url,
+            map_id,
+            match_id=match_id,
+            map_order=map_order,
+        )
 
-        if not players:
+        if not parsed_map.players:
             message = "Parsing returned no player records"
             self.map_state.mark_as_failed(map_id, message)
             return StageItemResult.failed(message)
 
-        self.store_players(players)
+        self.store_maps([parsed_map.map])
+        self.store_players(parsed_map.players)
         self.map_state.mark_as_processed(map_id)
         return StageItemResult.processed()

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -63,12 +63,13 @@ class MatchStageService:
         demo_links: list[tuple[str, str]],
     ) -> None:
         """Queue map and demo links returned by the parser."""
-        for map_id, map_url in map_links:
+        for map_order, (map_id, map_url) in enumerate(map_links, start=1):
             self.map_state.queue(
                 map_id,
                 map_url,
                 source="match_parser",
                 match_id=match_id,
+                map_order=map_order,
             )
         for demo_id, demo_url in demo_links:
             self.demo_state.queue(demo_id, demo_url, source="match_parser")

--- a/cs2_analytics/storage/map_storage.py
+++ b/cs2_analytics/storage/map_storage.py
@@ -1,4 +1,5 @@
-from cs2_analytics.models.map import Map  # assumes your map model is called Map
+from cs2_analytics.exceptions import MapStorageError
+from cs2_analytics.models.map import Map
 from cs2_analytics.storage.db_instance import db
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -11,34 +12,50 @@ def store_maps(maps: list[Map]) -> None:
 
     insert_query = """
     INSERT INTO maps (
-        map_id, match_id, map_name,
-        team1_score, team2_score,
-        last_inserted_at, last_scraped_at, last_updated_at, data_complete
+        map_id, match_id, map_url, map_order, map_name,
+        team1_score, team2_score, map_winner, date,
+        inserted_at, last_scraped_at, last_updated_at, data_complete
     )
     VALUES (
-        %(map_id)s, %(match_id)s, %(map_name)s,
-        %(team1_score)s, %(team2_score)s,
-        %(last_inserted_at)s, %(last_scraped_at)s, %(last_updated_at)s, %(data_complete)s
+        %(map_id)s, %(match_id)s, %(map_url)s, %(map_order)s, %(map_name)s,
+        %(team1_score)s, %(team2_score)s, %(map_winner)s, %(date)s,
+        %(inserted_at)s, %(last_scraped_at)s, %(last_updated_at)s, %(data_complete)s
     )
     ON CONFLICT (map_id) DO UPDATE SET
-        last_updated_at = EXCLUDED.last_updated_at;
+        match_id = EXCLUDED.match_id,
+        map_url = EXCLUDED.map_url,
+        map_order = EXCLUDED.map_order,
+        map_name = EXCLUDED.map_name,
+        team1_score = EXCLUDED.team1_score,
+        team2_score = EXCLUDED.team2_score,
+        map_winner = EXCLUDED.map_winner,
+        date = EXCLUDED.date,
+        last_scraped_at = EXCLUDED.last_scraped_at,
+        last_updated_at = EXCLUDED.last_updated_at,
+        data_complete = EXCLUDED.data_complete;
     """
 
-    with db.get_cursor() as cur:
-        for map_obj in maps:
-            cur.execute(
-                insert_query,
-                {
-                    "map_id": map_obj.map_id,
-                    "match_id": map_obj.match_id,
-                    "map_name": map_obj.map_name,
-                    "team1_score": map_obj.team1_score,
-                    "team2_score": map_obj.team2_score,
-                    "last_inserted_at": map_obj.last_inserted_at,
-                    "last_scraped_at": map_obj.last_scraped_at,
-                    "last_updated_at": map_obj.last_updated_at,
-                    "data_complete": map_obj.data_complete,
-                },
-            )
-        db.commit()
-        logger.info("📥 Stored %d map records.", len(maps))
+    try:
+        with db.get_cursor() as cur:
+            for map_obj in maps:
+                cur.execute(
+                    insert_query,
+                    {
+                        "map_id": map_obj.map_id,
+                        "match_id": map_obj.match_id,
+                        "map_url": map_obj.map_url,
+                        "map_order": map_obj.map_order,
+                        "map_name": map_obj.map_name,
+                        "team1_score": map_obj.team1_score,
+                        "team2_score": map_obj.team2_score,
+                        "map_winner": map_obj.map_winner,
+                        "date": map_obj.date,
+                        "inserted_at": map_obj.inserted_at,
+                        "last_scraped_at": map_obj.last_scraped_at,
+                        "last_updated_at": map_obj.last_updated_at,
+                        "data_complete": map_obj.data_complete,
+                    },
+                )
+            logger.info("Stored %d map records.", len(maps))
+    except Exception as e:
+        raise MapStorageError("Failed to store map records.") from e

--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -81,17 +81,22 @@ CREATE TABLE matches (
 -- ✅ Maps Table (Previously `maps_played`)
 CREATE TABLE maps (
     map_id INT PRIMARY KEY,
-    match_id INT REFERENCES matches(match_id) ON DELETE CASCADE,
-    map_order INT CHECK (
+    match_id INT NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    map_url TEXT UNIQUE NOT NULL,
+    map_order INT NOT NULL CHECK (
         map_order BETWEEN 1
         AND 5
     ),
     map_name TEXT NOT NULL,
-    team1_score INT,
-    team2_score INT,
-    winner TEXT NOT NULL CHECK (winner IN ('team1', 'team2')),
+    team1_score INT NOT NULL CHECK (team1_score >= 0),
+    team2_score INT NOT NULL CHECK (team2_score >= 0),
+    map_winner TEXT NOT NULL,
     date TIMESTAMP NOT NULL,
-    data_complete BOOLEAN DEFAULT TRUE
+    inserted_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    last_scraped_at TIMESTAMPTZ,
+    last_updated_at TIMESTAMPTZ,
+    data_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    UNIQUE (match_id, map_order)
 );
 
 -- ✅ Players Table (Previously `players_stats`)
@@ -190,6 +195,10 @@ CREATE TABLE map_ingestion_state (
     map_id INT PRIMARY KEY,
     map_url TEXT NOT NULL,
     match_id INT REFERENCES matches(match_id) ON DELETE CASCADE,
+    map_order INT CHECK (
+        map_order BETWEEN 1
+        AND 5
+    ),
     status TEXT CHECK (
         status IN ('pending', 'processing', 'processed', 'failed', 'skipped')
     ) NOT NULL DEFAULT 'pending',

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -147,13 +147,13 @@ remains the active schema source of truth.
 
 - [x] Add match context to discovered map rows so each map can be tied back to
       its parent match without parsing stringified link fields
-- [ ] Decide whether `map_order`, `map_name`, map scores, and map winner come
+- [x] Decide whether `map_order`, `map_name`, map scores, and map winner come
       from match pages, map pages, or both
-- [ ] Ensure the map stage writes one row per played map to `maps`
+- [x] Ensure the map stage writes one row per played map to `maps`
 - [ ] Keep `players` at the grain of one row per player per map
-- [ ] Make `cs2_analytics/storage/map_storage.py` match the active
+- [x] Make `cs2_analytics/storage/map_storage.py` match the active
       `cs2_analytics/storage/schema.sql`
-- [ ] Update `store_maps` to upsert all trusted map fields, or remove stale map
+- [x] Update `store_maps` to upsert all trusted map fields, or remove stale map
       storage code if it no longer has a role
 - [ ] Update `store_matches` conflict behavior to refresh trusted parsed fields,
       not only `last_updated_at`
@@ -190,9 +190,14 @@ relational ingestion outputs without starting dbt models yet.
    `map_name`, map scores, and map winner still need a separate source-of-truth
    decision before the map stage writes relational `maps` rows.
 
-2. [ ] `phase3.5-map-storage-contract`
+2. [x] `phase3.5-map-storage-contract`
    Align the `maps` schema, model, parser output, and `store_maps` behavior so
    the map stage can persist one row per played map.
+
+   Map storage now uses `map_order` from match discovery order and parses
+   `map_name`, map scores, map winner, and date from the map stats page. The
+   active `maps` table includes map audit fields and `map_url`, and the map
+   stage persists the map row before player rows.
 
 3. [ ] `phase3.5-storage-upsert-idempotency`
    Strengthen match, map, and player upserts so reruns refresh trusted fields

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -13,10 +13,10 @@ class _FakeMapQueue:
 
     def fetch_with_match_context(
         self, _limit: int = 25
-    ) -> list[tuple[int, str, int | None]]:
+    ) -> list[tuple[int, str, int | None, int | None]]:
         return [
-            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101),
-            (2, "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102),
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101, 1),
+            (2, "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102, 2),
         ]
 
     def mark_as_failed(self, item_id: int, reason: str) -> None:
@@ -57,6 +57,7 @@ class _TrackingStageService:
     def __init__(self) -> None:
         self.scrapers: list[object] = []
         self.match_ids: list[int | None] = []
+        self.map_orders: list[int | None] = []
 
     def process_item(
         self,
@@ -65,9 +66,11 @@ class _TrackingStageService:
         *,
         scraper: object,
         match_id: int | None = None,
+        map_order: int | None = None,
     ) -> StageItemResult:
         self.scrapers.append(scraper)
         self.match_ids.append(match_id)
+        self.map_orders.append(map_order)
         if len(self.scrapers) == 1:
             raise SessionScrapeError(f"Failed to fetch map stats page: {map_url}")
         return StageItemResult.processed()
@@ -77,20 +80,34 @@ class _FailOnceThenSucceedParser:
     def __init__(self) -> None:
         self.calls = 0
 
-    def parse_map(
-        self, _soup: object, _map_url: str, _map_id: int
-    ) -> list[object]:
+    def parse_map_details(
+        self,
+        _soup: object,
+        _map_url: str,
+        _map_id: int,
+        *,
+        match_id: int | None,
+        map_order: int | None,
+    ) -> object:
+        _ = (match_id, map_order)
         self.calls += 1
         if self.calls == 1:
             raise MapParseError("No player kills logged.")
-        return [object()]
+        return type("ParsedMap", (), {"map": object(), "players": [object()]})()
 
 
 class _SuccessfulParser:
-    def parse_map(
-        self, _soup: object, _map_url: str, _map_id: int
-    ) -> list[object]:
-        return [object()]
+    def parse_map_details(
+        self,
+        _soup: object,
+        _map_url: str,
+        _map_id: int,
+        *,
+        match_id: int | None,
+        map_order: int | None,
+    ) -> object:
+        _ = (match_id, map_order)
+        return type("ParsedMap", (), {"map": object(), "players": [object()]})()
 
 
 def _build_map_controller(
@@ -101,6 +118,11 @@ def _build_map_controller(
     monkeypatch.setattr(map_module, "MapScraper", scraper_cls)
     monkeypatch.setattr(map_module, "MapParser", parser_cls)
     monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapQueue)
+    monkeypatch.setattr(
+        map_module,
+        "store_maps",
+        lambda _maps: None,
+    )
     monkeypatch.setattr(
         map_module,
         "store_players",
@@ -114,10 +136,16 @@ def test_map_controller_continues_after_item_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stored_players: list[list[object]] = []
+    stored_maps: list[list[object]] = []
     info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(map_module, "MapScraper", _SuccessfulScraper)
     monkeypatch.setattr(map_module, "MapParser", _FailOnceThenSucceedParser)
     monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapQueue)
+    monkeypatch.setattr(
+        map_module,
+        "store_maps",
+        lambda maps: stored_maps.append(maps),
+    )
     monkeypatch.setattr(
         map_module,
         "store_players",
@@ -136,6 +164,7 @@ def test_map_controller_continues_after_item_failure(
     assert controller.state.failed == [(1, "No player kills logged.")]
     assert controller.state.processed == [2]
     assert controller.state.processing == [1, 2]
+    assert len(stored_maps) == 1
     assert len(stored_players) == 1
     assert any(
         call_args[0]
@@ -156,6 +185,12 @@ def test_map_controller_retries_retryable_error_before_succeeding(
         _SuccessfulParser,
     )
     stored_players: list[list[object]] = []
+    stored_maps: list[list[object]] = []
+    monkeypatch.setattr(
+        controller.stage_service,
+        "store_maps",
+        lambda maps: stored_maps.append(maps),
+    )
     monkeypatch.setattr(
         controller.stage_service,
         "store_players",
@@ -175,7 +210,7 @@ def test_map_controller_retries_retryable_error_before_succeeding(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123, 1)
         ],
     )
 
@@ -183,6 +218,7 @@ def test_map_controller_retries_retryable_error_before_succeeding(
 
     assert controller.state.failed == []
     assert controller.state.processed == [1]
+    assert len(stored_maps) == 1
     assert len(stored_players) == 1
     assert len(reset_calls) == 1
     assert any(
@@ -214,7 +250,7 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123, 1)
         ],
     )
 
@@ -222,6 +258,7 @@ def test_map_controller_passes_reset_scraper_to_stage_service(
 
     assert stage_service.scrapers == [first_scraper, reset_scraper]
     assert stage_service.match_ids == [123, 123]
+    assert stage_service.map_orders == [1, 1]
     assert controller.state.failed == []
     assert controller.state.processed == []
 
@@ -262,7 +299,7 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
         controller.state,
         "fetch_with_match_context",
         lambda _limit=25: [
-            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123)
+            (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 123, 1)
         ],
     )
 

--- a/tests/parsers/test_map_parser_regression.py
+++ b/tests/parsers/test_map_parser_regression.py
@@ -95,3 +95,112 @@ def test_parse_map_prefers_visible_over_hidden_metric_cells() -> None:
     assert player.opening_deaths == 2
     assert player.kd_diff == 5
     assert player.fk_diff == 3
+
+
+def test_parse_map_details_extracts_map_metadata() -> None:
+    html = """
+    <html>
+      <body>
+        <div class="match-info-box">
+          <div class="date">2025-08-05 14:30</div>
+          <div class="small-text">Map</div>
+          Train
+          <a href="/team/123/ecstatic">ECSTATIC</a>
+          <div>26</div>
+          <a href="/team/456/liquid">Liquid</a>
+          <div>28</div>
+          <div>Breakdown</div>
+        </div>
+
+        <table class="stats-table totalstats">
+          <thead>
+            <tr>
+              <th class="st-teamname">ECSTATIC</th>
+              <th>Op. K-D</th>
+              <th>MKs</th>
+              <th>KAST</th>
+              <th>1vsX</th>
+              <th>K (hs)</th>
+              <th>A (f)</th>
+              <th>D (t)</th>
+              <th>ADR</th>
+              <th>Swing</th>
+              <th>Rating 2.1</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="st-player"><a href="/player/1234/test-player">TestPlayer</a></td>
+              <td class="st-opkd">5 : 2</td>
+              <td class="st-mks">3</td>
+              <td class="st-kast">70.0%</td>
+              <td class="st-clutches">1</td>
+              <td class="st-kills">20 (12)</td>
+              <td class="st-assists">6 (2)</td>
+              <td class="st-deaths">15 (3)</td>
+              <td class="st-adr">95.2</td>
+              <td class="st-roundSwing won">+3.00%</td>
+              <td class="st-rating ratingPositive">1.24</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <table class="stats-table totalstats">
+          <thead>
+            <tr>
+              <th class="st-teamname">Liquid</th>
+              <th>Op. K-D</th>
+              <th>MKs</th>
+              <th>KAST</th>
+              <th>1vsX</th>
+              <th>K (hs)</th>
+              <th>A (f)</th>
+              <th>D (t)</th>
+              <th>ADR</th>
+              <th>Swing</th>
+              <th>Rating 2.1</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="st-player"><a href="/player/5678/other-player">OtherPlayer</a></td>
+              <td class="st-opkd">4 : 3</td>
+              <td class="st-mks">2</td>
+              <td class="st-kast">80.0%</td>
+              <td class="st-clutches">0</td>
+              <td class="st-kills">18 (9)</td>
+              <td class="st-assists">5 (1)</td>
+              <td class="st-deaths">13 (2)</td>
+              <td class="st-adr">90.1</td>
+              <td class="st-roundSwing won">+2.00%</td>
+              <td class="st-rating ratingPositive">1.10</td>
+            </tr>
+          </tbody>
+        </table>
+      </body>
+    </html>
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    parser = cast(Any, MapParser())
+    parsed = parser.parse_map_details(
+        soup,
+        map_url="https://www.hltv.org/stats/matches/mapstatsid/204269/liquid-vs-ecstatic",
+        map_id=204269,
+        match_id=1001,
+        map_order=1,
+    )
+
+    assert parsed.map.map_id == 204269
+    assert parsed.map.match_id == 1001
+    assert parsed.map.map_url == (
+        "https://www.hltv.org/stats/matches/mapstatsid/204269/liquid-vs-ecstatic"
+    )
+    assert parsed.map.map_order == 1
+    assert parsed.map.map_name == "Train"
+    assert parsed.map.team1_score == 26
+    assert parsed.map.team2_score == 28
+    assert parsed.map.map_winner == "Liquid"
+    assert parsed.map.date == "2025-08-05 14:30:00"
+    assert parsed.map.data_complete is True
+    assert len(parsed.players) == 2

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 
 import pytest
 
-from cs2_analytics.exceptions import MatchQueueError
 from cs2_analytics import ingestion_state as ingestion_state_package
+from cs2_analytics.exceptions import MatchQueueError
 from cs2_analytics.ingestion_state import MatchIngestionState
 from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
 from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
@@ -142,18 +142,24 @@ def test_map_ingestion_state_queues_parent_match_context(
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         source="match_parser",
         match_id=1,
+        map_order=1,
     )
 
     assert cursor.execute_query is not None
     assert "map_ingestion_state" in cursor.execute_query
     assert "match_id" in cursor.execute_query
+    assert "map_order" in cursor.execute_query
     assert "match_id = COALESCE(EXCLUDED.match_id, map_ingestion_state.match_id)" in (
         cursor.execute_query
     )
+    assert "map_order = COALESCE(EXCLUDED.map_order, map_ingestion_state.map_order)" in (
+        cursor.execute_query
+    )
     assert cursor.execute_values is not None
-    assert cursor.execute_values[:5] == (
+    assert cursor.execute_values[:6] == (
         1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
+        1,
         1,
         "match_parser",
         0,

--- a/tests/stage_services/test_map_stage_service.py
+++ b/tests/stage_services/test_map_stage_service.py
@@ -1,4 +1,12 @@
+from dataclasses import dataclass
+
 from cs2_analytics.stage_services import MapStageService
+
+
+@dataclass(frozen=True)
+class _ParsedMap:
+    map: object
+    players: list[object]
 
 
 class _FakeScraper:
@@ -11,13 +19,22 @@ class _FakeScraper:
 
 
 class _FakeParser:
-    def __init__(self, players: list[object]) -> None:
+    def __init__(self, players: list[object], map_obj: object | None = None) -> None:
         self.players = players
-        self.calls: list[tuple[str, int]] = []
+        self.map_obj = map_obj or object()
+        self.calls: list[tuple[str, int, int | None, int | None]] = []
 
-    def parse_map(self, _soup: object, map_url: str, map_id: int) -> list[object]:
-        self.calls.append((map_url, map_id))
-        return self.players
+    def parse_map_details(
+        self,
+        _soup: object,
+        map_url: str,
+        map_id: int,
+        *,
+        match_id: int | None,
+        map_order: int | None,
+    ) -> _ParsedMap:
+        self.calls.append((map_url, map_id, match_id, map_order))
+        return _ParsedMap(map=self.map_obj, players=self.players)
 
 
 class _FakeMapState:
@@ -37,12 +54,15 @@ class _FakeMapState:
 
 
 def test_map_stage_service_processes_success() -> None:
+    stored_maps: list[list[object]] = []
     stored_players: list[list[object]] = []
+    parsed_map = object()
     players = [object()]
     map_state = _FakeMapState()
-    parser = _FakeParser(players=players)
+    parser = _FakeParser(players=players, map_obj=parsed_map)
     service = MapStageService(
         parser=parser,
+        store_maps=lambda maps: stored_maps.append(maps),
         store_players=lambda parsed_players: stored_players.append(parsed_players),
         map_state=map_state,
     )
@@ -51,24 +71,29 @@ def test_map_stage_service_processes_success() -> None:
         1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
+        match_id=101,
+        map_order=1,
     )
 
     assert result.succeeded is True
     assert result.status == "processed"
     assert parser.calls == [
-        ("https://www.hltv.org/stats/matches/mapstatsid/1/test", 1)
+        ("https://www.hltv.org/stats/matches/mapstatsid/1/test", 1, 101, 1)
     ]
     assert map_state.processing == []
     assert map_state.processed == [1]
     assert map_state.failed == []
+    assert stored_maps == [[parsed_map]]
     assert stored_players == [players]
 
 
 def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None:
+    stored_maps: list[list[object]] = []
     stored_players: list[list[object]] = []
     map_state = _FakeMapState()
     service = MapStageService(
         parser=_FakeParser(players=[]),
+        store_maps=lambda maps: stored_maps.append(maps),
         store_players=lambda parsed_players: stored_players.append(parsed_players),
         map_state=map_state,
     )
@@ -77,6 +102,8 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
         1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=_FakeScraper(),
+        match_id=101,
+        map_order=1,
     )
 
     assert result.succeeded is False
@@ -85,6 +112,7 @@ def test_map_stage_service_marks_failed_when_parser_returns_no_players() -> None
     assert map_state.processing == []
     assert map_state.processed == []
     assert map_state.failed == [(1, "Parsing returned no player records")]
+    assert stored_maps == []
     assert stored_players == []
 
 
@@ -92,6 +120,7 @@ def test_map_stage_service_processes_with_attempt_scraper() -> None:
     attempt_scraper = _FakeScraper()
     service = MapStageService(
         parser=_FakeParser(players=[object()]),
+        store_maps=lambda _maps: None,
         store_players=lambda _players: None,
         map_state=_FakeMapState(),
     )
@@ -100,6 +129,8 @@ def test_map_stage_service_processes_with_attempt_scraper() -> None:
         1,
         "https://www.hltv.org/stats/matches/mapstatsid/1/test",
         scraper=attempt_scraper,
+        match_id=101,
+        map_order=1,
     )
 
     assert attempt_scraper.urls == [

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -47,7 +47,7 @@ class _FakeMatchState:
 
 class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[int | str, str, str, int | None]] = []
+        self.queued: list[tuple[int | str, str, str, int | None, int | None]] = []
 
     def queue(
         self,
@@ -55,8 +55,9 @@ class _FakeFollowupState:
         url: str,
         source: str = "unknown",
         match_id: int | None = None,
+        map_order: int | None = None,
     ) -> None:
-        self.queued.append((item_id, url, source, match_id))
+        self.queued.append((item_id, url, source, match_id, map_order))
 
 
 def test_match_stage_service_processes_success_and_queues_followups() -> None:
@@ -93,6 +94,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
             "https://www.hltv.org/stats/matches/mapstatsid/1/test",
             "match_parser",
             1,
+            1,
         )
     ]
     assert demo_state.queued == [
@@ -100,6 +102,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
             "demo-1",
             "https://www.hltv.org/download/demo/test",
             "match_parser",
+            None,
             None,
         )
     ]

--- a/tests/stage_services/test_stage_service_shells.py
+++ b/tests/stage_services/test_stage_service_shells.py
@@ -77,11 +77,13 @@ def test_map_stage_service_records_constructor_dependencies() -> None:
 
     service = MapStageService(
         parser=parser,
+        store_maps=_store_stub,
         store_players=_store_stub,
         map_state=map_state,
     )
 
     assert service.parser is parser
+    assert service.store_maps is _store_stub
     assert service.store_players is _store_stub
     assert service.map_state is map_state
 

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -162,3 +162,29 @@ def test_schema_defines_ingestion_state_tables() -> None:
     map_table_sql = _table_definition(schema_sql, "map_ingestion_state")
     assert "map_id INT PRIMARY KEY" in map_table_sql
     assert "match_id INT REFERENCES matches(match_id) ON DELETE CASCADE" in map_table_sql
+    assert "map_order INT CHECK" in map_table_sql
+
+
+def test_schema_defines_map_storage_contract() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+    table_sql = _table_definition(schema_sql, "maps")
+
+    required_columns = (
+        "map_id INT PRIMARY KEY",
+        "match_id INT NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE",
+        "map_url TEXT UNIQUE NOT NULL",
+        "map_order INT NOT NULL CHECK",
+        "map_name TEXT NOT NULL",
+        "team1_score INT NOT NULL CHECK (team1_score >= 0)",
+        "team2_score INT NOT NULL CHECK (team2_score >= 0)",
+        "map_winner TEXT NOT NULL",
+        "date TIMESTAMP NOT NULL",
+        "inserted_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
+        "last_scraped_at TIMESTAMPTZ",
+        "last_updated_at TIMESTAMPTZ",
+        "data_complete BOOLEAN NOT NULL DEFAULT FALSE",
+        "UNIQUE (match_id, map_order)",
+    )
+
+    for column_sql in required_columns:
+        assert column_sql in table_sql

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -1,0 +1,76 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cs2_analytics.exceptions import MapStorageError
+from cs2_analytics.models.map import Map
+from cs2_analytics.storage import map_storage as map_storage_module
+
+
+class _RecordingCursor:
+    def __init__(self, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self.executed: list[tuple[str, dict[str, object]]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: dict[str, object]) -> None:
+        if self.should_fail:
+            raise RuntimeError("insert failed")
+        self.executed.append((query, params))
+
+
+class _FakeDb:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _RecordingCursor:
+        return self.cursor
+
+
+def _map() -> Map:
+    now = datetime.now(UTC)
+    return Map(
+        map_id=204269,
+        match_id=1001,
+        map_url="https://www.hltv.org/stats/matches/mapstatsid/204269/test",
+        map_name="Train",
+        map_order=1,
+        team1_score=26,
+        team2_score=28,
+        map_winner="Liquid",
+        date="2025-08-05 14:30:00",
+        inserted_at=now,
+        last_scraped_at=now,
+        last_updated_at=now,
+        data_complete=True,
+    )
+
+
+def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+
+    map_storage_module.store_maps([_map()])
+
+    query, params = cursor.executed[0]
+    assert "map_url" in query
+    assert "map_order" in query
+    assert "map_winner" in query
+    assert "inserted_at" in query
+    assert params["map_id"] == 204269
+    assert params["match_id"] == 1001
+    assert params["map_order"] == 1
+    assert params["map_winner"] == "Liquid"
+
+
+def test_store_maps_wraps_database_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _RecordingCursor(should_fail=True)
+    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+
+    with pytest.raises(MapStorageError, match="Failed to store map records."):
+        map_storage_module.store_maps([_map()])


### PR DESCRIPTION
## Description

* Implements the Phase 3.5 map storage contract so the map stage can persist one relational `maps` row per played map before writing player rows.

## Changes

- Updates the active `maps` schema with `map_url`, `map_order`, `map_winner`, required score/date fields, audit timestamps, and `UNIQUE (match_id, map_order)`.
- Adds `map_order` discovery context to `map_ingestion_state`.
- Updates the `Map` model and `store_maps` to match the active schema.
- Adds `MapStorageError`.
- Extends `MapParser` with `parse_map_details`, returning map metadata plus players.
- Queues discovered maps with `map_order` from match map-link order.
- Wires `MapStageService` and `MapController` to persist map rows before player rows.
- Updates tests for schema, storage, parser, discovery context, and map-stage behavior.
- Marks the map storage contract branch complete in `docs/backlog.md`.

## Verification

- `.\.venv\Scripts\ruff.exe check ...`
- `.\.venv\Scripts\python.exe -m pytest`

Expected result: lint passes and pytest reports `59 passed, 3 skipped`.