### PR TITLE
Phase 3.5: Strengthen Storage Upsert Idempotency

### DIFF
--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -24,7 +24,21 @@ def store_matches(matches: list[Match]) -> None:
         %(last_inserted_at)s, %(last_scraped_at)s, %(last_updated_at)s, %(data_complete)s
     )
     ON CONFLICT (match_id) DO UPDATE SET
-        last_updated_at = EXCLUDED.last_updated_at;
+        match_url = EXCLUDED.match_url,
+        team1 = EXCLUDED.team1,
+        team2 = EXCLUDED.team2,
+        score1 = EXCLUDED.score1,
+        score2 = EXCLUDED.score2,
+        winner = EXCLUDED.winner,
+        event = EXCLUDED.event,
+        match_type = EXCLUDED.match_type,
+        forfeit = EXCLUDED.forfeit,
+        date = EXCLUDED.date,
+        map_links = EXCLUDED.map_links,
+        demo_links = EXCLUDED.demo_links,
+        last_scraped_at = EXCLUDED.last_scraped_at,
+        last_updated_at = EXCLUDED.last_updated_at,
+        data_complete = EXCLUDED.data_complete;
     """
 
     conn = db.get_connection()

--- a/cs2_analytics/storage/player_storage.py
+++ b/cs2_analytics/storage/player_storage.py
@@ -25,7 +25,11 @@ def store_players(players: list[Player]) -> None:
         %(kast)s, %(kd_diff)s, %(adr)s, %(fk_diff)s, %(round_swing)s, %(rating)s,
         %(last_inserted_at)s, %(last_scraped_at)s, %(last_updated_at)s, %(data_complete)s
     )
-    ON CONFLICT (player_id, map_id) DO UPDATE SET
+    ON CONFLICT (map_id, player_id) DO UPDATE SET
+        player_name = EXCLUDED.player_name,
+        player_url = EXCLUDED.player_url,
+        map_name = EXCLUDED.map_name,
+        team_name = EXCLUDED.team_name,
         kills = EXCLUDED.kills,
         headshots = EXCLUDED.headshots,
         assists = EXCLUDED.assists,
@@ -42,6 +46,7 @@ def store_players(players: list[Player]) -> None:
         fk_diff = EXCLUDED.fk_diff,
         round_swing = EXCLUDED.round_swing,
         rating = EXCLUDED.rating,
+        last_scraped_at = EXCLUDED.last_scraped_at,
         last_updated_at = EXCLUDED.last_updated_at,
         data_complete = EXCLUDED.data_complete;
     """

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -150,21 +150,21 @@ remains the active schema source of truth.
 - [x] Decide whether `map_order`, `map_name`, map scores, and map winner come
       from match pages, map pages, or both
 - [x] Ensure the map stage writes one row per played map to `maps`
-- [ ] Keep `players` at the grain of one row per player per map
+- [x] Keep `players` at the grain of one row per player per map
 - [x] Make `cs2_analytics/storage/map_storage.py` match the active
       `cs2_analytics/storage/schema.sql`
 - [x] Update `store_maps` to upsert all trusted map fields, or remove stale map
       storage code if it no longer has a role
-- [ ] Update `store_matches` conflict behavior to refresh trusted parsed fields,
+- [x] Update `store_matches` conflict behavior to refresh trusted parsed fields,
       not only `last_updated_at`
-- [ ] Decide which player context fields should refresh on rerun, such as
+- [x] Decide which player context fields should refresh on rerun, such as
       `player_name`, `player_url`, `map_name`, `team_name`, and
       `last_scraped_at`
-- [ ] Update `store_players` conflict behavior to refresh the agreed trusted
+- [x] Update `store_players` conflict behavior to refresh the agreed trusted
       fields
-- [ ] Keep `matches.map_links` and `matches.demo_links` as trace/debug fields
+- [x] Keep `matches.map_links` and `matches.demo_links` as trace/debug fields
       only if useful; dbt should not parse Python-list strings
-- [ ] Add storage idempotency tests for match, map, and player upserts
+- [x] Add storage idempotency tests for match, map, and player upserts
 - [ ] Add relationship readiness tests proving `players.map_id` joins to
       `maps.map_id` and `maps.match_id` joins to `matches.match_id`
 - [ ] Add a focused integration-style test for match discovery -> map discovery
@@ -199,9 +199,22 @@ relational ingestion outputs without starting dbt models yet.
    active `maps` table includes map audit fields and `map_url`, and the map
    stage persists the map row before player rows.
 
-3. [ ] `phase3.5-storage-upsert-idempotency`
+3. [x] `phase3.5-storage-upsert-idempotency`
    Strengthen match, map, and player upserts so reruns refresh trusted fields
    without duplicating rows or overwriting first-seen style timestamps.
+
+   Match storage now refreshes trusted parsed match fields on conflict while
+   preserving `last_inserted_at`. Player storage refreshes the agreed context
+   fields, metrics, scrape/update timestamps, and completeness flag on conflict
+   while preserving `last_inserted_at`. Map storage already had the same update
+   shape, and storage tests now assert the idempotent upsert contracts for all
+   three parsed source tables.
+
+   Audit-field naming cleanup is intentionally deferred to a later focused
+   schema/model/storage branch. That branch should normalize parsed source
+   tables toward `inserted_at`, `last_scraped_at`, `updated_at`, and
+   `data_complete`, replacing current mixed names such as `last_inserted_at`
+   and `last_updated_at`.
 
 4. [ ] `phase3.5-relationship-readiness-tests`
    Add focused tests that prove `players -> maps -> matches` joins work and
@@ -219,7 +232,7 @@ relational ingestion outputs without starting dbt models yet.
 
 - [ ] `matches`, `maps`, and `players` have stable grains
 - [ ] Map-player-match relationships are queryable without parsing strings
-- [ ] Storage upserts are duplicate-safe and refresh trusted fields
+- [x] Storage upserts are duplicate-safe and refresh trusted fields
 - [ ] Tests pass
 - [ ] dbt can start with clean staging models: `stg_matches`, `stg_maps`, and
       `stg_players`

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -51,6 +51,11 @@ def _map() -> Map:
     )
 
 
+def _conflict_update_clause(query: str) -> str:
+    assert "ON CONFLICT" in query, "Expected storage query to define an upsert conflict clause."
+    return query.split("ON CONFLICT", maxsplit=1)[1]
+
+
 def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     cursor = _RecordingCursor()
     monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
@@ -77,7 +82,7 @@ def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
     map_storage_module.store_maps([_map()])
 
     query, _params = cursor.executed[0]
-    conflict_update = query.split("ON CONFLICT", maxsplit=1)[1]
+    conflict_update = _conflict_update_clause(query)
 
     for field_name in (
         "match_id",

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -68,6 +68,35 @@ def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) 
     assert params["map_winner"] == "Liquid"
 
 
+def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+
+    map_storage_module.store_maps([_map()])
+
+    query, _params = cursor.executed[0]
+    conflict_update = query.split("ON CONFLICT", maxsplit=1)[1]
+
+    for field_name in (
+        "match_id",
+        "map_url",
+        "map_order",
+        "map_name",
+        "team1_score",
+        "team2_score",
+        "map_winner",
+        "date",
+        "last_scraped_at",
+        "last_updated_at",
+        "data_complete",
+    ):
+        assert f"{field_name} = EXCLUDED.{field_name}" in conflict_update
+
+    assert "inserted_at = EXCLUDED.inserted_at" not in conflict_update
+
+
 def test_store_maps_wraps_database_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     cursor = _RecordingCursor(should_fail=True)
     monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))

--- a/tests/storage/test_match_storage.py
+++ b/tests/storage/test_match_storage.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cs2_analytics.models.match import Match
+from cs2_analytics.storage import match_storage as match_storage_module
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict[str, object]]] = []
+
+    def execute(self, query: str, params: dict[str, object]) -> None:
+        self.executed.append((query, params))
+
+
+class _RecordingConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor_obj = cursor
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self) -> _RecordingCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class _FakeDb:
+    def __init__(self, conn: _RecordingConnection) -> None:
+        self.conn = conn
+        self.released = False
+
+    def get_connection(self) -> _RecordingConnection:
+        return self.conn
+
+    def release_connection(self, conn: _RecordingConnection) -> None:
+        self.released = True
+
+
+def _match() -> Match:
+    now = datetime.now(UTC)
+    return Match(
+        match_id=1,
+        match_url="https://www.hltv.org/matches/1/test",
+        map_links=[(11, "https://www.hltv.org/stats/matches/mapstatsid/11/test")],
+        demo_links=[("demo-1", "https://www.hltv.org/download/demo/demo-1/test")],
+        team1="A",
+        team2="B",
+        score1=16,
+        score2=10,
+        winner="A",
+        event="Event",
+        match_type="bo1",
+        forfeit=False,
+        date="2026-01-01",
+        last_inserted_at=now,
+        last_scraped_at=now,
+        last_updated_at=now,
+        data_complete=True,
+    )
+
+
+def _conflict_update_clause(query: str) -> str:
+    return query.split("ON CONFLICT", maxsplit=1)[1]
+
+
+def test_store_matches_refreshes_trusted_fields_on_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    conn = _RecordingConnection(cursor)
+    fake_db = _FakeDb(conn)
+    monkeypatch.setattr(match_storage_module, "db", fake_db)
+
+    match_storage_module.store_matches([_match()])
+
+    query, params = cursor.executed[0]
+    conflict_update = _conflict_update_clause(query)
+
+    for field_name in (
+        "match_url",
+        "team1",
+        "team2",
+        "score1",
+        "score2",
+        "winner",
+        "event",
+        "match_type",
+        "forfeit",
+        "date",
+        "map_links",
+        "demo_links",
+        "last_scraped_at",
+        "last_updated_at",
+        "data_complete",
+    ):
+        assert f"{field_name} = EXCLUDED.{field_name}" in conflict_update
+
+    assert "last_inserted_at = EXCLUDED.last_inserted_at" not in conflict_update
+    assert params["map_links"] == str(_match().map_links)
+    assert params["demo_links"] == str(_match().demo_links)
+    assert conn.committed is True
+    assert conn.rolled_back is False
+    assert fake_db.released is True
+

--- a/tests/storage/test_match_storage.py
+++ b/tests/storage/test_match_storage.py
@@ -66,6 +66,7 @@ def _match() -> Match:
 
 
 def _conflict_update_clause(query: str) -> str:
+    assert "ON CONFLICT" in query, "Expected storage query to define an upsert conflict clause."
     return query.split("ON CONFLICT", maxsplit=1)[1]
 
 
@@ -107,4 +108,3 @@ def test_store_matches_refreshes_trusted_fields_on_conflict(
     assert conn.committed is True
     assert conn.rolled_back is False
     assert fake_db.released is True
-

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -61,6 +61,7 @@ def _player() -> Player:
 
 
 def _conflict_update_clause(query: str) -> str:
+    assert "ON CONFLICT" in query, "Expected storage query to define an upsert conflict clause."
     return query.split("ON CONFLICT", maxsplit=1)[1]
 
 
@@ -106,4 +107,3 @@ def test_store_players_refreshes_context_and_metrics_on_conflict(
     assert "last_inserted_at = EXCLUDED.last_inserted_at" not in conflict_update
     assert params["map_id"] == 100
     assert params["player_id"] == 200
-

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -1,0 +1,109 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from cs2_analytics.models.player import Player
+from cs2_analytics.storage import player_storage as player_storage_module
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict[str, object]]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: dict[str, object]) -> None:
+        self.executed.append((query, params))
+
+
+class _FakeDb:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _RecordingCursor:
+        return self.cursor
+
+
+def _player() -> Player:
+    now = datetime.now(UTC)
+    return Player(
+        map_id=100,
+        player_id=200,
+        player_name="Player",
+        player_url="https://www.hltv.org/player/200/player",
+        map_name="Train",
+        team_name="Team",
+        kills=20,
+        headshots=12,
+        assists=5,
+        flash_assists=1,
+        deaths=13,
+        traded_deaths=2,
+        opening_kills=4,
+        opening_deaths=3,
+        multi_kills=6,
+        clutches_won=1,
+        kast=75.0,
+        kd_diff=7,
+        adr=90.5,
+        fk_diff=1,
+        round_swing=0.07,
+        rating=1.31,
+        last_inserted_at=now,
+        last_scraped_at=now,
+        last_updated_at=now,
+        data_complete=True,
+    )
+
+
+def _conflict_update_clause(query: str) -> str:
+    return query.split("ON CONFLICT", maxsplit=1)[1]
+
+
+def test_store_players_refreshes_context_and_metrics_on_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(player_storage_module, "db", _FakeDb(cursor))
+
+    player_storage_module.store_players([_player()])
+
+    query, params = cursor.executed[0]
+    conflict_update = _conflict_update_clause(query)
+
+    assert "ON CONFLICT (map_id, player_id)" in query
+    for field_name in (
+        "player_name",
+        "player_url",
+        "map_name",
+        "team_name",
+        "kills",
+        "headshots",
+        "assists",
+        "flash_assists",
+        "deaths",
+        "traded_deaths",
+        "opening_kills",
+        "opening_deaths",
+        "multi_kills",
+        "clutches_won",
+        "kast",
+        "kd_diff",
+        "adr",
+        "fk_diff",
+        "round_swing",
+        "rating",
+        "last_scraped_at",
+        "last_updated_at",
+        "data_complete",
+    ):
+        assert f"{field_name} = EXCLUDED.{field_name}" in conflict_update
+
+    assert "last_inserted_at = EXCLUDED.last_inserted_at" not in conflict_update
+    assert params["map_id"] == 100
+    assert params["player_id"] == 200
+


### PR DESCRIPTION
## Summary

- refresh trusted parsed fields when match rows are reprocessed
- refresh player context fields and metrics when player-map rows are reprocessed
- preserve first-insert audit timestamps during match, map, and player upserts
- add focused storage tests for match, map, and player upsert idempotency
- update the Phase 3.5 backlog notes and defer audit-field renaming to a later schema cleanup branch

## Verification

- `.venv\Scripts\python.exe -m pytest tests/storage/test_match_storage.py tests/storage/test_map_storage.py tests/storage/test_player_storage.py tests/storage/test_storage_exceptions.py`
- `.venv\Scripts\python.exe -m pytest`

Result: `62 passed, 3 skipped`