### PR TITLE
Clean up ingestion-state terminology

### DIFF
--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -1,4 +1,4 @@
-"""Controller for scraping and queuing match result links."""
+"""Controller for scraping and recording match result links."""
 
 import time
 
@@ -20,7 +20,7 @@ class ResultsController:
         self.scraper = ResultsScraper()
 
     def run(self, max_matches: int = 50) -> None:
-        """Scrapes result pages and queues match URLs for downstream stages."""
+        """Scrapes result pages and records match URLs for downstream stages."""
         logger.info("Running ResultsController with max_matches=%d", max_matches)
 
         max_attempts = 3

--- a/cs2_analytics/controllers/retry_utils.py
+++ b/cs2_analytics/controllers/retry_utils.py
@@ -69,7 +69,7 @@ def reset_scraper(
 
 
 def mark_item_failed(
-    queue,
+    state,
     item_id: int | str,
     error: Exception,
     *,
@@ -80,5 +80,5 @@ def mark_item_failed(
     reason_limit: int = 500,
 ) -> None:
     """Marks an ingestion-state item failed, then logs the terminal controller exception."""
-    queue.mark_as_failed(item_id, str(error)[:reason_limit])
+    state.mark_as_failed(item_id, str(error)[:reason_limit])
     logger.exception(log_message, item_id, attempt, max_attempts, error)

--- a/cs2_analytics/exceptions.py
+++ b/cs2_analytics/exceptions.py
@@ -81,20 +81,20 @@ class DemoStorageError(StorageError):
     """Raised when demo records cannot be stored."""
 
 
-class QueueError(CS2AnalyticsError):
-    """Base exception for queue operation failures."""
+class IngestionStateError(CS2AnalyticsError):
+    """Base exception for ingestion-state operation failures."""
 
 
-class MatchQueueError(QueueError):
-    """Raised when match queue operations fail."""
+class MatchIngestionStateError(IngestionStateError):
+    """Raised when match ingestion-state operations fail."""
 
 
-class MapQueueError(QueueError):
-    """Raised when map queue operations fail."""
+class MapIngestionStateError(IngestionStateError):
+    """Raised when map ingestion-state operations fail."""
 
 
-class DemoQueueError(QueueError):
-    """Raised when demo queue operations fail."""
+class DemoIngestionStateError(IngestionStateError):
+    """Raised when demo ingestion-state operations fail."""
 
 
 class PipelineError(CS2AnalyticsError):

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -2,7 +2,7 @@
 
 import datetime as dt
 
-from cs2_analytics.exceptions import QueueError
+from cs2_analytics.exceptions import IngestionStateError
 from cs2_analytics.storage.db_instance import get_db
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -23,7 +23,7 @@ class BaseIngestionState:
         table_name: str,
         id_field: str,
         url_field: str,
-        error_cls: type[QueueError] = QueueError,
+        error_cls: type[IngestionStateError] = IngestionStateError,
     ):
         self.table_name = table_name
         self.id_field = id_field
@@ -79,7 +79,7 @@ class BaseIngestionState:
                 cur.execute(query, (id_value, url, source, priority, now, now, now))
         except Exception as e:
             raise self.error_cls(
-                f"Failed to queue ingestion state item in {self.table_name}."
+                f"Failed to record ingestion state item in {self.table_name}."
             ) from e
 
     def queue_many(
@@ -118,11 +118,11 @@ class BaseIngestionState:
             with self.db.get_cursor() as cur:
                 cur.executemany(query, values)
                 logger.info(
-                    "Queued or refreshed %d items in %s", len(items), self.table_name
+                    "Recorded or refreshed %d items in %s", len(items), self.table_name
                 )
         except Exception as e:
             raise self.error_cls(
-                f"Failed to queue ingestion state items in {self.table_name}."
+                f"Failed to record ingestion state items in {self.table_name}."
             ) from e
 
     def mark_as_processing(self, id_value: int | str) -> None:

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -82,7 +82,7 @@ class BaseIngestionState:
                 f"Failed to record ingestion state item in {self.table_name}."
             ) from e
 
-    def queue_many(
+    def record_many(
         self,
         items: list[tuple[int | str, str]],
         source: str = "unknown",

--- a/cs2_analytics/ingestion_state/demo_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/demo_ingestion_state.py
@@ -1,6 +1,6 @@
 """Demo ingestion state manager."""
 
-from cs2_analytics.exceptions import DemoQueueError
+from cs2_analytics.exceptions import DemoIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
@@ -12,5 +12,5 @@ class DemoIngestionState(BaseIngestionState):
             table_name="demo_ingestion_state",
             id_field="demo_id",
             url_field="demo_url",
-            error_cls=DemoQueueError,
+            error_cls=DemoIngestionStateError,
         )

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -2,7 +2,7 @@
 
 import datetime as dt
 
-from cs2_analytics.exceptions import MapQueueError
+from cs2_analytics.exceptions import MapIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
@@ -14,7 +14,7 @@ class MapIngestionState(BaseIngestionState):
             table_name="map_ingestion_state",
             id_field="map_id",
             url_field="map_url",
-            error_cls=MapQueueError,
+            error_cls=MapIngestionStateError,
         )
 
     def fetch_with_match_context(
@@ -84,5 +84,5 @@ class MapIngestionState(BaseIngestionState):
                 )
         except Exception as e:
             raise self.error_cls(
-                "Failed to queue ingestion state item in map_ingestion_state."
+                "Failed to record ingestion state item in map_ingestion_state."
             ) from e

--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -1,6 +1,6 @@
 """Match ingestion state manager."""
 
-from cs2_analytics.exceptions import MatchQueueError
+from cs2_analytics.exceptions import MatchIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
@@ -12,5 +12,5 @@ class MatchIngestionState(BaseIngestionState):
             table_name="match_ingestion_state",
             id_field="match_id",
             url_field="match_url",
-            error_cls=MatchQueueError,
+            error_cls=MatchIngestionStateError,
         )

--- a/cs2_analytics/pipeline/cs2_pipeline.py
+++ b/cs2_analytics/pipeline/cs2_pipeline.py
@@ -16,7 +16,7 @@ class CS2AnalyticsPipeline:
     def run(self) -> None:
         self.logger.info("🚀 CS2 Analytics Pipeline started.")
 
-        # Step 1: Scrape results and queue match links
+        # Step 1: Scrape results and record match links
         self.logger.info("🔍 Scraping match results page...")
         self.results_controller.run()
 

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -15,7 +15,8 @@ class MapScraper:
     """
     Fetches map pages and returns soup objects for parsing.
 
-    This scraper does NOT handle queue orchestration, parsing, or persistence.
+    This scraper does NOT handle lifecycle-state orchestration, parsing, or
+    persistence.
     """
 
     def __init__(self) -> None:

--- a/cs2_analytics/scrapers/match_scraper.py
+++ b/cs2_analytics/scrapers/match_scraper.py
@@ -15,7 +15,8 @@ class MatchScraper:
     """
     Scrapes match pages and returns raw soup for later parsing.
 
-    This class does NOT handle queue orchestration, parsing, or database insertion.
+    This class does NOT handle lifecycle-state orchestration, parsing, or
+    database insertion.
     """
 
     def __init__(self):

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -1,4 +1,4 @@
-"""Scrapes HLTV results page to extract match links and queues them."""
+"""Scrapes HLTV results pages and records discovered match links."""
 
 import datetime as dt
 import random
@@ -28,7 +28,7 @@ class ResultsScraper:
         """Initializes the scraper with a SeleniumBase driver and config params."""
         self.driver = Driver(uc=True, headless=True)
         self.base_url = HLTV_URL
-        self.queue = MatchIngestionState()
+        self.match_state = MatchIngestionState()
         self.source: str = "results_scraper"
         self.start_date = dt.datetime.strptime(START_DATE, "%Y-%m-%d").date()
         self.end_date = dt.datetime.strptime(END_DATE, "%Y-%m-%d").date()
@@ -43,15 +43,15 @@ class ResultsScraper:
 
     def run(self, max_matches: int = MAX_MATCHES) -> None:
         """
-        Scrapes HLTV results and queues match links.
+        Scrapes HLTV results and records match links in ingestion state.
 
         Args:
-            max_matches (int): Maximum number of matches to queue.
+            max_matches (int): Maximum number of matches to record.
         """
         offset = 0
-        total_queued = 0
+        total_recorded = 0
 
-        while total_queued < max_matches:
+        while total_recorded < max_matches:
             page_url = f"{self.base_url}?offset={offset}&gameType=CS2"
             logger.info("Scraping page: %s", page_url)
 
@@ -61,11 +61,11 @@ class ResultsScraper:
                 match_id = self._extract_match_id(full_url)
                 if match_id:
                     batch.append((match_id, full_url))
-                    total_queued += 1
+                    total_recorded += 1
 
             chunk_and_queue(
                 items=batch,
-                queue_obj=self.queue,
+                queue_obj=self.match_state,
                 chunk_size=1000,
                 source=self.source,
             )
@@ -76,7 +76,7 @@ class ResultsScraper:
             offset += 100
             time.sleep(random.uniform(1.0, 2.0))
 
-        logger.info("Queued %s matches total.", total_queued)
+        logger.info("Recorded %s discovered matches total.", total_recorded)
 
     def _extract_matches_from_page(self, url: str) -> tuple[list[str], bool]:
         """

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -11,8 +11,8 @@ from seleniumbase import Driver
 from cs2_analytics.config.config import END_DATE, HLTV_URL, MAX_MATCHES, START_DATE
 from cs2_analytics.exceptions import ResultsScrapeError, SessionScrapeError
 from cs2_analytics.ingestion_state import MatchIngestionState
+from cs2_analytics.utils.ingestion_state_helpers import chunk_and_record
 from cs2_analytics.utils.log_manager import get_logger
-from cs2_analytics.utils.queue_helpers import chunk_and_queue
 
 logger = get_logger(__name__)
 
@@ -63,9 +63,9 @@ class ResultsScraper:
                     batch.append((match_id, full_url))
                     total_recorded += 1
 
-            chunk_and_queue(
+            chunk_and_record(
                 items=batch,
-                queue_obj=self.match_state,
+                state_obj=self.match_state,
                 chunk_size=1000,
                 source=self.source,
             )

--- a/cs2_analytics/stage_services/match_stage_service.py
+++ b/cs2_analytics/stage_services/match_stage_service.py
@@ -52,17 +52,17 @@ class MatchStageService:
             return StageItemResult.failed(message)
 
         self.store_matches([match])
-        self._queue_followups(match_id, map_links, demo_links)
+        self._record_followups(match_id, map_links, demo_links)
         self.match_state.mark_as_processed(match_id)
         return StageItemResult.processed()
 
-    def _queue_followups(
+    def _record_followups(
         self,
         match_id: int,
         map_links: list[tuple[int, str]],
         demo_links: list[tuple[str, str]],
     ) -> None:
-        """Queue map and demo links returned by the parser."""
+        """Record map and demo links returned by the parser."""
         for map_order, (map_id, map_url) in enumerate(map_links, start=1):
             self.map_state.queue(
                 map_id,

--- a/cs2_analytics/utils/__init__.py
+++ b/cs2_analytics/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utils package for shared utilities such as logging and helper functions."""
 
 from .log_manager import get_logger
-from .queue_helpers import chunk_and_queue
+from .ingestion_state_helpers import chunk_and_record
 
-__all__ = ["get_logger", "chunk_and_queue"]
+__all__ = ["get_logger", "chunk_and_record"]

--- a/cs2_analytics/utils/ingestion_state_helpers.py
+++ b/cs2_analytics/utils/ingestion_state_helpers.py
@@ -3,9 +3,9 @@
 from more_itertools import chunked
 
 
-def chunk_and_queue(
+def chunk_and_record(
     items: list[tuple[int | str, str]],
-    queue_obj,
+    state_obj,
     chunk_size: int = 1000,
     source: str = "scraper",
     priority: int = 0,
@@ -15,7 +15,7 @@ def chunk_and_queue(
 
     Args:
         items: List of (id, url) tuples to record.
-        queue_obj: Ingestion-state instance with a `queue_many()` method.
+        state_obj: Ingestion-state manager used to refresh rows.
         chunk_size (int): Max number of rows per insert batch. Defaults to 1000.
         source (str): Source identifier string for logging/tracking. Defaults to "scraper".
         priority (int): Optional priority score for processing. Defaults to 0.
@@ -24,4 +24,4 @@ def chunk_and_queue(
         None
     """
     for chunk in chunked(items, chunk_size):
-        queue_obj.queue_many(chunk, source=source, priority=priority)
+        state_obj.record_many(chunk, source=source, priority=priority)

--- a/cs2_analytics/utils/queue_helpers.py
+++ b/cs2_analytics/utils/queue_helpers.py
@@ -1,4 +1,4 @@
-"""Utility for chunking and queuing data into ingestion-state tables."""
+"""Utility for chunking ingestion-state refreshes."""
 
 from more_itertools import chunked
 
@@ -11,14 +11,14 @@ def chunk_and_queue(
     priority: int = 0,
 ) -> None:
     """
-    Efficiently insert a large list of items into an ingestion-state table in chunks.
+    Efficiently record a large list of items in an ingestion-state table in chunks.
 
     Args:
-        items: List of (id, url) tuples to insert.
+        items: List of (id, url) tuples to record.
         queue_obj: Ingestion-state instance with a `queue_many()` method.
         chunk_size (int): Max number of rows per insert batch. Defaults to 1000.
         source (str): Source identifier string for logging/tracking. Defaults to "scraper".
-        priority (int): Optional priority score for queue processing. Defaults to 0.
+        priority (int): Optional priority score for processing. Defaults to 0.
 
     Returns:
         None

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -182,7 +182,7 @@ remains the active schema source of truth.
       explicit schema/setup path
 - [x] Clean up import-time global database connection behavior so importing
       storage modules does not require a live PostgreSQL database
-- [ ] Rename queue-era exception and test names where they affect active code
+- [x] Rename queue-era exception and test names where they affect active code
       readability
 
 ### Suggested branch sequence
@@ -243,7 +243,7 @@ relational ingestion outputs without starting dbt models yet.
    so imports, tests, and setup commands do not require PostgreSQL until work
    actually needs a connection.
 
-7. [ ] `phase3.5-ingestion-terminology-cleanup`
+7. [x] `phase3.5-ingestion-terminology-cleanup`
    Rename queue-era exception and test names where they affect active
    ingestion-state readability.
 

--- a/tests/controllers/test_demo_controller.py
+++ b/tests/controllers/test_demo_controller.py
@@ -4,7 +4,7 @@ from cs2_analytics.controllers import demo_controller as demo_module
 from cs2_analytics.stage_services import StageItemResult
 
 
-class _FakeDemoQueue:
+class _FakeDemoState:
     def __init__(self) -> None:
         self.failed: list[tuple[str, str]] = []
         self.processed: list[str] = []
@@ -53,7 +53,7 @@ def test_demo_controller_delegates_per_item_work_and_continues(
     exception_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(demo_module, "DemoScraper", _PassiveScraper)
     monkeypatch.setattr(demo_module, "DemoParser", _PassiveParser)
-    monkeypatch.setattr(demo_module, "DemoIngestionState", _FakeDemoQueue)
+    monkeypatch.setattr(demo_module, "DemoIngestionState", _FakeDemoState)
     monkeypatch.setattr(demo_module, "DemoStageService", _TrackingStageService)
     monkeypatch.setattr(demo_module, "store_demo_file", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -5,7 +5,7 @@ from cs2_analytics.exceptions import MapParseError, SessionScrapeError
 from cs2_analytics.stage_services import StageItemResult
 
 
-class _FakeMapQueue:
+class _FakeMapState:
     def __init__(self) -> None:
         self.failed: list[tuple[int, str]] = []
         self.processed: list[int] = []
@@ -117,7 +117,7 @@ def _build_map_controller(
 ) -> map_module.MapController:
     monkeypatch.setattr(map_module, "MapScraper", scraper_cls)
     monkeypatch.setattr(map_module, "MapParser", parser_cls)
-    monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapQueue)
+    monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapState)
     monkeypatch.setattr(
         map_module,
         "store_maps",
@@ -140,7 +140,7 @@ def test_map_controller_continues_after_item_failure(
     info_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
     monkeypatch.setattr(map_module, "MapScraper", _SuccessfulScraper)
     monkeypatch.setattr(map_module, "MapParser", _FailOnceThenSucceedParser)
-    monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapQueue)
+    monkeypatch.setattr(map_module, "MapIngestionState", _FakeMapState)
     monkeypatch.setattr(
         map_module,
         "store_maps",

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -4,7 +4,7 @@ from cs2_analytics.controllers import match_controller as match_module
 from cs2_analytics.exceptions import MatchParseError, SessionScrapeError
 
 
-class _FakeMatchQueue:
+class _FakeMatchState:
     def __init__(self) -> None:
         self.failed: list[tuple[int, str]] = []
         self.processed: list[int] = []
@@ -24,9 +24,9 @@ class _FakeMatchQueue:
         self.processing.append(item_id)
 
 
-class _FakeFollowupQueue:
+class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[int | str, str, str, int | None]] = []
+        self.recorded: list[tuple[int | str, str, str, int | None]] = []
 
     def queue(
         self,
@@ -35,7 +35,7 @@ class _FakeFollowupQueue:
         source: str = "unknown",
         match_id: int | None = None,
     ) -> None:
-        self.queued.append((item_id, url, source, match_id))
+        self.recorded.append((item_id, url, source, match_id))
 
 
 class _PassiveScraper:
@@ -99,9 +99,9 @@ def _build_match_controller(
 ) -> match_module.MatchController:
     monkeypatch.setattr(match_module, "MatchScraper", scraper_cls)
     monkeypatch.setattr(match_module, "MatchParser", parser_cls)
-    monkeypatch.setattr(match_module, "MatchIngestionState", _FakeMatchQueue)
-    monkeypatch.setattr(match_module, "MapIngestionState", _FakeFollowupQueue)
-    monkeypatch.setattr(match_module, "DemoIngestionState", _FakeFollowupQueue)
+    monkeypatch.setattr(match_module, "MatchIngestionState", _FakeMatchState)
+    monkeypatch.setattr(match_module, "MapIngestionState", _FakeFollowupState)
+    monkeypatch.setattr(match_module, "DemoIngestionState", _FakeFollowupState)
     monkeypatch.setattr(match_module, "store_matches", lambda _matches: None)
     monkeypatch.setattr(match_module.time, "sleep", lambda *_args, **_kwargs: None)
     return match_module.MatchController()

--- a/tests/controllers/test_retry_utils.py
+++ b/tests/controllers/test_retry_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cs2_analytics.controllers import retry_utils
-from cs2_analytics.exceptions import MatchQueueError, SessionScrapeError
+from cs2_analytics.exceptions import MatchIngestionStateError, SessionScrapeError
 
 
 class _Logger:
@@ -32,9 +32,11 @@ class _Scraper:
             raise self.close_error
 
 
-class _FailingQueue:
+class _FailingState:
     def mark_as_failed(self, item_id: int, reason: str) -> None:
-        raise MatchQueueError("Failed to mark item as failed in match_ingestion_state.")
+        raise MatchIngestionStateError(
+            "Failed to mark item as failed in match_ingestion_state."
+        )
 
 
 def test_reset_scraper_retries_until_health_check_passes(
@@ -82,17 +84,18 @@ def test_reset_scraper_retries_until_health_check_passes(
     assert logger.infos == [("Scraper session recovered on reset attempt %d", 2)]
 
 
-def test_mark_item_failed_propagates_queue_errors(
+def test_mark_item_failed_propagates_ingestion_state_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     logger = _Logger()
     error = SessionScrapeError("Failed to fetch match page: https://www.hltv.org")
 
     with pytest.raises(
-        MatchQueueError, match="Failed to mark item as failed in match_ingestion_state."
+        MatchIngestionStateError,
+        match="Failed to mark item as failed in match_ingestion_state.",
     ):
         retry_utils.mark_item_failed(
-            _FailingQueue(),
+            _FailingState(),
             1,
             error,
             logger=logger,

--- a/tests/ingestion_state/test_ingestion_state_exceptions.py
+++ b/tests/ingestion_state/test_ingestion_state_exceptions.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import pytest
 
 from cs2_analytics import ingestion_state as ingestion_state_package
-from cs2_analytics.exceptions import MatchQueueError
+from cs2_analytics.exceptions import MatchIngestionStateError
 from cs2_analytics.ingestion_state import MatchIngestionState
 from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
 from cs2_analytics.ingestion_state.demo_ingestion_state import DemoIngestionState
@@ -13,7 +13,7 @@ from cs2_analytics.ingestion_state.match_ingestion_state import (
 )
 
 
-class _FailingQueueDb:
+class _FailingStateDb:
     @contextmanager
     def get_cursor(self):
         raise RuntimeError("db down")
@@ -36,7 +36,7 @@ class _RecordingCursor:
         self.executemany_values = values
 
 
-class _RecordingQueueDb:
+class _RecordingStateDb:
     def __init__(self, cursor: _RecordingCursor) -> None:
         self.cursor = cursor
 
@@ -45,17 +45,17 @@ class _RecordingQueueDb:
         yield self.cursor
 
 
-def test_match_queue_wraps_db_failures_in_typed_exception(
+def test_match_ingestion_state_wraps_db_failures_in_typed_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingQueueDb())
-    queue = MatchIngestionState()
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingStateDb())
+    state = MatchIngestionState()
 
     with pytest.raises(
-        MatchQueueError,
-        match="Failed to queue ingestion state items in match_ingestion_state.",
+        MatchIngestionStateError,
+        match="Failed to record ingestion state items in match_ingestion_state.",
     ):
-        queue.queue_many([(1, "https://www.hltv.org/matches/1/test")])
+        state.queue_many([(1, "https://www.hltv.org/matches/1/test")])
 
 
 def test_ingestion_state_classes_use_ingestion_state_tables() -> None:
@@ -91,7 +91,7 @@ def test_match_ingestion_state_refreshes_existing_rows_on_rediscovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
     state = MatchIngestionState()
 
     state.queue(1, "https://www.hltv.org/matches/1/test", source="results")
@@ -116,7 +116,7 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
     state = MatchIngestionState()
 
     state.mark_as_failed(1, "boom")
@@ -130,11 +130,11 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     assert cursor.execute_values[2:] == ("boom", 1)
 
 
-def test_map_ingestion_state_queues_parent_match_context(
+def test_map_ingestion_state_records_parent_match_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cursor = _RecordingCursor()
-    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingQueueDb(cursor))
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
     state = MapIngestionState()
 
     state.queue(

--- a/tests/ingestion_state/test_ingestion_state_exceptions.py
+++ b/tests/ingestion_state/test_ingestion_state_exceptions.py
@@ -55,7 +55,7 @@ def test_match_ingestion_state_wraps_db_failures_in_typed_exception(
         MatchIngestionStateError,
         match="Failed to record ingestion state items in match_ingestion_state.",
     ):
-        state.queue_many([(1, "https://www.hltv.org/matches/1/test")])
+        state.record_many([(1, "https://www.hltv.org/matches/1/test")])
 
 
 def test_ingestion_state_classes_use_ingestion_state_tables() -> None:

--- a/tests/parsers/test_map_parser_manual.py
+++ b/tests/parsers/test_map_parser_manual.py
@@ -1,4 +1,4 @@
-"""Manually tests MapParser from queued map pages.
+"""Manually tests MapParser from pending map ingestion-state rows.
 
 This helper bypasses controllers intentionally and is only for manual debugging.
 """
@@ -8,33 +8,33 @@ from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.scrapers.map_scraper import MapScraper
 from cs2_analytics.storage.player_storage import store_players
 
-map_queue = MapIngestionState()
+map_state = MapIngestionState()
 
 
 def main():
     print("Starting manual test for MapParser...")
 
-    queued_maps = map_queue.fetch(limit=1)
-    if not queued_maps:
-        print("No map pages in queue.")
+    pending_maps = map_state.fetch(limit=1)
+    if not pending_maps:
+        print("No pending map pages found.")
         return
 
     parser = MapParser()
     total_players = []
 
     with MapScraper() as scraper:
-        for queued_map in queued_maps:
-            map_id = queued_map[0]
-            map_url = queued_map[1]
+        for pending_map in pending_maps:
+            map_id = pending_map[0]
+            map_url = pending_map[1]
             soup = scraper.fetch_soup(map_url)
             players = parser.parse_map(soup, map_url, map_id)
             if players:
                 store_players(players)
-                map_queue.mark_as_processed(map_id)
+                map_state.mark_as_processed(map_id)
                 print(f"Parsed {len(players)} players from {map_url}")
                 total_players.extend(players)
             else:
-                map_queue.mark_as_failed(map_id, "Map parser returned empty")
+                map_state.mark_as_failed(map_id, "Map parser returned empty")
                 print(f"Failed to parse {map_url}")
 
     if total_players:

--- a/tests/parsers/test_match_parser_manual.py
+++ b/tests/parsers/test_match_parser_manual.py
@@ -6,7 +6,7 @@ This test:
 - Launches a headless browser using SeleniumBase
 - Navigates to a real HLTV match page
 - Parses the page using MatchParser
-- Prints the Match object and discovered demo/map links
+- Prints the MatchParser return value
 """
 
 from bs4 import BeautifulSoup

--- a/tests/parsers/test_match_parser_manual.py
+++ b/tests/parsers/test_match_parser_manual.py
@@ -6,7 +6,7 @@ This test:
 - Launches a headless browser using SeleniumBase
 - Navigates to a real HLTV match page
 - Parses the page using MatchParser
-- Prints the Match object and queues demo/map links
+- Prints the Match object and discovered demo/map links
 """
 
 from bs4 import BeautifulSoup

--- a/tests/scrapers/test_map_scraper_manual.py
+++ b/tests/scrapers/test_map_scraper_manual.py
@@ -1,4 +1,4 @@
-"""Manually tests MapScraper by fetching queued map pages.
+"""Manually tests MapScraper by fetching pending map ingestion-state rows.
 
 This helper bypasses controllers intentionally and is only for manual debugging.
 """
@@ -6,26 +6,26 @@ This helper bypasses controllers intentionally and is only for manual debugging.
 from cs2_analytics.ingestion_state import MapIngestionState
 from cs2_analytics.scrapers.map_scraper import MapScraper
 
-map_queue = MapIngestionState()
+map_state = MapIngestionState()
 
 
 def main():
     """Main test function for MapScraper."""
     print("Starting MapScraper manual test...")
 
-    queued_maps = map_queue.fetch(limit=3)
-    if not queued_maps:
-        print("No queued map links found. You may need to run MatchParser first.")
+    pending_maps = map_state.fetch(limit=3)
+    if not pending_maps:
+        print("No pending map links found. You may need to run MatchParser first.")
         return
 
     with MapScraper() as scraper:
-        for queued_map in queued_maps:
-            map_id = queued_map[0]
-            map_url = queued_map[1]
+        for pending_map in pending_maps:
+            map_id = pending_map[0]
+            map_url = pending_map[1]
             soup = scraper.fetch_soup(map_url)
             print(f"Scraped map {map_id} from {map_url}. Soup length: {len(soup.text)}")
 
-    print(f"Finished scraping {len(queued_maps)} map(s).")
+    print(f"Finished scraping {len(pending_maps)} map(s).")
 
 
 if __name__ == "__main__":

--- a/tests/scrapers/test_match_scraper_manual.py
+++ b/tests/scrapers/test_match_scraper_manual.py
@@ -1,4 +1,4 @@
-"""Manually tests MatchScraper + MatchParser integration from queued matches.
+"""Manually tests MatchScraper + MatchParser integration from pending matches.
 
 This helper bypasses controllers intentionally and is only for manual debugging.
 """
@@ -8,23 +8,23 @@ from cs2_analytics.parsers.match_parser import MatchParser
 from cs2_analytics.scrapers.match_scraper import MatchScraper
 from cs2_analytics.storage.match_storage import store_matches
 
-match_queue = MatchIngestionState()
+match_state = MatchIngestionState()
 
 
 def main():
     """Main test for MatchScraper + MatchParser integration."""
     print("Testing MatchScraper + MatchParser integration...")
 
-    queued_matches = match_queue.fetch(limit=3)
-    if not queued_matches:
-        print("No queued matches found. Run the results scraper first.")
+    pending_matches = match_state.fetch(limit=3)
+    if not pending_matches:
+        print("No pending matches found. Run the results scraper first.")
         return
 
     parser = MatchParser()
     parsed_matches = []
 
     with MatchScraper() as scraper:
-        for match_id, match_url in queued_matches:
+        for match_id, match_url in pending_matches:
             print(f"Parsing {match_url}")
             soup = scraper.fetch_soup(match_url)
             match_obj, _, _ = parser.parse_match(soup, match_url)
@@ -32,10 +32,10 @@ def main():
             if match_obj:
                 parsed_matches.append(match_obj)
                 store_matches([match_obj])
-                match_queue.mark_as_processed(match_id)
+                match_state.mark_as_processed(match_id)
                 print(f"Stored match {match_id}")
             else:
-                match_queue.mark_as_failed(match_id, "Parser returned None")
+                match_state.mark_as_failed(match_id, "Parser returned None")
                 print(f"Failed to parse match {match_id}")
 
     print(f"Completed. Parsed: {len(parsed_matches)} matches.")

--- a/tests/stage_services/test_match_stage_service.py
+++ b/tests/stage_services/test_match_stage_service.py
@@ -47,7 +47,7 @@ class _FakeMatchState:
 
 class _FakeFollowupState:
     def __init__(self) -> None:
-        self.queued: list[tuple[int | str, str, str, int | None, int | None]] = []
+        self.recorded: list[tuple[int | str, str, str, int | None, int | None]] = []
 
     def queue(
         self,
@@ -57,10 +57,10 @@ class _FakeFollowupState:
         match_id: int | None = None,
         map_order: int | None = None,
     ) -> None:
-        self.queued.append((item_id, url, source, match_id, map_order))
+        self.recorded.append((item_id, url, source, match_id, map_order))
 
 
-def test_match_stage_service_processes_success_and_queues_followups() -> None:
+def test_match_stage_service_processes_success_and_records_followups() -> None:
     stored_matches: list[list[object]] = []
     match = object()
     match_state = _FakeMatchState()
@@ -88,7 +88,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
     assert match_state.processed == [1]
     assert match_state.failed == []
     assert stored_matches == [[match]]
-    assert map_state.queued == [
+    assert map_state.recorded == [
         (
             1,
             "https://www.hltv.org/stats/matches/mapstatsid/1/test",
@@ -97,7 +97,7 @@ def test_match_stage_service_processes_success_and_queues_followups() -> None:
             1,
         )
     ]
-    assert demo_state.queued == [
+    assert demo_state.recorded == [
         (
             "demo-1",
             "https://www.hltv.org/download/demo/test",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,11 +2,11 @@ from cs2_analytics.exceptions import (
     CS2AnalyticsError,
     DatabaseConnectionError,
     DatabaseError,
+    IngestionStateError,
     MapParseError,
     MatchParseError,
     ParseError,
     PlayerStorageError,
-    QueueError,
     RetryableScrapeError,
     ScrapeError,
     SessionScrapeError,
@@ -18,7 +18,7 @@ def test_exception_hierarchy_uses_shared_base_classes() -> None:
     assert issubclass(ParseError, CS2AnalyticsError)
     assert issubclass(ScrapeError, CS2AnalyticsError)
     assert issubclass(StorageError, CS2AnalyticsError)
-    assert issubclass(QueueError, CS2AnalyticsError)
+    assert issubclass(IngestionStateError, CS2AnalyticsError)
 
     assert issubclass(MatchParseError, ParseError)
     assert issubclass(MapParseError, ParseError)


### PR DESCRIPTION
## Summary
- Rename queue-era exceptions to ingestion-state errors
- Move queue exception tests under ingestion-state tests
- Clean active-code/test wording from queue terminology toward ingestion-state terminology
- Mark Phase 3.5 ingestion terminology cleanup complete in the backlog

## Verification
- `.\.venv\Scripts\python.exe -m pytest`
- 83 passed, 3 skipped