### PR TITLE
Phase 3.5: Add Relationship Readiness Tests

### DIFF
--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -101,7 +101,7 @@ CREATE TABLE maps (
 
 -- ✅ Players Table (Previously `players_stats`)
 CREATE TABLE players (
-    map_id INT,
+    map_id INT NOT NULL REFERENCES maps(map_id) ON DELETE CASCADE,
     player_id INT,
     player_name TEXT NOT NULL,
     player_url TEXT,

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -165,7 +165,7 @@ remains the active schema source of truth.
 - [x] Keep `matches.map_links` and `matches.demo_links` as trace/debug fields
       only if useful; dbt should not parse Python-list strings
 - [x] Add storage idempotency tests for match, map, and player upserts
-- [ ] Add relationship readiness tests proving `players.map_id` joins to
+- [x] Add relationship readiness tests proving `players.map_id` joins to
       `maps.map_id` and `maps.match_id` joins to `matches.match_id`
 - [ ] Add a focused integration-style test for match discovery -> map discovery
       -> map/player persistence
@@ -216,7 +216,7 @@ relational ingestion outputs without starting dbt models yet.
    `data_complete`, replacing current mixed names such as `last_inserted_at`
    and `last_updated_at`.
 
-4. [ ] `phase3.5-relationship-readiness-tests`
+4. [x] `phase3.5-relationship-readiness-tests`
    Add focused tests that prove `players -> maps -> matches` joins work and
    that dbt will not need to parse stringified link fields.
 
@@ -231,7 +231,7 @@ relational ingestion outputs without starting dbt models yet.
 ### dbt entry criteria
 
 - [ ] `matches`, `maps`, and `players` have stable grains
-- [ ] Map-player-match relationships are queryable without parsing strings
+- [x] Map-player-match relationships are queryable without parsing strings
 - [x] Storage upserts are duplicate-safe and refresh trusted fields
 - [ ] Tests pass
 - [ ] dbt can start with clean staging models: `stg_matches`, `stg_maps`, and

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -2,9 +2,11 @@ import sys
 import unittest
 from datetime import UTC, datetime
 
+from cs2_analytics.models.map import Map
 from cs2_analytics.models.match import Match
 from cs2_analytics.models.player import Player
 from cs2_analytics.storage.database import Database
+from cs2_analytics.storage.map_storage import store_maps
 from cs2_analytics.storage.match_storage import store_matches
 from cs2_analytics.storage.player_storage import store_players
 
@@ -83,6 +85,40 @@ class TestDatabase(unittest.TestCase):
 
         now = datetime.now(UTC)
 
+        test_match = Match(
+            match_id=999998,
+            match_url="https://www.hltv.org/matches/999998/test-player-match",
+            map_links=[(999999, "https://www.hltv.org/matches/999998/test-map")],
+            demo_links=[],
+            team1="Test Team A",
+            team2="Test Team B",
+            score1=16,
+            score2=10,
+            winner="Test Team A",
+            event="Test Event",
+            match_type="BO1",
+            forfeit=False,
+            date="2025-03-15",
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
+        test_map = Map(
+            map_id=999999,
+            match_id=999998,
+            map_url="https://www.hltv.org/stats/matches/mapstatsid/999999/test-map",
+            map_name="de_dust2",
+            map_order=1,
+            team1_score=16,
+            team2_score=10,
+            map_winner="Test Team A",
+            date="2025-03-15",
+            inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
         test_player = Player(
             map_id=999999,
             player_id=888888,
@@ -117,8 +153,10 @@ class TestDatabase(unittest.TestCase):
         print(f"🟡 Player object as dictionary: {test_player.to_dict()}")
         sys.stdout.flush()
 
-        print("🟡 Inserting test player into database...")
+        print("🟡 Inserting parent match, map, and test player into database...")
         sys.stdout.flush()
+        store_matches([test_match])
+        store_maps([test_map])
         store_players([test_player])
 
         print("🔍 Fetching player from database...")

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -188,3 +188,11 @@ def test_schema_defines_map_storage_contract() -> None:
 
     for column_sql in required_columns:
         assert column_sql in table_sql
+
+
+def test_schema_defines_player_map_relationship() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+    table_sql = _table_definition(schema_sql, "players")
+
+    assert "map_id INT NOT NULL REFERENCES maps(map_id) ON DELETE CASCADE" in table_sql
+    assert "PRIMARY KEY (map_id, player_id)" in table_sql

--- a/tests/storage/test_relationship_readiness.py
+++ b/tests/storage/test_relationship_readiness.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+SCHEMA_PATH = Path(__file__).parents[2] / "cs2_analytics" / "storage" / "schema.sql"
+
+
+RELATIONSHIP_READINESS_QUERY = """
+SELECT
+    p.map_id,
+    p.player_id,
+    p.player_name,
+    m.match_id,
+    m.map_order,
+    m.map_name,
+    mt.team1,
+    mt.team2,
+    mt.winner
+FROM players AS p
+JOIN maps AS m
+    ON p.map_id = m.map_id
+JOIN matches AS mt
+    ON m.match_id = mt.match_id;
+"""
+
+
+def _table_definition(schema_sql: str, table_name: str) -> str:
+    start_marker = f"CREATE TABLE {table_name} ("
+    start_index = schema_sql.index(start_marker)
+    end_index = schema_sql.index("\n);", start_index)
+    return schema_sql[start_index:end_index]
+
+
+def test_schema_defines_normalized_player_map_match_relationships() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+
+    matches_table = _table_definition(schema_sql, "matches")
+    maps_table = _table_definition(schema_sql, "maps")
+    players_table = _table_definition(schema_sql, "players")
+
+    assert "match_id INT PRIMARY KEY" in matches_table
+    assert "map_id INT PRIMARY KEY" in maps_table
+    assert "match_id INT NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE" in (
+        maps_table
+    )
+    assert "map_id INT NOT NULL REFERENCES maps(map_id) ON DELETE CASCADE" in (
+        players_table
+    )
+    assert "PRIMARY KEY (map_id, player_id)" in players_table
+
+
+def test_maps_table_does_not_own_player_relationships() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+    maps_table = _table_definition(schema_sql, "maps")
+
+    assert "player_id" not in maps_table
+    assert "REFERENCES players" not in maps_table
+
+
+def test_relationship_readiness_query_does_not_parse_trace_link_fields() -> None:
+    assert "JOIN maps AS m" in RELATIONSHIP_READINESS_QUERY
+    assert "ON p.map_id = m.map_id" in RELATIONSHIP_READINESS_QUERY
+    assert "JOIN matches AS mt" in RELATIONSHIP_READINESS_QUERY
+    assert "ON m.match_id = mt.match_id" in RELATIONSHIP_READINESS_QUERY
+    assert "map_links" not in RELATIONSHIP_READINESS_QUERY
+    assert "demo_links" not in RELATIONSHIP_READINESS_QUERY


### PR DESCRIPTION
## Summary

- Enforce `players.map_id` as a foreign key to `maps.map_id`
- Add relationship-readiness tests for the dbt-ready `players -> maps -> matches` join path
- Assert that `maps` does not own player relationships
- Update the database storage smoke test to insert parent match/map rows before player rows
- Mark the Phase 3.5 relationship-readiness branch item complete in the backlog

## Verification

- `.\.venv\Scripts\python.exe -m pytest tests/storage/test_initialize_db.py tests/storage/test_relationship_readiness.py`
- `.\.venv\Scripts\python.exe -m ruff check tests/storage/test_initialize_db.py tests/storage/test_relationship_readiness.py tests/storage/test_database.py`

## Notes

Full `python -m pytest` currently has one local DB-backed failure because the local PostgreSQL schema is stale and its `maps` table lacks `map_url`. The active `schema.sql` has the expected column.