### PR TITLE
Harden environment-driven runtime configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,21 @@
-# GitHub Token for issue creation script
-# Create a Personal Access Token at: https://github.com/settings/tokens
-# Required scope: repo (Full control of private repositories)
-GITHUB_TOKEN=your_github_token_here
+# Runtime Environment
+# Use development for local work. Production fails fast unless all required
+# runtime settings below are explicitly provided.
+ENVIRONMENT=development
+DEBUG_MODE=true
 
-# Database Configuration
+# API Runtime
+API_HOST=127.0.0.1
+API_PORT=8000
+API_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8501,http://127.0.0.1:8501
+
+# PostgreSQL
 DB_NAME=cs2_db
 DB_USER=postgres
-DB_PASS=your_password_here
+DB_PASS=change_me
 DB_HOST=localhost
-DB_PORT=5433
+DB_PORT=5432
 
-# Application Configuration
-ENVIRONMENT=development
-DEBUG_MODE=True
+# Optional: GitHub issue helper scripts
+# Create a Personal Access Token at https://github.com/settings/tokens with repo scope.
+GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -88,9 +88,33 @@ pip install -e .
 pip install -e ".[dev]"
 ```
 
-### 4. Set Up Database
+### 4. Configure Environment Variables
 
-Ensure PostgreSQL is installed and configure database credentials through your local environment or `cs2_analytics/config/config.py`.
+Copy `.env.example` to `.env` for local development and adjust the values for
+your PostgreSQL instance.
+
+Required runtime variables:
+
+| Variable | Purpose | Local example |
+| --- | --- | --- |
+| `ENVIRONMENT` | Runtime environment name. Use `production` for deployed runtime validation. | `development` |
+| `DEBUG_MODE` | Enables debug logging and API reload behavior. Must be `false` in production. | `true` |
+| `API_HOST` | Host address used by `python run_api.py`. | `127.0.0.1` |
+| `API_PORT` | Port used by `python run_api.py`. | `8000` |
+| `API_CORS_ORIGINS` | Comma-separated browser origins allowed by the API. Wildcard CORS is rejected in production. | `http://localhost:8501` |
+| `DB_NAME` | PostgreSQL database name. | `cs2_db` |
+| `DB_USER` | PostgreSQL user. | `postgres` |
+| `DB_PASS` | PostgreSQL password. | `change_me` |
+| `DB_HOST` | PostgreSQL host. | `localhost` |
+| `DB_PORT` | PostgreSQL port. | `5432` |
+
+Production mode fails fast when required runtime variables are missing, when
+`DEBUG_MODE=true`, or when `API_CORS_ORIGINS` includes `*`.
+
+### 5. Set Up Database
+
+Ensure PostgreSQL is installed and configure database credentials through your
+local environment or `.env`.
 
 Run:
 
@@ -115,21 +139,22 @@ python manage_db.py --wipe
 
 The wipe command asks for `y` confirmation before dropping tables.
 
-### 5. Run the Pipeline
+### 6. Run the Pipeline
 
 ```sh
 python main.py
 ```
 
-### 6. Run the API
+### 7. Run the API
 
 ```sh
 python run_api.py
 ```
 
-Then open: `http://127.0.0.1:8000/docs`
+Then open the host and port configured by `API_HOST` and `API_PORT`, such as
+`http://127.0.0.1:8000/docs`.
 
-### 7. Run Tests
+### 8. Run Tests
 
 ```sh
 python -m pytest

--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,8 @@ Includes middleware setup and route registration.
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from cs2_analytics.config import API_CORS_ORIGINS, API_DEBUG
+
 from .routes import players
 
 
@@ -13,11 +15,11 @@ def create_app() -> FastAPI:
     """
     Creates and configures the FastAPI application.
     """
-    app = FastAPI(title="CS2 Analytics API")
+    app = FastAPI(title="CS2 Analytics API", debug=API_DEBUG)
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # Replace with specific origins in production
+        allow_origins=API_CORS_ORIGINS,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/cs2_analytics/config/__init__.py
+++ b/cs2_analytics/config/__init__.py
@@ -1,44 +1,52 @@
 """
 Configuration module for CS2 Analytics.
 
-This file ensures that configuration settings from `config.py` are easily accessible 
+This file ensures that configuration settings from `config.py` are easily accessible
 throughout the project without needing direct imports.
 """
 
 from .config import (
-    DB_NAME,
-    DB_USER,
-    DB_PASS,
+    API_CORS_ORIGINS,
+    API_DEBUG,
+    API_HOST,
+    API_PORT,
     DB_HOST,
+    DB_NAME,
+    DB_PASS,
     DB_PORT,
-    START_DATE,
-    END_DATE,
+    DB_USER,
     DEBUG_MODE,
-    MAX_MATCHES,
-    ENABLE_DEMO_DOWNLOADS,
-    ENABLE_DATA_STORAGE,
     ENABLE_ANALYTICS,
+    ENABLE_DATA_STORAGE,
+    ENABLE_DEMO_DOWNLOADS,
+    END_DATE,
     ENVIRONMENT,
     HLTV_URL,
+    LOG_FILE,
     LOG_LEVEL,
-    LOG_FILE
+    MAX_MATCHES,
+    START_DATE,
 )
 
 __all__ = [
-    "DB_NAME",
-    "DB_USER",
-    "DB_PASS",
-    "DB_HOST",
-    "DB_PORT",
-    "START_DATE",
-    "END_DATE",
+    "API_CORS_ORIGINS",
+    "API_DEBUG",
+    "API_HOST",
+    "API_PORT",
     "DEBUG_MODE",
-    "MAX_MATCHES",
-    "ENABLE_DEMO_DOWNLOADS",
-    "ENABLE_DATA_STORAGE",
+    "DB_NAME",
+    "DB_HOST",
+    "DB_PASS",
+    "DB_PORT",
+    "DB_USER",
     "ENABLE_ANALYTICS",
+    "ENABLE_DATA_STORAGE",
+    "ENABLE_DEMO_DOWNLOADS",
+    "END_DATE",
     "ENVIRONMENT",
     "HLTV_URL",
+    "LOG_FILE",
     "LOG_LEVEL",
-    "LOG_FILE"
+    "MAX_MATCHES",
+    "START_DATE",
 ]

--- a/cs2_analytics/config/config.py
+++ b/cs2_analytics/config/config.py
@@ -1,12 +1,4 @@
-"""
-Configuration file for CS2 Analytics Pipeline.
-
-This file centralizes all configurable settings, including:
-- Database credentials
-- Web scraping parameters
-- File storage paths
-- Logging settings
-"""
+"""Environment-backed runtime configuration for CS2 Analytics."""
 
 import datetime as dt
 import logging
@@ -14,19 +6,117 @@ import os
 
 from dotenv import load_dotenv
 
+from cs2_analytics.exceptions import ConfigurationError
+
 logger = logging.getLogger(__name__)
 
-# ✅ Load environment variables from `.env` file
 load_dotenv()
 
-# ✅ Database Configuration
+TRUTHY_VALUES = {"1", "true", "yes", "y", "on"}
+FALSY_VALUES = {"0", "false", "no", "n", "off"}
+
+PRODUCTION_REQUIRED_ENV_VARS = (
+    "DB_NAME",
+    "DB_USER",
+    "DB_PASS",
+    "DB_HOST",
+    "DB_PORT",
+    "API_HOST",
+    "API_PORT",
+    "API_CORS_ORIGINS",
+    "DEBUG_MODE",
+)
+
+
+def _read_bool(name: str, *, default: bool) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    normalized = raw_value.strip().lower()
+    if normalized in TRUTHY_VALUES:
+        return True
+    if normalized in FALSY_VALUES:
+        return False
+
+    raise ConfigurationError(
+        f"{name} must be one of: {', '.join(sorted(TRUTHY_VALUES | FALSY_VALUES))}."
+    )
+
+
+def _read_int(name: str, *, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise ConfigurationError(f"{name} must be an integer.") from exc
+
+
+def _read_csv(name: str, *, default: list[str]) -> list[str]:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    values = [value.strip() for value in raw_value.split(",") if value.strip()]
+    if not values:
+        raise ConfigurationError(f"{name} must include at least one value.")
+    return values
+
+
+def _validate_production_environment(
+    *,
+    environment: str,
+    debug_mode: bool,
+    cors_origins: list[str],
+) -> None:
+    if environment != "production":
+        return
+
+    missing_vars = [
+        name
+        for name in PRODUCTION_REQUIRED_ENV_VARS
+        if os.getenv(name) is None or os.getenv(name, "").strip() == ""
+    ]
+    if missing_vars:
+        raise ConfigurationError(
+            "Production configuration is missing required environment variables: "
+            + ", ".join(missing_vars)
+        )
+
+    if debug_mode:
+        raise ConfigurationError("DEBUG_MODE must be false in production.")
+
+    if "*" in cors_origins:
+        raise ConfigurationError("API_CORS_ORIGINS cannot include '*' in production.")
+
+
+ENVIRONMENT = os.getenv("ENVIRONMENT", default="development").strip().lower()
+DEBUG_MODE = _read_bool("DEBUG_MODE", default=True)
+
+# Database Configuration
 DB_NAME = os.getenv("DB_NAME", default="cs2_db")
 DB_USER = os.getenv("DB_USER", default="postgres")
 DB_PASS = os.getenv("DB_PASS", default="password")
 DB_HOST = os.getenv("DB_HOST", default="localhost")
 DB_PORT = os.getenv("DB_PORT", default="5432")
-BATCH_SIZE = 1000  # Number of rows to insert in a single batch
+BATCH_SIZE = 1000
 
+# API Configuration
+API_HOST = os.getenv("API_HOST", default="127.0.0.1")
+API_PORT = _read_int("API_PORT", default=8000)
+API_DEBUG = DEBUG_MODE
+API_CORS_ORIGINS = _read_csv(
+    "API_CORS_ORIGINS",
+    default=[
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:8501",
+        "http://127.0.0.1:8501",
+    ],
+)
 
 # Feature Toggles
 ENABLE_DATA_STORAGE = True
@@ -34,13 +124,10 @@ ENABLE_DEMO_DOWNLOADS = False
 ENABLE_ANALYTICS = False
 
 # Scraping Config
-HLTV_URL = "https://www.hltv.org/results"  # HLTV Results URL
-START_DATE = "2025-10-01"  # Extended to get more matches
+HLTV_URL = "https://www.hltv.org/results"
+START_DATE = "2025-10-01"
 END_DATE = str(dt.datetime.today().date())
-MAX_MATCHES = 10  # Process more matches for testing
-
-# Debugging Mode
-DEBUG_MODE = True
+MAX_MATCHES = 10
 
 # Logging Config
 LOG_LEVEL = logging.INFO
@@ -48,6 +135,8 @@ if DEBUG_MODE:
     LOG_LEVEL = logging.DEBUG
 LOG_FILE = os.path.join(os.getcwd(), "logs", "app.log")
 
-
-# ✅ Environment Type (dev, staging, production)
-ENVIRONMENT = os.getenv("ENVIRONMENT", default="development").lower()
+_validate_production_environment(
+    environment=ENVIRONMENT,
+    debug_mode=DEBUG_MODE,
+    cors_origins=API_CORS_ORIGINS,
+)

--- a/cs2_analytics/config/config.py
+++ b/cs2_analytics/config/config.py
@@ -105,7 +105,7 @@ DB_NAME = os.getenv("DB_NAME", default="cs2_db")
 DB_USER = os.getenv("DB_USER", default="postgres")
 DB_PASS = os.getenv("DB_PASS", default="password")
 DB_HOST = os.getenv("DB_HOST", default="localhost")
-DB_PORT = os.getenv("DB_PORT", default="5432")
+DB_PORT = _read_int("DB_PORT", default=5432)
 BATCH_SIZE = 1000
 
 # API Configuration

--- a/cs2_analytics/config/config.py
+++ b/cs2_analytics/config/config.py
@@ -49,8 +49,12 @@ def _read_int(name: str, *, default: int) -> int:
     if raw_value is None:
         return default
 
+    normalized = raw_value.strip()
+    if not normalized:
+        raise ConfigurationError(f"{name} must be an integer.")
+
     try:
-        return int(raw_value)
+        return int(normalized)
     except ValueError as exc:
         raise ConfigurationError(f"{name} must be an integer.") from exc
 

--- a/cs2_analytics/exceptions.py
+++ b/cs2_analytics/exceptions.py
@@ -5,6 +5,10 @@ class CS2AnalyticsError(Exception):
     """Base exception for application-specific failures."""
 
 
+class ConfigurationError(CS2AnalyticsError):
+    """Raised when runtime configuration is invalid or incomplete."""
+
+
 class ParseError(CS2AnalyticsError):
     """Base exception for parsing failures."""
 

--- a/run_api.py
+++ b/run_api.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
-"""Simple script to run the FastAPI backend server."""
+"""Run the FastAPI backend server."""
 
 import uvicorn
 
-from api.main import app
+from cs2_analytics.config import API_DEBUG, API_HOST, API_PORT
+from cs2_analytics.utils.log_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+def main() -> None:
+    """Run the API server with environment-driven runtime settings."""
+    logger.info(
+        "Starting FastAPI server.",
+        extra={"host": API_HOST, "port": API_PORT, "debug": API_DEBUG},
+    )
+    uvicorn.run("api.main:app", host=API_HOST, port=API_PORT, reload=API_DEBUG)
+
 
 if __name__ == "__main__":
-    print("🚀 Starting FastAPI server on http://127.0.0.1:8000")
-    uvicorn.run(app, host="127.0.0.1", port=8000, reload=False)
+    main()

--- a/tests/api/test_api_runtime_config.py
+++ b/tests/api/test_api_runtime_config.py
@@ -1,0 +1,23 @@
+from api import main as api_main
+
+
+def test_create_app_uses_configured_cors_origins(monkeypatch) -> None:
+    origins = ["https://analytics.example.com"]
+    monkeypatch.setattr(api_main, "API_CORS_ORIGINS", origins)
+
+    app = api_main.create_app()
+
+    cors_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls.__name__ == "CORSMiddleware"
+    )
+    assert cors_middleware.kwargs["allow_origins"] == origins
+
+
+def test_create_app_uses_configured_debug_mode(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "API_DEBUG", True)
+
+    app = api_main.create_app()
+
+    assert app.debug is True

--- a/tests/config/test_runtime_config.py
+++ b/tests/config/test_runtime_config.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 
 from cs2_analytics.config import config
@@ -39,6 +41,27 @@ def test_read_int_rejects_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with pytest.raises(ConfigurationError, match="API_PORT must be an integer"):
         config._read_int("API_PORT", default=8000)
+
+
+def test_db_port_is_parsed_as_integer() -> None:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("DB_PORT", " 5433 ")
+
+        reloaded_config = importlib.reload(config)
+
+        assert reloaded_config.DB_PORT == 5433
+
+    importlib.reload(config)
+
+
+def test_db_port_rejects_invalid_values() -> None:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("DB_PORT", "not-a-port")
+
+        with pytest.raises(ConfigurationError, match="DB_PORT must be an integer"):
+            importlib.reload(config)
+
+    importlib.reload(config)
 
 
 def test_read_csv_rejects_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/config/test_runtime_config.py
+++ b/tests/config/test_runtime_config.py
@@ -28,6 +28,19 @@ def test_read_int_rejects_non_integer_values(monkeypatch: pytest.MonkeyPatch) ->
         config._read_int("API_PORT", default=8000)
 
 
+def test_read_int_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_PORT", " 8000 ")
+
+    assert config._read_int("API_PORT", default=9000) == 8000
+
+
+def test_read_int_rejects_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_PORT", " ")
+
+    with pytest.raises(ConfigurationError, match="API_PORT must be an integer"):
+        config._read_int("API_PORT", default=8000)
+
+
 def test_read_csv_rejects_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_CORS_ORIGINS", " , ")
 

--- a/tests/config/test_runtime_config.py
+++ b/tests/config/test_runtime_config.py
@@ -1,0 +1,93 @@
+import pytest
+
+from cs2_analytics.config import config
+from cs2_analytics.exceptions import ConfigurationError
+
+
+def test_read_bool_accepts_common_true_and_false_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEATURE_FLAG", "yes")
+    assert config._read_bool("FEATURE_FLAG", default=False) is True
+
+    monkeypatch.setenv("FEATURE_FLAG", "0")
+    assert config._read_bool("FEATURE_FLAG", default=True) is False
+
+
+def test_read_bool_rejects_invalid_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FEATURE_FLAG", "sometimes")
+
+    with pytest.raises(ConfigurationError, match="FEATURE_FLAG must be one of"):
+        config._read_bool("FEATURE_FLAG", default=False)
+
+
+def test_read_int_rejects_non_integer_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_PORT", "not-a-port")
+
+    with pytest.raises(ConfigurationError, match="API_PORT must be an integer"):
+        config._read_int("API_PORT", default=8000)
+
+
+def test_read_csv_rejects_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_CORS_ORIGINS", " , ")
+
+    with pytest.raises(
+        ConfigurationError,
+        match="API_CORS_ORIGINS must include at least one value",
+    ):
+        config._read_csv("API_CORS_ORIGINS", default=[])
+
+
+def test_production_configuration_requires_explicit_runtime_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in config.PRODUCTION_REQUIRED_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+    with pytest.raises(ConfigurationError, match="DB_NAME"):
+        config._validate_production_environment(
+            environment="production",
+            debug_mode=False,
+            cors_origins=["https://example.com"],
+        )
+
+
+def test_production_configuration_rejects_debug_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in config.PRODUCTION_REQUIRED_ENV_VARS:
+        monkeypatch.setenv(env_var, "configured")
+
+    with pytest.raises(ConfigurationError, match="DEBUG_MODE must be false"):
+        config._validate_production_environment(
+            environment="production",
+            debug_mode=True,
+            cors_origins=["https://example.com"],
+        )
+
+
+def test_production_configuration_rejects_wildcard_cors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in config.PRODUCTION_REQUIRED_ENV_VARS:
+        monkeypatch.setenv(env_var, "configured")
+
+    with pytest.raises(ConfigurationError, match="cannot include"):
+        config._validate_production_environment(
+            environment="production",
+            debug_mode=False,
+            cors_origins=["*"],
+        )
+
+
+def test_development_configuration_allows_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for env_var in config.PRODUCTION_REQUIRED_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+    config._validate_production_environment(
+        environment="development",
+        debug_mode=True,
+        cors_origins=["*"],
+    )

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -1,0 +1,24 @@
+import run_api
+
+
+def test_run_api_uses_environment_backed_runtime_settings(monkeypatch) -> None:
+    run_calls: list[dict[str, object]] = []
+
+    def fake_run(app: str, **kwargs: object) -> None:
+        run_calls.append({"app": app, **kwargs})
+
+    monkeypatch.setattr(run_api, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(run_api, "API_PORT", 9000)
+    monkeypatch.setattr(run_api, "API_DEBUG", True)
+    monkeypatch.setattr(run_api.uvicorn, "run", fake_run)
+
+    run_api.main()
+
+    assert run_calls == [
+        {
+            "app": "api.main:app",
+            "host": "0.0.0.0",
+            "port": 9000,
+            "reload": True,
+        }
+    ]


### PR DESCRIPTION
## Summary

Harden runtime configuration for the Phase 3.75 deployment baseline by making API and database runtime settings environment-driven and adding production fail-fast validation. Production mode now requires explicit runtime variables, rejects debug mode, and rejects wildcard CORS.

## Related Issue

Closes #42

## Scope

- Added environment-backed API settings for host, port, debug/reload behavior, and CORS origins.
- Added typed configuration validation with production fail-fast checks.
- Updated FastAPI setup and `run_api.py` to use runtime config.
- Updated `.env.example` and README environment setup docs.
- Added focused tests for config parsing, production validation, API CORS/debug wiring, and API runner settings.

## Out of Scope

- No schema changes.
- No Alembic migrations.
- No Docker or docker-compose files.
- No GitHub Actions CI.
- No deployment target selection.
- No dbt, Airflow, or demo expansion.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: `Medium`

Reason: Runtime configuration affects local and deployment startup behavior, but the change is scoped to config/API wiring and covered by focused tests plus the full test suite.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: `Updated`

Reason: Runtime environment variables and local setup expectations changed, so `.env.example` and README were updated.

## Verification

Commands run:

```sh
.\.venv\Scripts\python.exe -m ruff check cs2_analytics/config api/main.py run_api.py tests/config/test_runtime_config.py tests/api/test_api_runtime_config.py tests/test_run_api.py
.\.venv\Scripts\python.exe -m pytest
```

Results:

- Ruff targeted check passed.
- Full test suite passed: 95 passed, 3 skipped.
- Note: plain `python -m pytest` with the system Python was not usable because pytest was not installed there; verification was run with the repo virtualenv.

## Review Notes

Please focus review on the production fail-fast semantics: required runtime variables, `DEBUG_MODE=false`, and non-wildcard CORS when `ENVIRONMENT=production`.