### PR TITLE
Add Phase 3.6 agent workflow docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,11 +16,9 @@ Closes #
 
 ## Risk Level
 
-Select exactly one:
+Select exactly one: `Low`, `Medium`, or `High`.
 
-- [ ] Low
-- [ ] Medium
-- [ ] High
+Risk level:
 
 Reason:
 
@@ -40,12 +38,14 @@ Reason:
 
 ## Documentation Check
 
-- [ ] Docs updated
-- [ ] Docs not needed
+Select exactly one: `Updated` or `Update not needed`.
+
+Documentation:
 
 Reason:
 
 <!-- If docs were not needed, explain why. -->
+<!-- See docs/workflow.md for documentation expectations. -->
 
 ## Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ Guidance for coding agents working in this repository.
 ## Read First
 
 - Start with `README.md`, `docs/architecture/overview.md`,
-  `docs/architecture/current_state.md`, `docs/conventions.md`, and
-  `docs/backlog.md`.
+  `docs/architecture/current_state.md`, `docs/conventions.md`,
+  `docs/workflow.md`, and `docs/backlog.md`.
 - Treat `cs2_analytics/storage/schema.sql` as the schema source of truth.
 - Prefer the existing architecture over new abstractions.
 - Keep changes aligned with the current roadmap: Phase 3 and Phase 3.5 are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,14 @@ Guidance for coding agents working in this repository.
 
 ## Read First
 
-- Start with `README.md`, `docs/architecture.md`, `docs/conventions.md`, and
+- Start with `README.md`, `docs/architecture/overview.md`,
+  `docs/architecture/current_state.md`, `docs/conventions.md`, and
   `docs/backlog.md`.
 - Treat `cs2_analytics/storage/schema.sql` as the schema source of truth.
 - Prefer the existing architecture over new abstractions.
-- Keep changes aligned with the current roadmap: Phase 3 is complete, dbt is
-  next, demo expansion is deferred, and Airflow comes after dbt.
+- Keep changes aligned with the current roadmap: Phase 3 and Phase 3.5 are
+  complete, Phase 3.6 is workflow hardening, Phase 3.75 deployment baseline
+  comes before dbt, demo expansion is deferred, and Airflow comes after dbt.
 
 ## Python Coding Standards
 
@@ -51,6 +53,34 @@ Guidance for coding agents working in this repository.
 - Do not move ingestion responsibilities into dbt.
 - Do not let orchestration concerns drive schema semantics prematurely.
 
+## Agent Change Policy
+
+Agents may make small, scoped changes without additional approval when the work
+matches an issue, branch, or explicit request and stays within the documented
+architecture.
+
+Agents may normally update:
+
+- docs, templates, labels, and issue metadata
+- focused tests for the behavior being changed
+- parser, scraper, controller, stage-service, storage, API, or config code that
+  is directly in scope for the requested task
+- backlog status when a branch completes or roadmap status changes
+
+Agents must ask before:
+
+- changing database schema, migrations, or lifecycle field semantics
+- changing ingestion stage order or controller/stage-service boundaries
+- adding dbt, Airflow, demo expansion, CT/T splits, eco-adjusted stats, or
+  unrelated analytics scope
+- changing deployment targets, production runtime assumptions, or credentials
+- running destructive commands, destructive schema resets, or broad formatters
+- refactoring outside the requested scope
+
+Human review is required before merge for schema changes, deployment/runtime
+changes, architecture-boundary changes, dependency changes, CI changes, and any
+PR marked medium or high risk.
+
 ## Change Discipline
 
 - Prefer small, reviewable diffs.
@@ -88,7 +118,29 @@ Guidance for coding agents working in this repository.
 ## Documentation Expectations
 
 - Update `docs/backlog.md` when roadmap status changes.
-- Update `docs/architecture.md` or `docs/conventions.md` when architectural
-  boundaries change.
+- Update `docs/architecture/overview.md`,
+  `docs/architecture/current_state.md`, `docs/architecture/decision_log.md`, or
+  `docs/conventions.md` when architectural boundaries or project decisions
+  change.
+- Update `docs/workflow.md` when agent, branch, PR, review, or documentation
+  workflow rules change.
 - Keep README changes user-facing and concise.
 - Prefer linking to existing docs over repeating long explanations.
+- Every PR must include a documentation check explaining whether docs were
+  updated or why they were not needed.
+
+Documentation must be updated when a change affects:
+
+- architecture or module responsibilities
+- setup/install commands
+- environment variables or configuration
+- database schema or migrations
+- API routes, request/response behavior, or health checks
+- pipeline execution flow
+- deployment/runtime behavior
+- test commands or CI behavior
+- agent/developer workflow rules
+
+Documentation does not need to be updated for purely internal refactors that do
+not change behavior, setup, architecture boundaries, commands, or public
+interfaces.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ The current ingestion architecture uses PostgreSQL-backed ingestion-state tables
 ### Deferred / Later-Phase Work
 
 - Demo processing: demo download and parsing remain deferred, though `DemoStageService` preserves the stage boundary.
-- dbt transformation layer: dbt is the next major architecture phase now that ingestion-state semantics, stage boundaries, and match/map/player grains are ready.
+- Deployment baseline: containerized runtime, environment-driven configuration,
+  migrations, CI, and smoke tests come before dbt.
+- dbt transformation layer: dbt follows the deployment baseline and stays
+  downstream of ingestion.
 - Airflow orchestration: Airflow comes after dbt and clean stage boundaries.
 
 ## Tech Stack
@@ -178,7 +181,8 @@ Current architecture direction:
 - Phase 3 controller thinning is complete.
 - Phase 3.5 dbt readiness is complete for the active `matches`, `maps`, and
   `players` grains.
-- The next major architecture phase is dbt scaffolding and staging models.
+- The next major architecture phase is the Phase 3.75 deployment baseline.
+- dbt scaffolding and staging models follow after the deployment baseline.
 - Demo pipeline implementation remains deferred.
 - Airflow comes after dbt and clean transformation boundaries.
 

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -1,0 +1,106 @@
+# Current Architecture State
+
+This document summarizes the active architecture as of Phase 3.6. For the
+longer architecture overview, see `docs/architecture/overview.md`.
+
+## Active Runtime Flow
+
+The active production path is:
+
+```text
+results discovery
+-> match_ingestion_state refresh
+-> MatchController batch processing
+-> MatchStageService per-match workflow
+-> map_ingestion_state refresh
+-> MapController batch processing
+-> MapStageService per-map workflow
+-> relational storage
+-> API/data consumers
+```
+
+The production path stops after map processing. Demo support exists as a
+boundary but remains deferred.
+
+## Stable Source Grains
+
+Phase 3.5 made the active parsed-source tables ready for downstream dbt staging:
+
+- `matches`: one row per match
+- `maps`: one row per played map
+- `players`: one row per player per map
+
+`cs2_analytics/storage/schema.sql` remains the current schema source of truth
+until deployment baseline work introduces versioned migrations.
+
+`docs/schema_target_pre_dbt.md` remains planning guidance only until implemented.
+
+## Ingestion-State Tables
+
+The active ingestion-state tables are:
+
+- `match_ingestion_state`
+- `map_ingestion_state`
+- `demo_ingestion_state`
+
+They are lifecycle/state tables for discovered entities, not simple transient
+work queues.
+
+Lifecycle fields must stay distinct:
+
+- `first_seen_at`
+- `last_seen_at`
+- `last_attempted_at`
+- `last_processed_at`
+- `last_failed_at`
+- `failure_count`
+- `last_error_message`
+- `source`
+- `priority`
+- `last_updated_at`
+
+Do not add `inserted_at` or `last_inserted_at` to ingestion-state tables.
+
+## Component Boundaries
+
+Controllers own:
+
+- batch coordination
+- retry policy and retry exhaustion behavior
+- scraper reset and rotation
+- run-level summaries
+
+Stage services own:
+
+- per-item fetch, parse, persist, and lifecycle outcome workflow
+- normal processed, failed, and skipped state transitions
+- returning `StageItemResult` for controller summaries
+
+Scrapers fetch remote content only.
+
+Parsers convert fetched content into structured outputs only.
+
+Storage modules centralize relational writes.
+
+Pipelines coordinate stage order and should stay thin.
+
+## Deferred Demo Boundary
+
+Demo URLs may be discovered during match processing, and demo-specific scraper,
+parser, storage, ingestion-state, and stage-service components exist.
+
+Full demo download, parse, event extraction, and local artifact cleanup remain
+deferred until after the initial dbt layer exists and downstream demo needs are
+clearer.
+
+## Transformation And Orchestration Boundary
+
+Phase 3.75 deployment baseline comes before dbt. The deployment baseline should
+prove that runtime configuration, migrations, containers, CI, and smoke tests
+work outside the local development machine.
+
+dbt will be added after the deployment baseline and must remain downstream of
+ingestion. It should transform stable source tables, not own ingestion logic or
+application/source schema.
+
+Airflow comes after dbt and must not drive schema semantics prematurely.

--- a/docs/architecture/decision_log.md
+++ b/docs/architecture/decision_log.md
@@ -1,0 +1,149 @@
+# Decision Log
+
+This file records accepted architecture and workflow decisions. Entries use a
+lightweight ADR style: status, date, context, decision, and consequences.
+
+## ADR-0001: Use Ingestion-State Tables Instead Of Scrape Queues
+
+Status:
+Accepted
+
+Date:
+Phase 1 / Phase 2
+
+Context:
+The old queue terminology did not describe the real lifecycle of discovered
+matches, maps, and demos. The system needed rediscovery, retry, processed,
+failed, and skipped semantics without treating rows as disposable work items.
+
+Decision:
+Use PostgreSQL-backed `match_ingestion_state`, `map_ingestion_state`, and
+`demo_ingestion_state` tables as lifecycle/state tables.
+
+Consequences:
+- Source IDs remain primary keys.
+- Rediscovery refreshes existing rows instead of duplicating work.
+- Lifecycle fields stay explicit and distinct.
+- Ingestion-state tables must not use parsed-source audit fields such as
+  `inserted_at` or `last_inserted_at`.
+
+## ADR-0002: Split Batch Controllers From Per-Item Stage Services
+
+Status:
+Accepted
+
+Date:
+Phase 3
+
+Context:
+Controllers had grown too responsible for one-item fetch, parse, persist, and
+lifecycle behavior. The project needed clearer boundaries before stabilizing
+storage outputs and adding downstream transformation work.
+
+Decision:
+Controllers own batch-level concerns, while stage services own per-item stage
+workflow.
+
+Consequences:
+- Controllers own retry policy, scraper reset/rotation, summaries, and retry
+  exhaustion.
+- Stage services own per-item fetch, parse, persist, and lifecycle outcomes.
+- Scrapers remain fetch-only.
+- Parsers remain parse-only.
+- Storage modules centralize relational writes.
+
+## ADR-0003: Stabilize Match, Map, And Player Source Grains Before dbt
+
+Status:
+Accepted
+
+Date:
+Phase 3.5
+
+Context:
+dbt staging models need stable relational source tables and joinable
+relationships. The project needed to avoid parsing stringified links or
+duplicating rows during reruns.
+
+Decision:
+Make `matches`, `maps`, and `players` stable, idempotent parsed-source tables
+before initializing dbt.
+
+Consequences:
+- `matches` is one row per match.
+- `maps` is one row per played map.
+- `players` is one row per player per map.
+- Storage upserts refresh trusted fields without duplicating rows.
+- dbt staging can start from `stg_matches`, `stg_maps`, and `stg_players`
+  after deployment baseline work is complete.
+
+## ADR-0004: Complete Deployment Baseline Before dbt
+
+Status:
+Accepted
+
+Date:
+2026-05-20
+
+Context:
+Phase 3.5 made the active source tables ready for dbt, but the project still
+needs reproducible runtime setup, environment-driven configuration, migrations,
+containers, CI, and deployment smoke tests.
+
+Decision:
+Complete Phase 3.75 deployment baseline before Phase 4 dbt initialization.
+
+Consequences:
+- Phase 3.75 follows Phase 3.6.
+- dbt remains the next analytics layer, but starts only after runtime and
+  deployment assumptions are reproducible.
+- Application/source schema should move to Alembic during deployment baseline
+  work before dbt owns downstream transformation models.
+- Airflow remains deferred until after dbt.
+
+## ADR-0005: Keep Demo Expansion Deferred
+
+Status:
+Accepted
+
+Date:
+Phase 3 / Phase 3.5
+
+Context:
+Demo processing introduces binary downloads, temporary file lifecycle,
+long-running parse work, event-level extraction, and cleanup requirements.
+Those concerns are larger than the active match/map ingestion surface.
+
+Decision:
+Keep demo support as a boundary, but defer full demo download and parsing until
+after the initial dbt layer exists and downstream demo needs are clearer.
+
+Consequences:
+- `DemoStageService` can preserve the stage boundary without expanding active
+  runtime scope.
+- The production path still stops after map processing.
+- Demo expansion should not be bundled into deployment baseline or dbt staging
+  work.
+
+## ADR-0006: Use Issue-Driven, Reviewable Branches
+
+Status:
+Accepted
+
+Date:
+Phase 3.6
+
+Context:
+The project is moving from ad hoc development toward small, reviewable changes
+before deployment hardening begins.
+
+Decision:
+Use issue-driven branches, a PR template with scope/risk/documentation checks,
+repo-tracked labels, and explicit agent/human review policy.
+
+Consequences:
+- Branches should be scoped to one issue or one clear roadmap item.
+- PRs must document scope, out-of-scope work, risk, verification, and
+  documentation impact.
+- Medium-risk, high-risk, schema, deployment, dependency, CI, and architecture
+  changes require human review before merge.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -12,7 +12,9 @@ The schema uses PostgreSQL ingestion-state tables directly, and the active match
 - `MatchController`, `MapController`, and `DemoController` own batch-level concerns
 - stage services own per-item fetch, parse, persist, and lifecycle outcome work
 - demo processing remains deferred even though it now has a placeholder stage service boundary
-- dbt is the next planned phase; Airflow remains later
+- deployment baseline work is the next architecture phase before dbt
+- dbt remains the next analytics layer after deployment baseline hardening
+- Airflow remains later, after dbt
 
 ## Current Flow
 
@@ -36,7 +38,10 @@ The intended design is:
 - stage-specific processing reads from those lifecycle rows
 - per-item stage workflow is handled by dedicated stage services
 - controllers stay thin and focus on batch-level concerns
-- dbt is added after ingestion semantics and stage boundaries are stable
+- deployment baseline work happens before dbt so runtime, configuration,
+  migrations, containers, CI, and smoke tests are reproducible
+- dbt is added after ingestion semantics, stage boundaries, and deployment
+  baseline assumptions are stable
 - Airflow is added only after dbt exists and the stage boundaries are clean
 
 ## Stage Responsibilities
@@ -169,9 +174,10 @@ The demo processing implementation should stay deferred until:
 
 1. Keep the current `*_ingestion_state` tables stable.
 2. Keep controller/stage-service responsibilities clean as ingestion evolves.
-3. Implement dbt models over the stable `matches`, `maps`, and `players`
+3. Complete the Phase 3.75 deployment baseline before adding dbt.
+4. Implement dbt models over the stable `matches`, `maps`, and `players`
    parsed-source grains.
-4. Implement Airflow after dbt exists and the stage boundaries are clean.
+5. Implement Airflow after dbt exists and the stage boundaries are clean.
 
 ## Rules
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -288,26 +288,27 @@ agent-friendly implementation before deployment hardening begins.
 
 Status:
 In progress. The `phase3.6-issue-templates` branch has added GitHub issue
-forms and a pull request template, and the `phase3.6-label-taxonomy` branch has
-added the repo-tracked label taxonomy. Agent docs, workflow docs, and deployment
-issue creation remain open.
+forms and a pull request template, the `phase3.6-label-taxonomy` branch has
+added the repo-tracked label taxonomy, and the `phase3.6-agent-docs` branch has
+added agent/workflow/architecture decision documentation. Deployment issue
+creation remains open.
 
 ### Planned work
 
 - [x] Add GitHub issue templates
 - [x] Add pull request template
 - [x] Add labels for phase, type, priority, and risk
-- [ ] Ensure `AGENTS.md` complies with repo rules and coding standards
-- [ ] Add `docs/workflow.md` describing issue -> branch -> PR -> merge flow
-- [ ] Add `docs/architecture/current_state.md` summarizing the active architecture
-- [ ] Add `docs/architecture/decision_log.md` for project decisions
-- [ ] Add documentation maintenance rules to `AGENTS.md`, `docs/workflow.md`,
+- [x] Ensure `AGENTS.md` complies with repo rules and coding standards
+- [x] Add `docs/workflow.md` describing issue -> branch -> PR -> merge flow
+- [x] Add `docs/architecture/current_state.md` summarizing the active architecture
+- [x] Add `docs/architecture/decision_log.md` for project decisions
+- [x] Add documentation maintenance rules to `AGENTS.md`, `docs/workflow.md`,
       and the pull request template
 - [ ] Convert Phase 3.75 deployment tasks into GitHub issues
 - [ ] Create small acceptance criteria for each issue
-- [ ] Create branch naming conventions
-- [ ] Define what agents are allowed to change without approval
-- [ ] Define what requires human review before merge
+- [x] Create branch naming conventions
+- [x] Define what agents are allowed to change without approval
+- [x] Define what requires human review before merge
 
 ### Documentation maintenance rule
 
@@ -334,12 +335,13 @@ Every pull request must include a documentation check section:
 
 ## Documentation Check
 
-- [ ] Docs updated
-- [ ] Docs not needed
+Select exactly one: `Updated` or `Update not needed`.
+
+Documentation:
 
 Reason:
 
-If `Docs not needed` is selected, the PR must briefly explain why.
+If `Update not needed` is selected, the PR must briefly explain why.
 
 ### Suggested branch sequence
 
@@ -362,7 +364,7 @@ If `Docs not needed` is selected, the PR must briefly explain why.
    - priority labels
    - risk labels
 
-3. [ ] `phase3.6-agent-docs`
+3. [x] `phase3.6-agent-docs`
        Add `AGENTS.md`, workflow docs, current architecture summary, decision
        log, and agent/human review policy.
 
@@ -390,12 +392,12 @@ If `Docs not needed` is selected, the PR must briefly explain why.
 
 - [ ] GitHub issues can be created from templates
 - [ ] Pull requests have a consistent review checklist
-- [ ] Pull requests include a documentation check
-- [ ] `AGENTS.md` explains repo architecture, coding standards, and no-touch areas
-- [ ] `AGENTS.md` explains documentation responsibilities
-- [ ] `docs/workflow.md` explains documentation expectations
+- [x] Pull requests include a documentation check
+- [x] `AGENTS.md` explains repo architecture, coding standards, and no-touch areas
+- [x] `AGENTS.md` explains documentation responsibilities
+- [x] `docs/workflow.md` explains documentation expectations
 - [ ] Deployment baseline work is represented as small, reviewable issues
-- [ ] Branch naming and issue-to-PR workflow are documented
+- [x] Branch naming and issue-to-PR workflow are documented
 
 ---
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,156 @@
+# Workflow
+
+This project uses small, issue-driven branches so architecture changes stay
+reviewable and aligned with the roadmap.
+
+## Current Roadmap Order
+
+1. Phase 3.6: issue-driven workflow and agent readiness.
+2. Phase 3.75: deployment baseline.
+3. Phase 4: dbt transformation layer.
+4. Phase 5: Airflow orchestration.
+
+Demo expansion remains deferred. dbt must stay downstream of ingestion, and
+Airflow comes after dbt.
+
+## Issue To Merge Flow
+
+1. Create or choose a GitHub issue with clear scope, acceptance criteria,
+   out-of-scope notes, and verification expectations.
+2. Create a branch from the current mainline branch using the branch naming
+   convention below.
+3. Keep the change focused on the issue. Split broad work into follow-up issues.
+4. Open a pull request using the repo template.
+5. Fill in summary, related issue, scope, out of scope, risk level,
+   architecture/roadmap check, documentation check, verification, and review
+   notes.
+6. Request human review for medium-risk, high-risk, schema, deployment,
+   dependency, CI, or architecture-boundary changes.
+7. Merge only after review concerns and verification gaps are resolved.
+
+## Branch Naming
+
+Use lower-case, hyphen-separated branch names:
+
+`phase<phase>-<short-scope>`
+
+Examples:
+
+- `phase3.6-agent-docs`
+- `phase3.75-env-config-hardening`
+- `phase3.75-container-runtime`
+- `phase4-dbt-staging-models`
+
+Bugfix branches may use:
+
+`fix-<short-scope>`
+
+## Labels
+
+Apply labels that describe phase, type, priority, and risk.
+
+Use exactly one phase label when possible:
+
+- `phase: 3.6`
+- `phase: 3.75`
+- `phase: 4`
+- `phase: 5`
+- `phase: deferred`
+
+Use type labels to describe the main kind of work:
+
+- `type: implementation`
+- `type: bug`
+- `type: documentation`
+- `type: maintenance`
+- `type: architecture`
+- `type: deployment`
+
+Use one priority label and one risk label:
+
+- `priority: high`, `priority: medium`, or `priority: low`
+- `risk: high`, `risk: medium`, or `risk: low`
+
+## Risk Levels
+
+Low risk:
+
+- docs-only changes
+- templates or label metadata
+- narrow tests with no runtime behavior change
+- small implementation changes with isolated behavior
+
+Medium risk:
+
+- shared behavior changes
+- controller, stage-service, storage, parser, or API changes with contained
+  impact
+- dependency or CI changes
+- config changes that affect local development
+
+High risk:
+
+- schema or migration changes
+- deployment/runtime behavior changes
+- ingestion lifecycle semantics changes
+- broad refactors
+- changes that could affect production data, retries, or idempotency
+
+## Agent Change Policy
+
+Agents may make small, scoped changes without additional approval when the work
+matches an issue, branch, or explicit request and stays within documented
+architecture boundaries.
+
+Agents should ask before changing schema, deployment targets, lifecycle
+semantics, stage order, architecture boundaries, dependencies, CI, or anything
+outside the requested scope.
+
+Agents must not add dbt, Airflow, demo expansion, CT/T splits, eco-adjusted
+stats, or unrelated analytics scope unless explicitly requested.
+
+## Human Review Policy
+
+Human review is required before merge for:
+
+- schema, migration, or database ownership changes
+- deployment/runtime changes
+- architecture-boundary changes
+- dependency or CI changes
+- medium-risk or high-risk PRs
+- changes that expand roadmap scope
+
+Low-risk docs and template changes may still be reviewed, but they are intended
+to be small and fast to evaluate.
+
+## Documentation Check
+
+Every PR must select either `Updated` or `Update not needed` in the PR template
+and include a reason.
+
+Documentation must be updated when a change affects:
+
+- architecture or module responsibilities
+- setup/install commands
+- environment variables or configuration
+- database schema or migrations
+- API routes, request/response behavior, or health checks
+- pipeline execution flow
+- deployment/runtime behavior
+- test commands or CI behavior
+- agent/developer workflow rules
+
+Documentation does not need to be updated for purely internal refactors that do
+not change behavior, setup, architecture boundaries, commands, or public
+interfaces.
+
+## Verification
+
+Docs-only changes do not require tests unless they describe executable behavior.
+
+For code changes, run targeted tests first when appropriate, then
+`python -m pytest` for shared behavior.
+
+For schema, storage, controller, or stage-service behavior, include focused
+tests that prove idempotency, lifecycle behavior, or join/readiness assumptions
+as appropriate.


### PR DESCRIPTION
## Summary

Add the Phase 3.6 agent-readiness documentation set and align roadmap guidance around Phase 3.75 deployment baseline before dbt.

## Related Issue

No tracking issue for this docs branch.

## Scope

- Move `docs/architecture.md` to `docs/architecture/overview.md`.
- Add `docs/workflow.md` for issue -> branch -> PR -> merge flow, branch naming, labels, risk, documentation checks, and review policy.
- Add `docs/architecture/current_state.md` summarizing the active ingestion architecture.
- Add lightweight ADR-style `docs/architecture/decision_log.md`.
- Update `AGENTS.md` with repo rules, agent change policy, human review expectations, and documentation responsibilities.
- Update README and backlog roadmap wording so Phase 3.75 deployment baseline comes before dbt.
- Update the PR template so risk/docs selections are plain text instead of unchecked task boxes.

## Out of Scope

- Creating Phase 3.75 deployment issues.
- Code, schema, dbt, Airflow, demo expansion, or deployment runtime changes.

## Risk Level

Risk level: Low

Reason:

Docs/template-only branch. No runtime code, schema, dependency, or deployment behavior changes.

## Documentation Check

Documentation: Updated

Reason:

This PR is documentation-focused and adds the Phase 3.6 workflow, current architecture, decision log, and agent guidance docs.

## Verification

Commands run:

- `rg -n "docs/architecture\.md|architecture\.md|dbt is the next|next major architecture phase is dbt"`
- `git diff --stat origin/main...HEAD`
- `git status --short --branch`

Results:

- No stale `docs/architecture.md` references found.
- No old "dbt is next" roadmap wording found.
- Diff contains the expected docs/template files only.
- Branch was clean before PR prep.

Tests were not run because this is docs/template-only work.

## Review Notes

Focus review on whether the agent permissions, human review policy, branch naming, and ADR entries are strict enough for Phase 3.75 deployment work.