### PR TITLE
Avoid database connection during storage imports

### DIFF
--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -3,7 +3,7 @@
 import datetime as dt
 
 from cs2_analytics.exceptions import QueueError
-from cs2_analytics.storage.db_instance import db
+from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -29,7 +29,11 @@ class BaseIngestionState:
         self.id_field = id_field
         self.url_field = url_field
         self.error_cls = error_cls
-        self.db = db
+
+    @property
+    def db(self):
+        """Return the shared database instance when an operation needs it."""
+        return get_db()
 
     def fetch(self, limit: int = 25) -> list[tuple[int | str, str]]:
         """Fetches pending items from the ingestion state table."""

--- a/cs2_analytics/storage/__init__.py
+++ b/cs2_analytics/storage/__init__.py
@@ -1,18 +1,23 @@
 """
 The `storage` package provides database connection helpers and persistence modules.
 
-The shared `db` instance is loaded lazily to avoid opening a PostgreSQL connection
-when importing setup-only modules such as `cs2_analytics.storage.initialize_db`.
+The shared database instance is loaded lazily to avoid opening a PostgreSQL
+connection when importing setup-only modules such as
+`cs2_analytics.storage.initialize_db`.
 """
 
 __all__ = [
-    "db",
+    "get_db",
 ]
 
 
 def __getattr__(name: str):
-    if name == "db":
-        from .db_instance import db
+    if name == "get_db":
+        from .db_instance import get_db
 
-        return db
+        return get_db
+    if name == "db":
+        from .db_instance import get_db
+
+        return get_db()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cs2_analytics/storage/db_instance.py
+++ b/cs2_analytics/storage/db_instance.py
@@ -1,7 +1,15 @@
-"""
-# This module provides a global instance of the Database class for use in scraping tasks."""
+"""Lazy shared database access for persistence modules."""
 
 from cs2_analytics.storage.database import Database
 
-# Global shared instance for scraping
-db = Database()
+_db: Database | None = None
+
+
+def get_db() -> Database:
+    """Return the shared database instance, creating it on first use."""
+    global _db
+
+    if _db is None:
+        _db = Database()
+
+    return _db

--- a/cs2_analytics/storage/demo_storage.py
+++ b/cs2_analytics/storage/demo_storage.py
@@ -1,7 +1,7 @@
 import datetime as dt
 
 from cs2_analytics.exceptions import DemoStorageError
-from cs2_analytics.storage.db_instance import db
+from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -59,6 +59,7 @@ def store_demo_file(
     }
 
     try:
+        db = get_db()
         with db.get_cursor() as cur:
             cur.execute(query, values)
             logger.info("📥 Stored demo file for map_id: %s", map_id)

--- a/cs2_analytics/storage/map_storage.py
+++ b/cs2_analytics/storage/map_storage.py
@@ -1,6 +1,6 @@
 from cs2_analytics.exceptions import MapStorageError
 from cs2_analytics.models.map import Map
-from cs2_analytics.storage.db_instance import db
+from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -36,6 +36,7 @@ def store_maps(maps: list[Map]) -> None:
     """
 
     try:
+        db = get_db()
         with db.get_cursor() as cur:
             for map_obj in maps:
                 cur.execute(

--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -1,6 +1,6 @@
 from cs2_analytics.exceptions import MatchStorageError
 from cs2_analytics.models.match import Match
-from cs2_analytics.storage.db_instance import db
+from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -41,6 +41,7 @@ def store_matches(matches: list[Match]) -> None:
         data_complete = EXCLUDED.data_complete;
     """
 
+    db = get_db()
     conn = db.get_connection()
     if conn is None:
         return

--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -41,12 +41,14 @@ def store_matches(matches: list[Match]) -> None:
         data_complete = EXCLUDED.data_complete;
     """
 
-    db = get_db()
-    conn = db.get_connection()
-    if conn is None:
-        return
-
+    db = None
+    conn = None
     try:
+        db = get_db()
+        conn = db.get_connection()
+        if conn is None:
+            return
+
         cur = conn.cursor()
         for match in matches:
             cur.execute(
@@ -74,8 +76,10 @@ def store_matches(matches: list[Match]) -> None:
         conn.commit()
         logger.info("📥 Stored %d match records.", len(matches))
     except Exception as e:
-        conn.rollback()
+        if conn is not None:
+            conn.rollback()
         raise MatchStorageError("Failed to store match records.") from e
     finally:
-        db.release_connection(conn)
+        if db is not None and conn is not None:
+            db.release_connection(conn)
 

--- a/cs2_analytics/storage/player_storage.py
+++ b/cs2_analytics/storage/player_storage.py
@@ -1,6 +1,6 @@
 from cs2_analytics.exceptions import PlayerStorageError
 from cs2_analytics.models.player import Player
-from cs2_analytics.storage.db_instance import db
+from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -52,6 +52,7 @@ def store_players(players: list[Player]) -> None:
     """
 
     try:
+        db = get_db()
         with db.get_cursor() as cur:
             for p in players:
                 cur.execute(

--- a/tests/queues/test_queue_exceptions.py
+++ b/tests/queues/test_queue_exceptions.py
@@ -48,7 +48,7 @@ class _RecordingQueueDb:
 def test_match_queue_wraps_db_failures_in_typed_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(base_state_module, "db", _FailingQueueDb())
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingQueueDb())
     queue = MatchIngestionState()
 
     with pytest.raises(
@@ -91,7 +91,7 @@ def test_match_ingestion_state_refreshes_existing_rows_on_rediscovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
     state = MatchIngestionState()
 
     state.queue(1, "https://www.hltv.org/matches/1/test", source="results")
@@ -116,7 +116,7 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
     state = MatchIngestionState()
 
     state.mark_as_failed(1, "boom")
@@ -134,7 +134,7 @@ def test_map_ingestion_state_queues_parent_match_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "db", _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
     state = MapIngestionState()
 
     state.queue(

--- a/tests/storage/test_database_setup.py
+++ b/tests/storage/test_database_setup.py
@@ -1,4 +1,19 @@
+import importlib
+import sys
+
 from cs2_analytics.storage import database as database_module
+
+IMPORT_SAFETY_MODULES = (
+    "cs2_analytics.storage.db_instance",
+    "cs2_analytics.storage.match_storage",
+    "cs2_analytics.storage.map_storage",
+    "cs2_analytics.storage.player_storage",
+    "cs2_analytics.storage.demo_storage",
+    "cs2_analytics.ingestion_state.base_ingestion_state",
+    "cs2_analytics.ingestion_state.match_ingestion_state",
+    "cs2_analytics.ingestion_state.map_ingestion_state",
+    "cs2_analytics.ingestion_state.demo_ingestion_state",
+)
 
 
 class _RecordingCursor:
@@ -31,6 +46,34 @@ class _RecordingPool:
 
     def putconn(self, conn: _RecordingConnection) -> None:
         self.released = True
+
+
+def _clear_import_safety_modules() -> None:
+    for module_name in IMPORT_SAFETY_MODULES:
+        sys.modules.pop(module_name, None)
+
+
+def test_importing_storage_and_state_modules_does_not_create_database(
+    monkeypatch,
+) -> None:
+    created_database_instances = 0
+
+    class _ForbiddenDatabase:
+        def __init__(self) -> None:
+            nonlocal created_database_instances
+            created_database_instances += 1
+            raise AssertionError("Database was created during import")
+
+    monkeypatch.setattr(database_module, "Database", _ForbiddenDatabase)
+    _clear_import_safety_modules()
+
+    try:
+        for module_name in IMPORT_SAFETY_MODULES:
+            importlib.import_module(module_name)
+    finally:
+        _clear_import_safety_modules()
+
+    assert created_database_instances == 0
 
 
 def test_database_init_does_not_create_indexes(monkeypatch) -> None:

--- a/tests/storage/test_database_setup.py
+++ b/tests/storage/test_database_setup.py
@@ -48,9 +48,9 @@ class _RecordingPool:
         self.released = True
 
 
-def _clear_import_safety_modules() -> None:
+def _clear_import_safety_modules(monkeypatch) -> None:
     for module_name in IMPORT_SAFETY_MODULES:
-        sys.modules.pop(module_name, None)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
 
 def test_importing_storage_and_state_modules_does_not_create_database(
@@ -65,13 +65,10 @@ def test_importing_storage_and_state_modules_does_not_create_database(
             raise AssertionError("Database was created during import")
 
     monkeypatch.setattr(database_module, "Database", _ForbiddenDatabase)
-    _clear_import_safety_modules()
+    _clear_import_safety_modules(monkeypatch)
 
-    try:
-        for module_name in IMPORT_SAFETY_MODULES:
-            importlib.import_module(module_name)
-    finally:
-        _clear_import_safety_modules()
+    for module_name in IMPORT_SAFETY_MODULES:
+        importlib.import_module(module_name)
 
     assert created_database_instances == 0
 

--- a/tests/storage/test_demo_storage.py
+++ b/tests/storage/test_demo_storage.py
@@ -1,6 +1,9 @@
 from datetime import UTC
 from contextlib import contextmanager
 
+import pytest
+
+from cs2_analytics.exceptions import DemoStorageError
 from cs2_analytics.storage import demo_storage as demo_storage_module
 
 
@@ -44,3 +47,18 @@ def test_store_demo_file_relies_on_get_cursor_for_commit(
     assert fake_db.cursor.values["demo_url"] == "https://www.hltv.org/download/demo/123"
     assert fake_db.cursor.values["last_inserted_at"].tzinfo is UTC
     assert fake_db.cursor.values["last_processed_at"].tzinfo is UTC
+
+
+def test_store_demo_file_wraps_database_factory_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_database_error():
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(demo_storage_module, "get_db", raise_database_error)
+
+    with pytest.raises(DemoStorageError, match="Failed to store demo file."):
+        demo_storage_module.store_demo_file(
+            map_id=123,
+            demo_url="https://www.hltv.org/download/demo/123",
+        )

--- a/tests/storage/test_demo_storage.py
+++ b/tests/storage/test_demo_storage.py
@@ -29,7 +29,7 @@ def test_store_demo_file_relies_on_get_cursor_for_commit(
     monkeypatch,
 ) -> None:
     fake_db = _CursorOnlyDb()
-    monkeypatch.setattr(demo_storage_module, "db", fake_db)
+    monkeypatch.setattr(demo_storage_module, "get_db", lambda: fake_db)
 
     demo_storage_module.store_demo_file(
         map_id=123,

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -58,7 +58,7 @@ def _conflict_update_clause(query: str) -> str:
 
 def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+    monkeypatch.setattr(map_storage_module, "get_db", lambda: _FakeDb(cursor))
 
     map_storage_module.store_maps([_map()])
 
@@ -77,7 +77,7 @@ def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+    monkeypatch.setattr(map_storage_module, "get_db", lambda: _FakeDb(cursor))
 
     map_storage_module.store_maps([_map()])
 
@@ -104,7 +104,7 @@ def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
 
 def test_store_maps_wraps_database_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     cursor = _RecordingCursor(should_fail=True)
-    monkeypatch.setattr(map_storage_module, "db", _FakeDb(cursor))
+    monkeypatch.setattr(map_storage_module, "get_db", lambda: _FakeDb(cursor))
 
     with pytest.raises(MapStorageError, match="Failed to store map records."):
         map_storage_module.store_maps([_map()])

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -108,3 +108,15 @@ def test_store_maps_wraps_database_failures(monkeypatch: pytest.MonkeyPatch) -> 
 
     with pytest.raises(MapStorageError, match="Failed to store map records."):
         map_storage_module.store_maps([_map()])
+
+
+def test_store_maps_wraps_database_factory_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_database_error():
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(map_storage_module, "get_db", raise_database_error)
+
+    with pytest.raises(MapStorageError, match="Failed to store map records."):
+        map_storage_module.store_maps([_map()])

--- a/tests/storage/test_match_storage.py
+++ b/tests/storage/test_match_storage.py
@@ -76,7 +76,7 @@ def test_store_matches_refreshes_trusted_fields_on_conflict(
     cursor = _RecordingCursor()
     conn = _RecordingConnection(cursor)
     fake_db = _FakeDb(conn)
-    monkeypatch.setattr(match_storage_module, "db", fake_db)
+    monkeypatch.setattr(match_storage_module, "get_db", lambda: fake_db)
 
     match_storage_module.store_matches([_match()])
 

--- a/tests/storage/test_match_storage.py
+++ b/tests/storage/test_match_storage.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from cs2_analytics.exceptions import MatchStorageError
 from cs2_analytics.models.match import Match
 from cs2_analytics.storage import match_storage as match_storage_module
 
@@ -40,6 +41,11 @@ class _FakeDb:
 
     def release_connection(self, conn: _RecordingConnection) -> None:
         self.released = True
+
+
+class _ConnectionFailingDb:
+    def get_connection(self) -> None:
+        raise RuntimeError("connection unavailable")
 
 
 def _match() -> Match:
@@ -108,3 +114,24 @@ def test_store_matches_refreshes_trusted_fields_on_conflict(
     assert conn.committed is True
     assert conn.rolled_back is False
     assert fake_db.released is True
+
+
+def test_store_matches_wraps_database_factory_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_database_error():
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(match_storage_module, "get_db", raise_database_error)
+
+    with pytest.raises(MatchStorageError, match="Failed to store match records."):
+        match_storage_module.store_matches([_match()])
+
+
+def test_store_matches_wraps_connection_acquisition_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(match_storage_module, "get_db", lambda: _ConnectionFailingDb())
+
+    with pytest.raises(MatchStorageError, match="Failed to store match records."):
+        match_storage_module.store_matches([_match()])

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from cs2_analytics.exceptions import PlayerStorageError
 from cs2_analytics.models.player import Player
 from cs2_analytics.storage import player_storage as player_storage_module
 
@@ -107,3 +108,15 @@ def test_store_players_refreshes_context_and_metrics_on_conflict(
     assert "last_inserted_at = EXCLUDED.last_inserted_at" not in conflict_update
     assert params["map_id"] == 100
     assert params["player_id"] == 200
+
+
+def test_store_players_wraps_database_factory_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_database_error():
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(player_storage_module, "get_db", raise_database_error)
+
+    with pytest.raises(PlayerStorageError, match="Failed to store player records."):
+        player_storage_module.store_players([_player()])

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -69,7 +69,7 @@ def test_store_players_refreshes_context_and_metrics_on_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(player_storage_module, "db", _FakeDb(cursor))
+    monkeypatch.setattr(player_storage_module, "get_db", lambda: _FakeDb(cursor))
 
     player_storage_module.store_players([_player()])
 

--- a/tests/storage/test_storage_exceptions.py
+++ b/tests/storage/test_storage_exceptions.py
@@ -43,7 +43,7 @@ def test_store_matches_wraps_database_failures(
 ) -> None:
     conn = _FailingConnection()
     fake_db = _FakeDb(conn)
-    monkeypatch.setattr(match_storage_module, "db", fake_db)
+    monkeypatch.setattr(match_storage_module, "get_db", lambda: fake_db)
     now = datetime.now(UTC)
 
     match = Match(


### PR DESCRIPTION
## Summary

- Replace the import-time shared `Database()` instance with lazy `get_db()` access.
- Update storage and ingestion-state modules so PostgreSQL is only required when a database operation actually runs.
- Add import-safety coverage to prove storage and ingestion-state module imports do not create a database connection.

## Notes

- Queue-era exception and test names are intentionally unchanged for the next cleanup branch.
- No schema, dbt, Airflow, or ingestion behavior changes are included.

## Verification

- `.venv\Scripts\python.exe -m pytest tests/storage/test_database_setup.py tests/storage/test_match_storage.py tests/storage/test_map_storage.py tests/storage/test_player_storage.py tests/storage/test_demo_storage.py tests/storage/test_storage_exceptions.py tests/queues/test_queue_exceptions.py`
- `.venv\Scripts\python.exe -m pytest`