### PR TITLE
Phase 3.5: Clean Up Database Schema Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,25 @@ Ensure PostgreSQL is installed and configure database credentials through your l
 Run:
 
 ```sh
-python -m cs2_analytics.storage.initialize_db
+python manage_db.py --init
 ```
+
+Running `python manage_db.py` with no flags also uses the safe init path.
+
+For first-time local setup when the configured PostgreSQL database does not
+exist yet:
+
+```sh
+python manage_db.py --create-database
+```
+
+To explicitly wipe application tables:
+
+```sh
+python manage_db.py --wipe
+```
+
+The wipe command asks for `y` confirmation before dropping tables.
 
 ### 5. Run the Pipeline
 

--- a/cs2_analytics/storage/__init__.py
+++ b/cs2_analytics/storage/__init__.py
@@ -1,16 +1,18 @@
 """
-The `storage` package provides a centralized interface for all database-related
-interactions including:
+The `storage` package provides database connection helpers and persistence modules.
 
-- Database connections and session management
-- Database connection helpers and persistence modules
-- Data models representing persistent entities
+The shared `db` instance is loaded lazily to avoid opening a PostgreSQL connection
+when importing setup-only modules such as `cs2_analytics.storage.initialize_db`.
 """
-
-from .db_instance import db
 
 __all__ = [
     "db",
-    "Match",
-    "Player",
 ]
+
+
+def __getattr__(name: str):
+    if name == "db":
+        from .db_instance import db
+
+        return db
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cs2_analytics/storage/database.py
+++ b/cs2_analytics/storage/database.py
@@ -1,4 +1,4 @@
-"""Handles all database interactions, including connection management and data storage."""
+"""Handles database connections and cursor lifecycle."""
 
 from contextlib import contextmanager
 
@@ -31,7 +31,7 @@ def _initialize_db_pool() -> psycopg2.pool.SimpleConnectionPool | None:
             host=DB_HOST,
             port=DB_PORT,
         )
-        logger.info("✅ PostgreSQL connection pool initialized successfully.")
+        logger.info("PostgreSQL connection pool initialized successfully.")
     except (psycopg2.pool.PoolError, psycopg2.Error) as e:
         DB_POOL = None
         raise DatabaseConnectionError(
@@ -42,24 +42,19 @@ def _initialize_db_pool() -> psycopg2.pool.SimpleConnectionPool | None:
 
 
 class Database:
-    """Handles all database interactions, including connection management and data storage."""
-
-    _indexes_ensured = False
+    """Handles database connection pooling and cursor management."""
 
     def __init__(self):
-        """Initialize database connection."""
+        """Initialize the database connection pool."""
         self.pool = _initialize_db_pool()
         if self.pool is None:
             raise DatabaseConnectionError("Database connection pool is not available.")
-
-        if not Database._indexes_ensured:
-            Database._indexes_ensured = self.create_indexes()
 
     def get_connection(self):
         """Retrieves a database connection from the pool."""
         try:
             conn = self.pool.getconn()
-            logger.debug("✅ Retrieved database connection from pool.")
+            logger.debug("Retrieved database connection from pool.")
             return conn
         except (psycopg2.pool.PoolError, psycopg2.Error) as e:
             raise DatabaseConnectionError(
@@ -70,7 +65,7 @@ class Database:
         """Releases a database connection back to the pool."""
         if self.pool and conn:
             self.pool.putconn(conn)
-            logger.debug("🔄 Database connection released back to the pool.")
+            logger.debug("Database connection released back to the pool.")
 
     def close_db_pool(self):
         """Closes all connections in the database pool."""
@@ -79,11 +74,11 @@ class Database:
         if self.pool:
             self.pool.closeall()
             DB_POOL = None
-            logger.info("❌ Database connection pool closed.")
+            logger.info("Database connection pool closed.")
 
     @contextmanager
     def get_cursor(self):
-        """Yields a DB cursor and handles commit/rollback and connection release."""
+        """Yield a DB cursor and handle commit, rollback, and connection release."""
         conn = self.get_connection()
         if conn is None:
             raise DatabaseConnectionError(
@@ -101,7 +96,7 @@ class Database:
             self.release_connection(conn)
 
     def create_indexes(self) -> bool:
-        """Ensures necessary indexes exist for optimized queries."""
+        """Create schema indexes during explicit database setup."""
         conn = self.get_connection()
         if conn is None:
             return False
@@ -110,27 +105,30 @@ class Database:
             cur = conn.cursor()
             cur.execute(
                 """
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS traded_deaths INT;
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS opening_kills INT;
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS opening_deaths INT;
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS multi_kills INT;
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS clutches_won INT;
-                ALTER TABLE players ADD COLUMN IF NOT EXISTS round_swing FLOAT;
-
                 CREATE INDEX IF NOT EXISTS idx_matches_date ON matches (date);
+                CREATE INDEX IF NOT EXISTS idx_maps_match_id ON maps (match_id);
                 CREATE INDEX IF NOT EXISTS idx_players_map_id ON players (map_id);
+                CREATE INDEX IF NOT EXISTS idx_players_player_id ON players (player_id);
                 CREATE INDEX IF NOT EXISTS idx_players_team_name ON players (team_name);
                 CREATE INDEX IF NOT EXISTS idx_player_stats ON players (player_id, map_id);
-            """
+                CREATE INDEX IF NOT EXISTS idx_player_info_team_id ON player_info (team_id);
+                CREATE INDEX IF NOT EXISTS idx_player_transfers_player_id
+                    ON player_transfers (player_id);
+                CREATE INDEX IF NOT EXISTS idx_player_team_history_player_id
+                    ON player_team_history (player_id);
+                CREATE INDEX IF NOT EXISTS idx_match_ingestion_state_pending
+                    ON match_ingestion_state (status, priority DESC, first_seen_at);
+                CREATE INDEX IF NOT EXISTS idx_map_ingestion_state_pending
+                    ON map_ingestion_state (status, priority DESC, first_seen_at);
+                CREATE INDEX IF NOT EXISTS idx_demo_ingestion_state_pending
+                    ON demo_ingestion_state (status, priority DESC, first_seen_at);
+                """
             )
             conn.commit()
-            logger.info("✅ Database indexes ensured.")
+            logger.info("Database indexes created or verified.")
             return True
 
         except Exception as e:
             raise DatabaseOperationError("Failed to create database indexes.") from e
         finally:
             self.release_connection(conn)
-
-
-

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -1,38 +1,151 @@
-"""This script initializes the database schema by executing the schema.sql file."""
+"""Database setup commands for schema creation and explicit wipes."""
 
+import argparse
 import os
 
 import psycopg2
+from psycopg2 import sql
 
 from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
 from cs2_analytics.exceptions import DatabaseOperationError
+from cs2_analytics.storage.database import Database
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
 
+TABLES_TO_WIPE = (
+    "demo_files",
+    "demo_ingestion_state",
+    "map_ingestion_state",
+    "match_ingestion_state",
+    "player_metrics",
+    "player_transfers",
+    "player_aliases",
+    "player_team_history",
+    "players",
+    "maps",
+    "matches",
+    "teams",
+    "player_info",
+    "scrape_runs",
+)
 
-def initialize_database():
-    """Executes the schema.sql file to create/update the database schema."""
+
+def _connection_kwargs(dbname: str) -> dict[str, str]:
+    return {
+        "dbname": dbname,
+        "user": DB_USER,
+        "password": DB_PASS,
+        "host": DB_HOST,
+        "port": DB_PORT,
+    }
+
+
+def create_database_if_missing(maintenance_db: str = "postgres") -> None:
+    """Create the configured database when it does not already exist."""
     try:
-        with psycopg2.connect(
-            dbname=DB_NAME,
-            user=DB_USER,
-            password=DB_PASS,
-            host=DB_HOST,
-            port=DB_PORT,
-        ) as conn:
+        with psycopg2.connect(**_connection_kwargs(maintenance_db)) as conn:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_database WHERE datname = %s;",
+                    (DB_NAME,),
+                )
+                if cur.fetchone():
+                    logger.info("Database %s already exists.", DB_NAME)
+                    return
+
+                cur.execute(
+                    sql.SQL("CREATE DATABASE {}").format(sql.Identifier(DB_NAME))
+                )
+                logger.info("Database %s created.", DB_NAME)
+    except Exception as e:
+        raise DatabaseOperationError("Failed to create database.") from e
+
+
+def wipe_database() -> None:
+    """Drop application tables from the configured database."""
+    drop_sql = "\n".join(
+        f"DROP TABLE IF EXISTS {table_name} CASCADE;" for table_name in TABLES_TO_WIPE
+    )
+
+    try:
+        with psycopg2.connect(**_connection_kwargs(DB_NAME)) as conn:
+            with conn.cursor() as cur:
+                cur.execute(drop_sql)
+        logger.info("Database tables wiped successfully.")
+    except Exception as e:
+        raise DatabaseOperationError("Failed to wipe database tables.") from e
+
+
+def confirm_wipe() -> bool:
+    """Ask for interactive confirmation before wiping application tables."""
+    answer = input(
+        f"This will drop CS2 Analytics tables in database '{DB_NAME}'. "
+        "Are you sure? [y/n]: "
+    )
+    return answer.strip().lower() == "y"
+
+
+def initialize_database(create_db: bool = False) -> None:
+    """Create schema tables and indexes in the configured database."""
+    if create_db:
+        create_database_if_missing()
+
+    try:
+        with psycopg2.connect(**_connection_kwargs(DB_NAME)) as conn:
+            logger.info("Connected to PostgreSQL database for schema initialization.")
             with conn.cursor() as cur:
                 schema_path = os.path.join(os.path.dirname(__file__), "schema.sql")
 
                 with open(schema_path, encoding="utf-8") as schema_file:
                     schema_sql = schema_file.read()
                     cur.execute(schema_sql)
-        logger.info("✅ Database initialized successfully.")
+
+        logger.info("Database tables created or verified.")
+
+        db = Database()
+        try:
+            db.create_indexes()
+        finally:
+            db.close_db_pool()
+
+        logger.info("Database schema initialized successfully.")
 
     except Exception as e:
         raise DatabaseOperationError("Failed to initialize database schema.") from e
 
 
-if __name__ == "__main__":
-    initialize_database()
+def main(argv: list[str] | None = None) -> None:
+    """Run database setup commands from the command line."""
+    parser = argparse.ArgumentParser(description="Initialize CS2 Analytics storage.")
+    command_group = parser.add_mutually_exclusive_group()
+    command_group.add_argument(
+        "--init",
+        action="store_true",
+        help="Create or verify schema tables and indexes in the configured database.",
+    )
+    command_group.add_argument(
+        "--create-database",
+        action="store_true",
+        help="Create the configured database before initializing schema tables.",
+    )
+    command_group.add_argument(
+        "--wipe",
+        action="store_true",
+        help="Drop application tables from the configured database and exit.",
+    )
+    args = parser.parse_args(argv)
 
+    if args.wipe:
+        if not confirm_wipe():
+            logger.info("Database wipe cancelled.")
+            return
+        wipe_database()
+        return
+
+    initialize_database(create_db=args.create_database)
+
+
+if __name__ == "__main__":
+    main()

--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -1,34 +1,5 @@
--- Drop existing tables in correct dependency order
-DROP TABLE IF EXISTS demo_files CASCADE;
-
-DROP TABLE IF EXISTS demo_ingestion_state CASCADE;
-
-DROP TABLE IF EXISTS map_ingestion_state CASCADE;
-
-DROP TABLE IF EXISTS match_ingestion_state CASCADE;
-
-DROP TABLE IF EXISTS player_metrics CASCADE;
-
-DROP TABLE IF EXISTS player_transfers CASCADE;
-
-DROP TABLE IF EXISTS player_aliases CASCADE;
-
-DROP TABLE IF EXISTS player_team_history CASCADE;
-
-DROP TABLE IF EXISTS players CASCADE;
-
-DROP TABLE IF EXISTS maps CASCADE;
-
-DROP TABLE IF EXISTS matches CASCADE;
-
-DROP TABLE IF EXISTS teams CASCADE;
-
-DROP TABLE IF EXISTS player_info CASCADE;
-
-DROP TABLE IF EXISTS scrape_runs CASCADE;
-
--- ✅ Teams Table
-CREATE TABLE teams (
+-- Teams Table
+CREATE TABLE IF NOT EXISTS teams (
     team_id INT PRIMARY KEY,
     team_name TEXT NOT NULL,
     team_url TEXT NOT NULL,
@@ -39,23 +10,21 @@ CREATE TABLE teams (
     data_complete BOOLEAN
 );
 
--- ✅ Player Info Table (Previously `players`)
-CREATE TABLE player_info (
+-- Player Info Table (Previously `players`)
+CREATE TABLE IF NOT EXISTS player_info (
     player_id INT PRIMARY KEY,
     player_name TEXT NOT NULL,
     player_url TEXT NOT NULL,
-    team_id INT REFERENCES teams(team_id) ON DELETE
-    SET
-        NULL,
-        active BOOLEAN DEFAULT TRUE,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        last_scraped_at TIMESTAMP,
-        last_updated_at TIMESTAMP,
-        data_complete BOOLEAN
+    team_id INT REFERENCES teams(team_id) ON DELETE SET NULL,
+    active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_scraped_at TIMESTAMP,
+    last_updated_at TIMESTAMP,
+    data_complete BOOLEAN
 );
 
--- ✅ Matches Table
-CREATE TABLE matches (
+-- Matches Table
+CREATE TABLE IF NOT EXISTS matches (
     match_id INT PRIMARY KEY,
     match_url TEXT UNIQUE NOT NULL,
     map_links TEXT,
@@ -78,8 +47,8 @@ CREATE TABLE matches (
     data_complete BOOLEAN
 );
 
--- ✅ Maps Table (Previously `maps_played`)
-CREATE TABLE maps (
+-- Maps Table (Previously `maps_played`)
+CREATE TABLE IF NOT EXISTS maps (
     map_id INT PRIMARY KEY,
     match_id INT NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
     map_url TEXT UNIQUE NOT NULL,
@@ -99,8 +68,8 @@ CREATE TABLE maps (
     UNIQUE (match_id, map_order)
 );
 
--- ✅ Players Table (Previously `players_stats`)
-CREATE TABLE players (
+-- Players Table (Previously `players_stats`)
+CREATE TABLE IF NOT EXISTS players (
     map_id INT NOT NULL REFERENCES maps(map_id) ON DELETE CASCADE,
     player_id INT,
     player_name TEXT NOT NULL,
@@ -130,48 +99,42 @@ CREATE TABLE players (
     PRIMARY KEY (map_id, player_id)
 );
 
--- ✅ Player Team History Table (Tracks past teams)
-CREATE TABLE player_team_history (
+-- Player Team History Table (Tracks past teams)
+CREATE TABLE IF NOT EXISTS player_team_history (
     id SERIAL PRIMARY KEY,
     player_id INT REFERENCES player_info(player_id) ON DELETE CASCADE,
     player_name TEXT NOT NULL,
-    team_id INT REFERENCES teams(team_id) ON DELETE
-    SET
-        NULL,
-        team_name TEXT NOT NULL,
-        start_date DATE NOT NULL,
-        end_date DATE,
-        last_inserted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        UNIQUE(player_id, team_id, start_date)
+    team_id INT REFERENCES teams(team_id) ON DELETE SET NULL,
+    team_name TEXT NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE,
+    last_inserted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(player_id, team_id, start_date)
 );
 
--- ✅ Player Aliases Table (Tracks name changes)
-CREATE TABLE player_aliases (
+-- Player Aliases Table (Tracks name changes)
+CREATE TABLE IF NOT EXISTS player_aliases (
     id SERIAL PRIMARY KEY,
     player_id INT REFERENCES player_info(player_id) ON DELETE CASCADE,
     alias TEXT NOT NULL,
     changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- ✅ Player Transfers Table (Tracks when players move between teams)
-CREATE TABLE player_transfers (
+-- Player Transfers Table (Tracks when players move between teams)
+CREATE TABLE IF NOT EXISTS player_transfers (
     transfer_id SERIAL PRIMARY KEY,
     player_id INT REFERENCES player_info(player_id) ON DELETE CASCADE,
     player_name TEXT NOT NULL,
-    old_team_id INT REFERENCES teams(team_id) ON DELETE
-    SET
-        NULL,
-        old_team_name TEXT NOT NULL,
-        new_team_id INT REFERENCES teams(team_id) ON DELETE
-    SET
-        NULL,
-        new_team_name TEXT NOT NULL,
-        transfer_date DATE NOT NULL
+    old_team_id INT REFERENCES teams(team_id) ON DELETE SET NULL,
+    old_team_name TEXT NOT NULL,
+    new_team_id INT REFERENCES teams(team_id) ON DELETE SET NULL,
+    new_team_name TEXT NOT NULL,
+    transfer_date DATE NOT NULL
 );
 
 -- Match Ingestion State Table
 -- Tracks discovery and processing lifecycle for matches.
-CREATE TABLE match_ingestion_state (
+CREATE TABLE IF NOT EXISTS match_ingestion_state (
     match_id INT PRIMARY KEY,
     match_url TEXT NOT NULL,
     status TEXT CHECK (
@@ -191,7 +154,7 @@ CREATE TABLE match_ingestion_state (
 
 -- Map Ingestion State Table
 -- Tracks discovery and processing lifecycle for maps.
-CREATE TABLE map_ingestion_state (
+CREATE TABLE IF NOT EXISTS map_ingestion_state (
     map_id INT PRIMARY KEY,
     map_url TEXT NOT NULL,
     match_id INT REFERENCES matches(match_id) ON DELETE CASCADE,
@@ -215,7 +178,7 @@ CREATE TABLE map_ingestion_state (
 );
 
 -- Demo Ingestion State Table
-CREATE TABLE demo_ingestion_state (
+CREATE TABLE IF NOT EXISTS demo_ingestion_state (
     demo_id TEXT PRIMARY KEY,
     demo_url TEXT NOT NULL,
     status TEXT CHECK (
@@ -234,7 +197,7 @@ CREATE TABLE demo_ingestion_state (
 );
 
 -- This table is used to track the status of demo files.
-CREATE TABLE demo_files (
+CREATE TABLE IF NOT EXISTS demo_files (
     map_id INT PRIMARY KEY REFERENCES maps(map_id) ON DELETE CASCADE,
     demo_url TEXT NOT NULL,
     local_path TEXT,
@@ -245,9 +208,9 @@ CREATE TABLE demo_files (
     last_processed_at TIMESTAMP
 );
 
--- ✅ Scraper history table
+-- Scraper history table
 -- This table is used to track the history of scrape runs.
-CREATE TABLE scrape_runs (
+CREATE TABLE IF NOT EXISTS scrape_runs (
     run_id SERIAL PRIMARY KEY,
     started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     ended_at TIMESTAMP,
@@ -257,9 +220,9 @@ CREATE TABLE scrape_runs (
     notes TEXT
 );
 
--- ✅ Player Metrics Table
+-- Player Metrics Table
 -- This table is used to store player performance metrics.
-CREATE TABLE player_metrics (
+CREATE TABLE IF NOT EXISTS player_metrics (
     player_id INT,
     map_name TEXT,
     average_kills FLOAT,
@@ -269,18 +232,3 @@ CREATE TABLE player_metrics (
     last_updated_at TIMESTAMP,
     PRIMARY KEY (player_id, map_name)
 );
-
--- ✅ Indexes for Performance Optimization
-CREATE INDEX idx_matches_date ON matches (date);
-
-CREATE INDEX idx_maps_match_id ON maps (match_id);
-
-CREATE INDEX idx_players_map_id ON players (map_id);
-
-CREATE INDEX idx_players_player_id ON players(player_id);
-
-CREATE INDEX idx_player_info_team_id ON player_info (team_id);
-
-CREATE INDEX idx_player_transfers_player_id ON player_transfers (player_id);
-
-CREATE INDEX idx_player_team_history_player_id ON player_team_history (player_id);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -169,10 +169,12 @@ remains the active schema source of truth.
       `maps.map_id` and `maps.match_id` joins to `matches.match_id`
 - [ ] Add a focused integration-style test for match discovery -> map discovery
       -> map/player persistence
-- [ ] Separate destructive schema reset behavior from normal schema
+- [x] Separate destructive schema reset behavior from normal schema
       initialization
-- [ ] Move `ALTER TABLE` and index mutation out of `Database.__init__` into an
+- [x] Move `ALTER TABLE` and index mutation out of `Database.__init__` into an
       explicit schema/setup path
+- [ ] Clean up import-time global database connection behavior so importing
+      storage modules does not require a live PostgreSQL database
 - [ ] Rename queue-era exception and test names where they affect active code
       readability
 
@@ -220,11 +222,16 @@ relational ingestion outputs without starting dbt models yet.
    Add focused tests that prove `players -> maps -> matches` joins work and
    that dbt will not need to parse stringified link fields.
 
-5. [ ] `phase3.5-schema-initialization-cleanup`
+5. [x] `phase3.5-schema-initialization-cleanup`
    Separate destructive schema reset behavior from normal initialization and
    move runtime schema mutation out of `Database.__init__`.
 
-6. [ ] `phase3.5-ingestion-terminology-cleanup`
+6. [ ] `phase3.5-database-access-cleanup`
+   Remove remaining import-time global database connection behavior, such as
+   module-level `db = Database()` access paths, and move toward lazy or
+   injectable database access where it improves tests and setup commands.
+
+7. [ ] `phase3.5-ingestion-terminology-cleanup`
    Rename queue-era exception and test names where they affect active
    ingestion-state readability.
 
@@ -233,7 +240,7 @@ relational ingestion outputs without starting dbt models yet.
 - [ ] `matches`, `maps`, and `players` have stable grains
 - [x] Map-player-match relationships are queryable without parsing strings
 - [x] Storage upserts are duplicate-safe and refresh trusted fields
-- [ ] Tests pass
+- [x] Tests pass
 - [ ] dbt can start with clean staging models: `stg_matches`, `stg_maps`, and
       `stg_players`
 

--- a/manage_db.py
+++ b/manage_db.py
@@ -1,0 +1,7 @@
+"""Convenience entry point for database setup commands."""
+
+from cs2_analytics.storage.initialize_db import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/storage/test_database_setup.py
+++ b/tests/storage/test_database_setup.py
@@ -1,0 +1,73 @@
+from cs2_analytics.storage import database as database_module
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.executed_sql: str | None = None
+
+    def execute(self, sql: str) -> None:
+        self.executed_sql = sql
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = _RecordingCursor()
+        self.committed = False
+
+    def cursor(self) -> _RecordingCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+class _RecordingPool:
+    def __init__(self) -> None:
+        self.conn = _RecordingConnection()
+        self.released = False
+
+    def getconn(self) -> _RecordingConnection:
+        return self.conn
+
+    def putconn(self, conn: _RecordingConnection) -> None:
+        self.released = True
+
+
+def test_database_init_does_not_create_indexes(monkeypatch) -> None:
+    pool = _RecordingPool()
+    create_indexes_called = False
+
+    def fail_if_called(_self) -> bool:
+        nonlocal create_indexes_called
+        create_indexes_called = True
+        return True
+
+    monkeypatch.setattr(database_module, "_initialize_db_pool", lambda: pool)
+    monkeypatch.setattr(database_module.Database, "create_indexes", fail_if_called)
+
+    database_module.Database()
+
+    assert create_indexes_called is False
+
+
+def test_create_indexes_uses_current_schema_indexes_without_alter_table(
+    monkeypatch,
+) -> None:
+    pool = _RecordingPool()
+    monkeypatch.setattr(database_module, "_initialize_db_pool", lambda: pool)
+
+    db = database_module.Database()
+
+    assert db.create_indexes() is True
+
+    index_sql = pool.conn.cursor_obj.executed_sql
+    assert index_sql is not None
+    assert "ALTER TABLE" not in index_sql
+    assert "idx_matches_date" in index_sql
+    assert "idx_maps_match_id" in index_sql
+    assert "idx_players_map_id" in index_sql
+    assert "idx_match_ingestion_state_pending" in index_sql
+    assert "idx_map_ingestion_state_pending" in index_sql
+    assert "idx_demo_ingestion_state_pending" in index_sql
+    assert pool.conn.committed is True
+    assert pool.released is True

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -11,9 +11,14 @@ SCHEMA_PATH = Path(__file__).parents[2] / "cs2_analytics" / "storage" / "schema.
 
 
 class _RecordingCursor:
-    def __init__(self, should_fail: bool = False) -> None:
+    def __init__(
+        self,
+        should_fail: bool = False,
+        fetchone_response: tuple[int] | None = None,
+    ) -> None:
         self.should_fail = should_fail
-        self.executed_sql: str | None = None
+        self.fetchone_response = fetchone_response
+        self.executed: list[tuple[object, object | None]] = []
         self.entered = False
         self.exited = False
 
@@ -24,10 +29,13 @@ class _RecordingCursor:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.exited = True
 
-    def execute(self, sql: str) -> None:
+    def execute(self, sql: object, params: object | None = None) -> None:
         if self.should_fail:
             raise RuntimeError("schema apply failed")
-        self.executed_sql = sql
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> tuple[int] | None:
+        return self.fetchone_response
 
 
 class _RecordingConnection:
@@ -35,6 +43,7 @@ class _RecordingConnection:
         self.cursor_obj = cursor
         self.entered = False
         self.exited = False
+        self.autocommit = False
 
     def __enter__(self):
         self.entered = True
@@ -47,26 +56,44 @@ class _RecordingConnection:
         return self.cursor_obj
 
 
+class _RecordingDatabase:
+    instances: list["_RecordingDatabase"] = []
+
+    def __init__(self) -> None:
+        self.indexes_created = False
+        self.closed = False
+        self.instances.append(self)
+
+    def create_indexes(self) -> bool:
+        self.indexes_created = True
+        return True
+
+    def close_db_pool(self) -> None:
+        self.closed = True
+
+
 def _fake_schema_file(*_args, **_kwargs) -> io.StringIO:
     return io.StringIO("SELECT 1;")
 
 
 def _table_definition(schema_sql: str, table_name: str) -> str:
-    start_marker = f"CREATE TABLE {table_name} ("
+    start_marker = f"CREATE TABLE IF NOT EXISTS {table_name} ("
     start_index = schema_sql.index(start_marker)
     end_index = schema_sql.index("\n);", start_index)
     return schema_sql[start_index:end_index]
 
 
-def test_initialize_database_executes_schema_with_context_managers(
+def test_initialize_database_executes_schema_and_creates_indexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
     connection = _RecordingConnection(cursor)
+    _RecordingDatabase.instances = []
 
     monkeypatch.setattr(
         initialize_db_module.psycopg2, "connect", lambda **_: connection
     )
+    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
     monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
     monkeypatch.setattr(
         builtins,
@@ -80,7 +107,36 @@ def test_initialize_database_executes_schema_with_context_managers(
     assert connection.exited is True
     assert cursor.entered is True
     assert cursor.exited is True
-    assert cursor.executed_sql == "SELECT 1;"
+    assert cursor.executed == [("SELECT 1;", None)]
+    assert _RecordingDatabase.instances[0].indexes_created is True
+    assert _RecordingDatabase.instances[0].closed is True
+
+
+def test_initialize_database_can_create_configured_database_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    connection = _RecordingConnection(cursor)
+    create_database_calls: list[bool] = []
+    _RecordingDatabase.instances = []
+
+    monkeypatch.setattr(
+        initialize_db_module.psycopg2, "connect", lambda **_: connection
+    )
+    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
+    monkeypatch.setattr(
+        initialize_db_module,
+        "create_database_if_missing",
+        lambda: create_database_calls.append(True),
+    )
+    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
+    monkeypatch.setattr(builtins, "open", _fake_schema_file)
+
+    initialize_db_module.initialize_database(create_db=True)
+
+    assert create_database_calls == [True]
+    assert cursor.executed == [("SELECT 1;", None)]
+    assert _RecordingDatabase.instances[0].indexes_created is True
 
 
 def test_initialize_database_wraps_schema_failures_in_typed_error(
@@ -92,6 +148,7 @@ def test_initialize_database_wraps_schema_failures_in_typed_error(
     monkeypatch.setattr(
         initialize_db_module.psycopg2, "connect", lambda **_: connection
     )
+    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
     monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
     monkeypatch.setattr(
         builtins,
@@ -109,6 +166,131 @@ def test_initialize_database_wraps_schema_failures_in_typed_error(
     assert cursor.exited is True
 
 
+def test_wipe_database_executes_explicit_drop_table_statements(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    connection = _RecordingConnection(cursor)
+
+    monkeypatch.setattr(
+        initialize_db_module.psycopg2, "connect", lambda **_: connection
+    )
+
+    initialize_db_module.wipe_database()
+
+    wipe_sql = cursor.executed[0][0]
+    assert isinstance(wipe_sql, str)
+    assert "DROP TABLE IF EXISTS demo_files CASCADE;" in wipe_sql
+    assert "DROP TABLE IF EXISTS matches CASCADE;" in wipe_sql
+    assert "CREATE TABLE" not in wipe_sql
+
+
+def test_init_flag_runs_schema_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    initialize_calls: list[bool] = []
+
+    monkeypatch.setattr(
+        initialize_db_module,
+        "initialize_database",
+        lambda create_db=False: initialize_calls.append(create_db),
+    )
+
+    initialize_db_module.main(["--init"])
+
+    assert initialize_calls == [False]
+
+
+def test_default_command_still_runs_schema_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialize_calls: list[bool] = []
+
+    monkeypatch.setattr(
+        initialize_db_module,
+        "initialize_database",
+        lambda create_db=False: initialize_calls.append(create_db),
+    )
+
+    initialize_db_module.main([])
+
+    assert initialize_calls == [False]
+
+
+def test_create_database_flag_runs_database_creation_then_schema_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initialize_calls: list[bool] = []
+
+    monkeypatch.setattr(
+        initialize_db_module,
+        "initialize_database",
+        lambda create_db=False: initialize_calls.append(create_db),
+    )
+
+    initialize_db_module.main(["--create-database"])
+
+    assert initialize_calls == [True]
+
+
+def test_wipe_flag_requires_confirmation_before_wiping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wipe_calls: list[bool] = []
+
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "n")
+    monkeypatch.setattr(
+        initialize_db_module,
+        "wipe_database",
+        lambda: wipe_calls.append(True),
+    )
+
+    initialize_db_module.main(["--wipe"])
+
+    assert wipe_calls == []
+
+
+def test_wipe_flag_runs_wipe_after_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wipe_calls: list[bool] = []
+
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "y")
+    monkeypatch.setattr(
+        initialize_db_module,
+        "wipe_database",
+        lambda: wipe_calls.append(True),
+    )
+
+    initialize_db_module.main(["--wipe"])
+
+    assert wipe_calls == [True]
+
+
+def test_create_database_if_missing_creates_database_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(fetchone_response=None)
+    connection = _RecordingConnection(cursor)
+
+    monkeypatch.setattr(
+        initialize_db_module.psycopg2, "connect", lambda **_: connection
+    )
+
+    initialize_db_module.create_database_if_missing()
+
+    assert connection.autocommit is True
+    assert cursor.executed[0][0] == "SELECT 1 FROM pg_database WHERE datname = %s;"
+    assert cursor.executed[0][1] == (initialize_db_module.DB_NAME,)
+    assert len(cursor.executed) == 2
+
+
+def test_schema_defines_non_destructive_table_creation() -> None:
+    schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
+
+    assert "DROP TABLE" not in schema_sql
+    assert "CREATE INDEX" not in schema_sql
+    assert "CREATE TABLE IF NOT EXISTS matches" in schema_sql
+
+
 def test_schema_defines_ingestion_state_tables() -> None:
     schema_sql = SCHEMA_PATH.read_text(encoding="utf-8")
 
@@ -117,14 +299,14 @@ def test_schema_defines_ingestion_state_tables() -> None:
         "map_ingestion_state",
         "demo_ingestion_state",
     ):
-        assert f"CREATE TABLE {table_name}" in schema_sql
+        assert f"CREATE TABLE IF NOT EXISTS {table_name}" in schema_sql
 
     for removed_table_name in (
         "match_scrape_queue",
         "map_scrape_queue",
         "demo_scrape_queue",
     ):
-        assert f"CREATE TABLE {removed_table_name}" not in schema_sql
+        assert f"CREATE TABLE IF NOT EXISTS {removed_table_name}" not in schema_sql
 
     required_columns = (
         "status",

--- a/tests/storage/test_relationship_readiness.py
+++ b/tests/storage/test_relationship_readiness.py
@@ -23,7 +23,7 @@ JOIN matches AS mt
 
 
 def _table_definition(schema_sql: str, table_name: str) -> str:
-    start_marker = f"CREATE TABLE {table_name} ("
+    start_marker = f"CREATE TABLE IF NOT EXISTS {table_name} ("
     start_index = schema_sql.index(start_marker)
     end_index = schema_sql.index("\n);", start_index)
     return schema_sql[start_index:end_index]


### PR DESCRIPTION
## Summary

- Separate safe schema initialization from destructive database wipes
- Add explicit database setup commands: `--init`, `--create-database`, and `--wipe`
- Add a root-level `manage_db.py` helper for easier local database setup
- Move index creation into the explicit setup path instead of `Database.__init__`
- Make `schema.sql` non-destructive with `CREATE TABLE IF NOT EXISTS`
- Add wipe confirmation before dropping application tables
- Document the next database access cleanup branch in the backlog

## Verification

- `python manage_db.py --help`
- `python -m pytest tests/storage/test_initialize_db.py`
- `python -m pytest`