### PR TITLE
Clarify backlog update workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,12 @@ Documentation:
 
 Reason:
 
+Backlog:
+
+Reason:
+
 <!-- If docs were not needed, explain why. -->
+<!-- Set Backlog to `Updated` when this branch completes roadmap work, changes phase status, changes checklist status, or alters planned branch sequencing. Otherwise explain why backlog changes were not needed. -->
 <!-- See docs/workflow.md for documentation expectations. -->
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,10 @@ PR marked medium or high risk.
 ## Documentation Expectations
 
 - Update `docs/backlog.md` when roadmap status changes.
+- At the end of each branch, update `docs/backlog.md` when the branch completes
+  roadmap work, changes phase status, changes checklist status, or alters
+  planned branch sequencing. If no backlog update is needed, explain why in the
+  PR documentation check.
 - Update `docs/architecture/overview.md`,
   `docs/architecture/current_state.md`, `docs/architecture/decision_log.md`, or
   `docs/conventions.md` when architectural boundaries or project decisions

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -311,46 +311,12 @@ into small GitHub issues.
 - [x] Define what agents are allowed to change without approval
 - [x] Define what requires human review before merge
 
-### Documentation maintenance rule
-
-Agents must check whether their coding session changes any
-documentation-relevant behavior.
-
-Documentation must be updated when a change affects:
-
-- architecture or module responsibilities
-- setup/install commands
-- environment variables or configuration
-- database schema or migrations
-- API routes, request/response behavior, or health checks
-- pipeline execution flow
-- deployment/runtime behavior
-- test commands or CI behavior
-- agent/developer workflow rules
-
-Documentation does not need to be updated for purely internal refactors that do
-not change behavior, setup, architecture boundaries, commands, or public
-interfaces.
-
-Every pull request must include a documentation check section:
-
-## Documentation Check
-
-Select exactly one: `Updated` or `Update not needed`.
-
-Documentation:
-
-Reason:
-
-If `Update not needed` is selected, the PR must briefly explain why.
-
 ### Suggested branch sequence
 
 1. [x] `phase3.6-issue-templates`
        Add GitHub issue templates and a pull request template.
 
    Covers:
-
    - GitHub issue templates
    - pull request template
    - pull request documentation check
@@ -359,7 +325,6 @@ If `Update not needed` is selected, the PR must briefly explain why.
        Add labels for phase, type, priority, and risk.
 
    Covers:
-
    - phase labels
    - type labels
    - priority labels
@@ -370,7 +335,6 @@ If `Update not needed` is selected, the PR must briefly explain why.
        log, and agent/human review policy.
 
    Covers:
-
    - `AGENTS.md` repo rules and coding standards
    - `docs/workflow.md` issue -> branch -> PR -> merge flow
    - `docs/architecture/current_state.md`
@@ -385,7 +349,6 @@ If `Update not needed` is selected, the PR must briefly explain why.
        acceptance criteria, out-of-scope notes, and verification commands.
 
    Covers:
-
    - Phase 3.75 deployment tasks converted into GitHub issues
    - small acceptance criteria for each deployment issue
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -372,7 +372,9 @@ Make the current ingestion pipeline and API deployable in a reproducible,
 containerized environment before adding dbt.
 
 Status:
-Not started.
+In progress. The `phase3.75-env-config-hardening` branch completed the first
+deployment-baseline slice by making runtime configuration environment-driven
+and production-safe.
 
 Rationale:
 Phase 3.5 confirms that the parsed-source tables are stable enough for dbt, but
@@ -383,9 +385,9 @@ assumptions work outside the local development machine.
 
 ### Planned work
 
-- [ ] Add `.env.example` with all required runtime variables
-- [ ] Move dev-only config defaults out of production paths
-- [ ] Make API host, port, CORS origins, debug mode, and database settings environment-driven
+- [x] Add `.env.example` with all required runtime variables
+- [x] Move dev-only config defaults out of production paths
+- [x] Make API host, port, CORS origins, debug mode, and database settings environment-driven
 - [ ] Add Alembic for versioned application database migrations
 - [ ] Convert the current `schema.sql` source tables into an initial Alembic migration
 - [ ] Keep schema initialization non-destructive by default
@@ -406,9 +408,14 @@ assumptions work outside the local development machine.
 
 ### Suggested branch sequence
 
-1. [ ] `phase3.75-env-config-hardening`
+1. [x] `phase3.75-env-config-hardening`
        Add `.env.example`, environment-driven runtime config, production-safe CORS
        config, debug toggles, and deployment-safe API host/port settings.
+
+   Runtime configuration now uses explicit environment variables for API host,
+   API port, CORS origins, debug mode, and database settings. Production mode
+   fails fast when required runtime variables are missing, debug mode is enabled,
+   wildcard CORS is configured, or numeric ports are invalid.
 
 2. [ ] `phase3.75-alembic-migrations`
        Add Alembic, create the initial migration from the active schema, document

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -21,12 +21,15 @@ Airflow comes after dbt.
    convention below.
 3. Keep the change focused on the issue. Split broad work into follow-up issues.
 4. Open a pull request using the repo template.
-5. Fill in summary, related issue, scope, out of scope, risk level,
+5. Before opening or finalizing the pull request, update `docs/backlog.md` when
+   the branch completes roadmap work, changes phase status, or alters planned
+   branch sequencing.
+6. Fill in summary, related issue, scope, out of scope, risk level,
    architecture/roadmap check, documentation check, verification, and review
    notes.
-6. Request human review for medium-risk, high-risk, schema, deployment,
+7. Request human review for medium-risk, high-risk, schema, deployment,
    dependency, CI, or architecture-boundary changes.
-7. Merge only after review concerns and verification gaps are resolved.
+8. Merge only after review concerns and verification gaps are resolved.
 
 ## Branch Naming
 
@@ -127,6 +130,11 @@ to be small and fast to evaluate.
 
 Every PR must select either `Updated` or `Update not needed` in the PR template
 and include a reason.
+
+At the end of each branch, update `docs/backlog.md` when the branch completes
+roadmap work, changes phase status, changes checklist status, or alters planned
+branch sequencing. If no backlog update is needed, explain why in the PR
+documentation check.
 
 Documentation must be updated when a change affects:
 


### PR DESCRIPTION
## Summary

Clarify where documentation maintenance policy lives and make backlog updates an explicit branch-end workflow step. This keeps `docs/backlog.md` focused on roadmap/status history while `AGENTS.md`, `docs/workflow.md`, and the PR template carry the recurring workflow rules.

## Related Issue

Closes #

## Scope

- Condensed duplicated documentation maintenance policy out of `docs/backlog.md`.
- Updated Phase 3.75 backlog status for completed environment-config hardening work.
- Added branch-end backlog update guidance to `docs/workflow.md`.
- Added matching agent guidance to `AGENTS.md`.
- Added a backlog check prompt to the PR template.

## Out of Scope

- No code changes.
- No schema changes.
- No runtime behavior changes.
- No roadmap scope expansion.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: `Low`

Reason: Docs/template-only change that clarifies workflow expectations and updates roadmap status.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: `Updated`

Reason: This PR intentionally updates workflow, agent, PR-template, and backlog documentation.

Backlog: `Updated`

Reason: The backlog now reflects Phase 3.75 environment-config hardening progress and no longer duplicates the full recurring documentation maintenance policy.

## Verification

Commands run:

Not run.

Results:

Docs/template-only change; tests are not required because no executable behavior changed.

## Review Notes

Please review whether the backlog update rule is now clear in the workflow docs and PR template without overloading `docs/backlog.md` with policy text.