### PR TITLE
Add Phase 3.6 label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,70 @@
+# GitHub label taxonomy for issue and pull request triage.
+# Apply these labels in GitHub manually or with a label-sync tool.
+
+- name: "phase: 3.6"
+  color: "5319e7"
+  description: "Issue-driven workflow and agent readiness work."
+
+- name: "phase: 3.75"
+  color: "6f42c1"
+  description: "Deployment baseline work before dbt."
+
+- name: "phase: 4"
+  color: "1d76db"
+  description: "dbt transformation layer work."
+
+- name: "phase: 5"
+  color: "0052cc"
+  description: "Airflow orchestration work."
+
+- name: "phase: deferred"
+  color: "bfdadc"
+  description: "Deferred work such as demo expansion, API expansion, or later orchestration."
+
+- name: "type: implementation"
+  color: "0e8a16"
+  description: "Planned code, schema, workflow, or feature implementation."
+
+- name: "type: bug"
+  color: "d73a4a"
+  description: "Regression, failing behavior, or broken workflow."
+
+- name: "type: documentation"
+  color: "0075ca"
+  description: "Documentation-only change or documentation maintenance."
+
+- name: "type: maintenance"
+  color: "cfd3d7"
+  description: "Focused cleanup, tests, tooling, dependency, or repo hygiene work."
+
+- name: "type: architecture"
+  color: "fbca04"
+  description: "Architecture decision, boundary, or design documentation work."
+
+- name: "type: deployment"
+  color: "a2eeef"
+  description: "Deployment, runtime, container, migration, CI, or release-readiness work."
+
+- name: "priority: high"
+  color: "b60205"
+  description: "High-priority work that blocks the current roadmap or important reliability."
+
+- name: "priority: medium"
+  color: "fbca04"
+  description: "Normal-priority work needed for the active roadmap."
+
+- name: "priority: low"
+  color: "0e8a16"
+  description: "Useful but non-blocking work."
+
+- name: "risk: high"
+  color: "b60205"
+  description: "High-risk change with broad behavior, schema, deployment, or data impact."
+
+- name: "risk: medium"
+  color: "fbca04"
+  description: "Moderate-risk change with contained but meaningful impact."
+
+- name: "risk: low"
+  color: "0e8a16"
+  description: "Low-risk change such as docs, templates, or narrow behavior updates."

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -288,14 +288,15 @@ agent-friendly implementation before deployment hardening begins.
 
 Status:
 In progress. The `phase3.6-issue-templates` branch has added GitHub issue
-forms and a pull request template. Label taxonomy, agent docs, workflow docs,
-and deployment issue creation remain open.
+forms and a pull request template, and the `phase3.6-label-taxonomy` branch has
+added the repo-tracked label taxonomy. Agent docs, workflow docs, and deployment
+issue creation remain open.
 
 ### Planned work
 
 - [x] Add GitHub issue templates
 - [x] Add pull request template
-- [ ] Add labels for phase, type, priority, and risk
+- [x] Add labels for phase, type, priority, and risk
 - [ ] Ensure `AGENTS.md` complies with repo rules and coding standards
 - [ ] Add `docs/workflow.md` describing issue -> branch -> PR -> merge flow
 - [ ] Add `docs/architecture/current_state.md` summarizing the active architecture
@@ -351,7 +352,7 @@ If `Docs not needed` is selected, the PR must briefly explain why.
    - pull request template
    - pull request documentation check
 
-2. [ ] `phase3.6-label-taxonomy`
+2. [x] `phase3.6-label-taxonomy`
        Add labels for phase, type, priority, and risk.
 
    Covers:


### PR DESCRIPTION
## Summary

- Add a repo-tracked GitHub label taxonomy in `.github/labels.yml`.
- Define labels for phase, type, priority, and risk.
- Update the Phase 3.6 backlog status and mark `phase3.6-label-taxonomy` complete.

## Related Issue

Closes #

## Scope

- `.github/labels.yml`
- `docs/backlog.md`

## Out of Scope

- Creating or syncing labels in GitHub remotely.
- Adding label automation or label-sync tooling.
- Updating issue templates or PR templates.
- Agent workflow docs or deployment issue creation.

## Risk Level

Select exactly one:

- [x] Low
- [ ] Medium
- [ ] High

Reason:

- Repo metadata and backlog-only change. No runtime behavior is affected.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

- [x] Docs updated
- [ ] Docs not needed

Reason:

- Updated `docs/backlog.md` to reflect the completed label taxonomy branch.

## Verification

Commands run:

- `git diff --check`

Results:

- Passed, with only the existing Windows line-ending warning for `docs/backlog.md`.

## Review Notes

- `.github/labels.yml` is the source of truth for labels, but this PR does not sync or create labels in GitHub remotely.