### PR TITLE
Add Alembic migration baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,10 @@ Guidance for coding agents working in this repository.
 - Start with `README.md`, `docs/architecture/overview.md`,
   `docs/architecture/current_state.md`, `docs/conventions.md`,
   `docs/workflow.md`, and `docs/backlog.md`.
-- Treat `cs2_analytics/storage/schema.sql` as the schema source of truth.
+- Treat Alembic migrations in `cs2_analytics/alembic/versions/` as the
+  executable application/source schema source of truth. Keep
+  `cs2_analytics/storage/schema.sql` aligned as the readable schema reference
+  during the migration ownership transition.
 - Prefer the existing architecture over new abstractions.
 - Keep changes aligned with the current roadmap: Phase 3 and Phase 3.5 are
   complete, Phase 3.6 is workflow hardening, Phase 3.75 deployment baseline
@@ -109,8 +112,9 @@ PR marked medium or high risk.
 ## Local Development Notes
 
 - Install development dependencies with `pip install -e ".[dev]"`.
-- Use `python -m cs2_analytics.storage.initialize_db` to initialize the local
-  database schema when needed.
+- Use `python -m cs2_analytics.storage.initialize_db` or
+  `alembic -c cs2_analytics/alembic.ini upgrade head` to initialize or upgrade
+  the local database schema when needed.
 - Keep local credentials and environment-specific settings out of commits.
 - Avoid committing generated caches, coverage output, logs, parsed data, or
   downloaded demos.

--- a/README.md
+++ b/README.md
@@ -116,16 +116,29 @@ Production mode fails fast when required runtime variables are missing, when
 Ensure PostgreSQL is installed and configure database credentials through your
 local environment or `.env`.
 
-Run:
+Run the non-destructive migration path:
 
 ```sh
 python manage_db.py --init
 ```
 
-Running `python manage_db.py` with no flags also uses the safe init path.
+Running `python manage_db.py` with no flags also applies migrations. Deployed
+environments should run the equivalent Alembic command during release startup:
+
+```sh
+alembic -c cs2_analytics/alembic.ini upgrade head
+```
+
+For an existing database that was already initialized from the current
+`schema.sql`, first confirm the live schema matches the initial Alembic
+migration, then mark it as migration-managed without recreating tables:
+
+```sh
+alembic -c cs2_analytics/alembic.ini stamp head
+```
 
 For first-time local setup when the configured PostgreSQL database does not
-exist yet:
+exist yet, create it and then apply migrations:
 
 ```sh
 python manage_db.py --create-database
@@ -137,7 +150,9 @@ To explicitly wipe application tables:
 python manage_db.py --wipe
 ```
 
-The wipe command asks for `y` confirmation before dropping tables.
+The wipe command asks for `y` confirmation before dropping tables. Alembic owns
+the application/source schema; future dbt models will remain downstream and
+will not manage ingestion tables.
 
 ### 6. Run the Pipeline
 

--- a/cs2_analytics/alembic.ini
+++ b/cs2_analytics/alembic.ini
@@ -1,0 +1,8 @@
+[alembic]
+script_location = cs2_analytics/alembic
+prepend_sys_path = .
+path_separator = os
+
+# The runtime URL is assembled from DB_* environment variables in
+# cs2_analytics/alembic/env.py.
+sqlalchemy.url = driver://user:pass@localhost/dbname # This value is not used, but must be present. Overwritten by env.py at runtime.

--- a/cs2_analytics/alembic/__init__.py
+++ b/cs2_analytics/alembic/__init__.py
@@ -1,0 +1,1 @@
+"""Alembic migration environment for CS2 Analytics."""

--- a/cs2_analytics/alembic/env.py
+++ b/cs2_analytics/alembic/env.py
@@ -1,7 +1,7 @@
 """Alembic runtime configuration for CS2 Analytics."""
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import create_engine, pool
 from sqlalchemy.engine import URL
 
 from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
@@ -11,8 +11,8 @@ config = context.config
 target_metadata = None
 
 
-def _database_url() -> str:
-    url = URL.create(
+def _database_url() -> URL:
+    return URL.create(
         drivername="postgresql+psycopg2",
         username=DB_USER,
         password=DB_PASS,
@@ -20,13 +20,16 @@ def _database_url() -> str:
         port=DB_PORT,
         database=DB_NAME,
     )
-    return url.render_as_string(hide_password=False)
+
+
+def _redacted_database_url() -> str:
+    return _database_url().render_as_string(hide_password=True)
 
 
 def run_migrations_offline() -> None:
     """Run migrations without opening a DBAPI connection."""
     context.configure(
-        url=_database_url(),
+        url=_redacted_database_url(),
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -38,10 +41,8 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations with a live database connection."""
-    config.set_main_option("sqlalchemy.url", _database_url())
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
+    connectable = create_engine(
+        _database_url(),
         poolclass=pool.NullPool,
     )
 

--- a/cs2_analytics/alembic/env.py
+++ b/cs2_analytics/alembic/env.py
@@ -1,0 +1,58 @@
+"""Alembic runtime configuration for CS2 Analytics."""
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import URL
+
+from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
+
+config = context.config
+
+target_metadata = None
+
+
+def _database_url() -> str:
+    url = URL.create(
+        drivername="postgresql+psycopg2",
+        username=DB_USER,
+        password=DB_PASS,
+        host=DB_HOST,
+        port=DB_PORT,
+        database=DB_NAME,
+    )
+    return url.render_as_string(hide_password=False)
+
+
+def run_migrations_offline() -> None:
+    """Run migrations without opening a DBAPI connection."""
+    context.configure(
+        url=_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations with a live database connection."""
+    config.set_main_option("sqlalchemy.url", _database_url())
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/cs2_analytics/alembic/script.py.mako
+++ b/cs2_analytics/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/cs2_analytics/alembic/versions/20260521_0001_initial_application_schema.py
+++ b/cs2_analytics/alembic/versions/20260521_0001_initial_application_schema.py
@@ -1,0 +1,308 @@
+"""Create initial application source schema.
+
+Revision ID: 20260521_0001
+Revises:
+Create Date: 2026-05-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260521_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams",
+        sa.Column("team_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column("team_name", sa.Text(), nullable=False),
+        sa.Column("team_url", sa.Text(), nullable=False),
+        sa.Column("region", sa.Text()),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_scraped_at", sa.TIMESTAMP()),
+        sa.Column("last_updated_at", sa.TIMESTAMP()),
+        sa.Column("data_complete", sa.Boolean()),
+    )
+    op.create_table(
+        "player_info",
+        sa.Column("player_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column("player_name", sa.Text(), nullable=False),
+        sa.Column("player_url", sa.Text(), nullable=False),
+        sa.Column("team_id", sa.Integer(), sa.ForeignKey("teams.team_id", ondelete="SET NULL")),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("TRUE")),
+        sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_scraped_at", sa.TIMESTAMP()),
+        sa.Column("last_updated_at", sa.TIMESTAMP()),
+        sa.Column("data_complete", sa.Boolean()),
+    )
+    op.create_table(
+        "matches",
+        sa.Column("match_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column("match_url", sa.Text(), nullable=False, unique=True),
+        sa.Column("map_links", sa.Text()),
+        sa.Column("demo_links", sa.Text()),
+        sa.Column("team1", sa.Text(), nullable=False),
+        sa.Column("team2", sa.Text(), nullable=False),
+        sa.Column("score1", sa.Integer()),
+        sa.Column("score2", sa.Integer()),
+        sa.Column("winner", sa.Text(), nullable=False),
+        sa.Column("event", sa.Text()),
+        sa.Column("match_type", sa.Text()),
+        sa.Column("forfeit", sa.Boolean(), server_default=sa.text("FALSE")),
+        sa.Column("date", sa.TIMESTAMP(), nullable=False),
+        sa.Column("last_inserted_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_scraped_at", sa.TIMESTAMP()),
+        sa.Column("last_updated_at", sa.TIMESTAMP()),
+        sa.Column("data_complete", sa.Boolean()),
+        sa.CheckConstraint("score1 >= 0"),
+        sa.CheckConstraint("score2 >= 0"),
+        sa.CheckConstraint("winner = team1 OR winner = team2"),
+    )
+    op.create_table(
+        "maps",
+        sa.Column("map_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column(
+            "match_id",
+            sa.Integer(),
+            sa.ForeignKey("matches.match_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("map_url", sa.Text(), nullable=False, unique=True),
+        sa.Column("map_order", sa.Integer(), nullable=False),
+        sa.Column("map_name", sa.Text(), nullable=False),
+        sa.Column("team1_score", sa.Integer(), nullable=False),
+        sa.Column("team2_score", sa.Integer(), nullable=False),
+        sa.Column("map_winner", sa.Text(), nullable=False),
+        sa.Column("date", sa.TIMESTAMP(), nullable=False),
+        sa.Column(
+            "inserted_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("last_scraped_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("last_updated_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("data_complete", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.CheckConstraint("map_order BETWEEN 1 AND 5"),
+        sa.CheckConstraint("team1_score >= 0"),
+        sa.CheckConstraint("team2_score >= 0"),
+        sa.UniqueConstraint("match_id", "map_order"),
+    )
+    op.create_table(
+        "players",
+        sa.Column(
+            "map_id",
+            sa.Integer(),
+            sa.ForeignKey("maps.map_id", ondelete="CASCADE"),
+            primary_key=True,
+            autoincrement=False,
+        ),
+        sa.Column("player_id", sa.Integer(), primary_key=True),
+        sa.Column("player_name", sa.Text(), nullable=False),
+        sa.Column("player_url", sa.Text()),
+        sa.Column("map_name", sa.Text(), nullable=False),
+        sa.Column("team_name", sa.Text()),
+        sa.Column("kills", sa.Integer()),
+        sa.Column("headshots", sa.Integer()),
+        sa.Column("assists", sa.Integer()),
+        sa.Column("flash_assists", sa.Integer()),
+        sa.Column("deaths", sa.Integer()),
+        sa.Column("traded_deaths", sa.Integer()),
+        sa.Column("opening_kills", sa.Integer()),
+        sa.Column("opening_deaths", sa.Integer()),
+        sa.Column("multi_kills", sa.Integer()),
+        sa.Column("clutches_won", sa.Integer()),
+        sa.Column("kast", sa.Float()),
+        sa.Column("kd_diff", sa.Integer()),
+        sa.Column("adr", sa.Float()),
+        sa.Column("fk_diff", sa.Integer()),
+        sa.Column("round_swing", sa.Float()),
+        sa.Column("rating", sa.Float()),
+        sa.Column("last_inserted_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_scraped_at", sa.TIMESTAMP()),
+        sa.Column("last_updated_at", sa.TIMESTAMP()),
+        sa.Column("data_complete", sa.Boolean(), server_default=sa.text("TRUE")),
+    )
+    op.create_table(
+        "player_team_history",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("player_id", sa.Integer(), sa.ForeignKey("player_info.player_id", ondelete="CASCADE")),
+        sa.Column("player_name", sa.Text(), nullable=False),
+        sa.Column("team_id", sa.Integer(), sa.ForeignKey("teams.team_id", ondelete="SET NULL")),
+        sa.Column("team_name", sa.Text(), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date()),
+        sa.Column("last_inserted_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.UniqueConstraint("player_id", "team_id", "start_date"),
+    )
+    op.create_table(
+        "player_aliases",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("player_id", sa.Integer(), sa.ForeignKey("player_info.player_id", ondelete="CASCADE")),
+        sa.Column("alias", sa.Text(), nullable=False),
+        sa.Column("changed_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_table(
+        "player_transfers",
+        sa.Column("transfer_id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("player_id", sa.Integer(), sa.ForeignKey("player_info.player_id", ondelete="CASCADE")),
+        sa.Column("player_name", sa.Text(), nullable=False),
+        sa.Column("old_team_id", sa.Integer(), sa.ForeignKey("teams.team_id", ondelete="SET NULL")),
+        sa.Column("old_team_name", sa.Text(), nullable=False),
+        sa.Column("new_team_id", sa.Integer(), sa.ForeignKey("teams.team_id", ondelete="SET NULL")),
+        sa.Column("new_team_name", sa.Text(), nullable=False),
+        sa.Column("transfer_date", sa.Date(), nullable=False),
+    )
+    op.create_table(
+        "match_ingestion_state",
+        sa.Column("match_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column("match_url", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("first_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_attempted_at", sa.TIMESTAMP()),
+        sa.Column("last_processed_at", sa.TIMESTAMP()),
+        sa.Column("last_failed_at", sa.TIMESTAMP()),
+        sa.Column("failure_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error_message", sa.Text()),
+        sa.Column("source", sa.Text()),
+        sa.Column("priority", sa.Integer(), server_default=sa.text("0")),
+        sa.Column("last_updated_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("status IN ('pending', 'processing', 'processed', 'failed', 'skipped')"),
+    )
+    op.create_table(
+        "map_ingestion_state",
+        sa.Column("map_id", sa.Integer(), primary_key=True, autoincrement=False),
+        sa.Column("map_url", sa.Text(), nullable=False),
+        sa.Column("match_id", sa.Integer(), sa.ForeignKey("matches.match_id", ondelete="CASCADE")),
+        sa.Column("map_order", sa.Integer()),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("first_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_attempted_at", sa.TIMESTAMP()),
+        sa.Column("last_processed_at", sa.TIMESTAMP()),
+        sa.Column("last_failed_at", sa.TIMESTAMP()),
+        sa.Column("failure_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error_message", sa.Text()),
+        sa.Column("source", sa.Text()),
+        sa.Column("priority", sa.Integer(), server_default=sa.text("0")),
+        sa.Column("last_updated_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("map_order BETWEEN 1 AND 5"),
+        sa.CheckConstraint("status IN ('pending', 'processing', 'processed', 'failed', 'skipped')"),
+    )
+    op.create_table(
+        "demo_ingestion_state",
+        sa.Column("demo_id", sa.Text(), primary_key=True),
+        sa.Column("demo_url", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("first_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_seen_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_attempted_at", sa.TIMESTAMP()),
+        sa.Column("last_processed_at", sa.TIMESTAMP()),
+        sa.Column("last_failed_at", sa.TIMESTAMP()),
+        sa.Column("failure_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error_message", sa.Text()),
+        sa.Column("source", sa.Text()),
+        sa.Column("priority", sa.Integer(), server_default=sa.text("0")),
+        sa.Column("last_updated_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("status IN ('pending', 'processing', 'processed', 'failed', 'skipped')"),
+    )
+    op.create_table(
+        "demo_files",
+        sa.Column(
+            "map_id",
+            sa.Integer(),
+            sa.ForeignKey("maps.map_id", ondelete="CASCADE"),
+            primary_key=True,
+            autoincrement=False,
+        ),
+        sa.Column("demo_url", sa.Text(), nullable=False),
+        sa.Column("local_path", sa.Text()),
+        sa.Column("parsed", sa.Boolean(), server_default=sa.text("FALSE")),
+        sa.Column("heatmap_done", sa.Boolean(), server_default=sa.text("FALSE")),
+        sa.Column("grenade_analysis_done", sa.Boolean(), server_default=sa.text("FALSE")),
+        sa.Column("last_inserted_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("last_processed_at", sa.TIMESTAMP()),
+    )
+    op.create_table(
+        "scrape_runs",
+        sa.Column("run_id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("started_at", sa.TIMESTAMP(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("ended_at", sa.TIMESTAMP()),
+        sa.Column("total_matches", sa.Integer()),
+        sa.Column("matches_success", sa.Integer()),
+        sa.Column("matches_failed", sa.Integer()),
+        sa.Column("notes", sa.Text()),
+    )
+    op.create_table(
+        "player_metrics",
+        sa.Column("player_id", sa.Integer(), primary_key=True),
+        sa.Column("map_name", sa.Text(), primary_key=True),
+        sa.Column("average_kills", sa.Float()),
+        sa.Column("entry_rating", sa.Float()),
+        sa.Column("clutch_success_rate", sa.Float()),
+        sa.Column("matches_played", sa.Integer()),
+        sa.Column("last_updated_at", sa.TIMESTAMP()),
+    )
+
+    op.create_index("idx_matches_date", "matches", ["date"])
+    op.create_index("idx_maps_match_id", "maps", ["match_id"])
+    op.create_index("idx_players_map_id", "players", ["map_id"])
+    op.create_index("idx_players_player_id", "players", ["player_id"])
+    op.create_index("idx_players_team_name", "players", ["team_name"])
+    op.create_index("idx_player_stats", "players", ["player_id", "map_id"])
+    op.create_index("idx_player_info_team_id", "player_info", ["team_id"])
+    op.create_index("idx_player_transfers_player_id", "player_transfers", ["player_id"])
+    op.create_index("idx_player_team_history_player_id", "player_team_history", ["player_id"])
+    op.execute(
+        "CREATE INDEX idx_match_ingestion_state_pending "
+        "ON match_ingestion_state (status, priority DESC, first_seen_at)"
+    )
+    op.execute(
+        "CREATE INDEX idx_map_ingestion_state_pending "
+        "ON map_ingestion_state (status, priority DESC, first_seen_at)"
+    )
+    op.execute(
+        "CREATE INDEX idx_demo_ingestion_state_pending "
+        "ON demo_ingestion_state (status, priority DESC, first_seen_at)"
+    )
+
+
+def downgrade() -> None:
+    for index_name in (
+        "idx_demo_ingestion_state_pending",
+        "idx_map_ingestion_state_pending",
+        "idx_match_ingestion_state_pending",
+        "idx_player_team_history_player_id",
+        "idx_player_transfers_player_id",
+        "idx_player_info_team_id",
+        "idx_player_stats",
+        "idx_players_team_name",
+        "idx_players_player_id",
+        "idx_players_map_id",
+        "idx_maps_match_id",
+        "idx_matches_date",
+    ):
+        op.drop_index(index_name)
+
+    for table_name in (
+        "player_metrics",
+        "scrape_runs",
+        "demo_files",
+        "demo_ingestion_state",
+        "map_ingestion_state",
+        "match_ingestion_state",
+        "player_transfers",
+        "player_aliases",
+        "player_team_history",
+        "players",
+        "maps",
+        "matches",
+        "player_info",
+        "teams",
+    ):
+        op.drop_table(table_name)

--- a/cs2_analytics/alembic/versions/__init__.py
+++ b/cs2_analytics/alembic/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Versioned application schema migrations."""

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -114,7 +114,8 @@ def initialize_database(create_db: bool = False) -> None:
         logger.info("Applying database migrations.")
         run_migrations()
         logger.info("Database migrations applied successfully.")
-
+    except DatabaseOperationError:
+        raise
     except Exception as e:
         raise DatabaseOperationError("Failed to initialize database schema.") from e
 

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -1,14 +1,13 @@
 """Database setup commands for schema creation and explicit wipes."""
 
 import argparse
-import os
+from pathlib import Path
 
 import psycopg2
 from psycopg2 import sql
 
 from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PASS, DB_PORT, DB_USER
 from cs2_analytics.exceptions import DatabaseOperationError
-from cs2_analytics.storage.database import Database
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
@@ -63,6 +62,25 @@ def create_database_if_missing(maintenance_db: str = "postgres") -> None:
         raise DatabaseOperationError("Failed to create database.") from e
 
 
+def run_migrations() -> None:
+    """Apply application schema migrations to the configured database."""
+    try:
+        from alembic import command
+        from alembic.config import Config
+
+        backend_root = Path(__file__).parents[1]
+        project_root = backend_root.parent
+        alembic_config = Config(str(backend_root / "alembic.ini"))
+        alembic_config.set_main_option(
+            "script_location",
+            str(backend_root / "alembic"),
+        )
+        alembic_config.set_main_option("prepend_sys_path", str(project_root))
+        command.upgrade(alembic_config, "head")
+    except Exception as e:
+        raise DatabaseOperationError("Failed to apply database migrations.") from e
+
+
 def wipe_database() -> None:
     """Drop application tables from the configured database."""
     drop_sql = "\n".join(
@@ -88,29 +106,14 @@ def confirm_wipe() -> bool:
 
 
 def initialize_database(create_db: bool = False) -> None:
-    """Create schema tables and indexes in the configured database."""
+    """Apply non-destructive schema migrations to the configured database."""
     if create_db:
         create_database_if_missing()
 
     try:
-        with psycopg2.connect(**_connection_kwargs(DB_NAME)) as conn:
-            logger.info("Connected to PostgreSQL database for schema initialization.")
-            with conn.cursor() as cur:
-                schema_path = os.path.join(os.path.dirname(__file__), "schema.sql")
-
-                with open(schema_path, encoding="utf-8") as schema_file:
-                    schema_sql = schema_file.read()
-                    cur.execute(schema_sql)
-
-        logger.info("Database tables created or verified.")
-
-        db = Database()
-        try:
-            db.create_indexes()
-        finally:
-            db.close_db_pool()
-
-        logger.info("Database schema initialized successfully.")
+        logger.info("Applying database migrations.")
+        run_migrations()
+        logger.info("Database migrations applied successfully.")
 
     except Exception as e:
         raise DatabaseOperationError("Failed to initialize database schema.") from e

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -27,6 +27,7 @@ TABLES_TO_WIPE = (
     "teams",
     "player_info",
     "scrape_runs",
+    "alembic_version",
 )
 
 

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -1,7 +1,8 @@
 # Current Architecture State
 
-This document summarizes the active architecture as of Phase 3.6. For the
-longer architecture overview, see `docs/architecture/overview.md`.
+This document summarizes the active architecture as of the Phase 3.75 Alembic
+migration baseline. For the longer architecture overview, see
+`docs/architecture/overview.md`.
 
 ## Active Runtime Flow
 
@@ -30,8 +31,11 @@ Phase 3.5 made the active parsed-source tables ready for downstream dbt staging:
 - `maps`: one row per played map
 - `players`: one row per player per map
 
-`cs2_analytics/storage/schema.sql` remains the current schema source of truth
-until deployment baseline work introduces versioned migrations.
+Alembic now owns the application/source schema for deployed environments. The
+initial migration mirrors the active `cs2_analytics/storage/schema.sql` tables,
+constraints, ingestion-state lifecycle fields, and setup indexes. Keep
+`schema.sql` aligned as a readable schema reference while migration ownership is
+being established.
 
 `docs/schema_target_pre_dbt.md` remains planning guidance only until implemented.
 
@@ -98,6 +102,11 @@ clearer.
 Phase 3.75 deployment baseline comes before dbt. The deployment baseline should
 prove that runtime configuration, migrations, containers, CI, and smoke tests
 work outside the local development machine.
+
+Normal database setup applies Alembic migrations through
+`alembic -c cs2_analytics/alembic.ini upgrade head` or
+`python manage_db.py --init`. Destructive table wipes remain explicit and
+interactive.
 
 dbt will be added after the deployment baseline and must remain downstream of
 ingestion. It should transform stable source tables, not own ingestion logic or

--- a/docs/architecture/decision_log.md
+++ b/docs/architecture/decision_log.md
@@ -97,8 +97,8 @@ Consequences:
 - Phase 3.75 follows Phase 3.6.
 - dbt remains the next analytics layer, but starts only after runtime and
   deployment assumptions are reproducible.
-- Application/source schema should move to Alembic during deployment baseline
-  work before dbt owns downstream transformation models.
+- Application/source schema moves to Alembic during deployment baseline work
+  before dbt owns downstream transformation models.
 - Airflow remains deferred until after dbt.
 
 ## ADR-0005: Keep Demo Expansion Deferred
@@ -125,7 +125,36 @@ Consequences:
 - Demo expansion should not be bundled into deployment baseline or dbt staging
   work.
 
-## ADR-0006: Use Issue-Driven, Reviewable Branches
+## ADR-0006: Use Alembic For Application Source Schema
+
+Status:
+Accepted
+
+Date:
+2026-05-21
+
+Context:
+Deployment baseline work needs a reproducible, non-destructive way to create
+and upgrade application/source tables outside one local development database.
+The previous setup path executed `schema.sql` directly and created indexes from
+Python setup code.
+
+Decision:
+Use Alembic migrations for application/source schema ownership. The initial
+migration mirrors the active `schema.sql` table shape, constraints,
+ingestion-state lifecycle fields, and setup indexes. Normal setup runs
+`alembic -c cs2_analytics/alembic.ini upgrade head` through
+`python manage_db.py --init`.
+
+Consequences:
+- Deployed environments update schema through Alembic.
+- `schema.sql` remains a readable schema reference during the migration
+  ownership transition and must stay aligned when schema changes occur.
+- Ingestion-state tables keep their lifecycle fields and do not gain
+  parsed-source audit fields.
+- dbt remains downstream and will not manage application/source schema.
+
+## ADR-0007: Use Issue-Driven, Reviewable Branches
 
 Status:
 Accepted

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,6 +30,11 @@ Demo processing is intentionally staged for later and remains decoupled from the
 
 The architecture is centered on explicit lifecycle/state tracking for discovered entities.
 
+Application/source schema changes are now managed through Alembic migrations
+during deployment baseline work. The initial migration preserves the active
+`schema.sql` semantics, including ingestion-state lifecycle fields and setup
+indexes. dbt remains downstream and does not own ingestion tables.
+
 For match and map discovery, the PostgreSQL tables `match_ingestion_state` and `map_ingestion_state` are source-of-truth lifecycle tables rather than simple transient work queues.
 
 The intended design is:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -374,7 +374,9 @@ containerized environment before adding dbt.
 Status:
 In progress. The `phase3.75-env-config-hardening` branch completed the first
 deployment-baseline slice by making runtime configuration environment-driven
-and production-safe.
+and production-safe. The `phase3.75-alembic-migrations` branch added Alembic
+configuration and an initial migration for the current application/source
+schema.
 
 Rationale:
 Phase 3.5 confirms that the parsed-source tables are stable enough for dbt, but
@@ -388,11 +390,11 @@ assumptions work outside the local development machine.
 - [x] Add `.env.example` with all required runtime variables
 - [x] Move dev-only config defaults out of production paths
 - [x] Make API host, port, CORS origins, debug mode, and database settings environment-driven
-- [ ] Add Alembic for versioned application database migrations
-- [ ] Convert the current `schema.sql` source tables into an initial Alembic migration
-- [ ] Keep schema initialization non-destructive by default
-- [ ] Add migration command documentation for local Docker and deployment usage
-- [ ] Ensure deployed database updates through `alembic upgrade head`
+- [x] Add Alembic for versioned application database migrations
+- [x] Convert the current `schema.sql` source tables into an initial Alembic migration
+- [x] Keep schema initialization non-destructive by default
+- [x] Add migration command documentation for local Docker and deployment usage
+- [x] Ensure deployed database updates through `alembic -c cs2_analytics/alembic.ini upgrade head`
 - [ ] Add a `Dockerfile` for the application runtime
 - [ ] Add `docker-compose.yml` for local deployment with app/API + PostgreSQL
 - [ ] Add a dedicated pipeline runner command or module entrypoint
@@ -417,10 +419,19 @@ assumptions work outside the local development machine.
    fails fast when required runtime variables are missing, debug mode is enabled,
    wildcard CORS is configured, or numeric ports are invalid.
 
-2. [ ] `phase3.75-alembic-migrations`
+2. [x] `phase3.75-alembic-migrations`
        Add Alembic, create the initial migration from the active schema, document
        migration commands, and make migrations the source of truth for deployed
        application/source tables.
+
+   Alembic now manages the application/source schema through an initial
+   migration that mirrors the active tables, constraints, ingestion-state
+   lifecycle fields, and setup indexes. `python manage_db.py --init` and
+   `python manage_db.py --create-database` apply
+   `alembic -c cs2_analytics/alembic.ini upgrade head`
+   non-destructively, while explicit wipe behavior remains separate. Existing
+   databases that already match the initial migration can be brought under
+   migration tracking with `alembic -c cs2_analytics/alembic.ini stamp head`.
 
 3. [ ] `phase3.75-container-runtime`
        Add `Dockerfile`, `docker-compose.yml`, and documented local container
@@ -444,10 +455,10 @@ assumptions work outside the local development machine.
 - [ ] Required environment variables are documented
 - [ ] API binds correctly in a deployed/container environment
 - [ ] PostgreSQL connection works through environment config
-- [ ] Fresh database can be initialized through migrations
-- [ ] Existing database can be upgraded without destructive reset
-- [ ] App tables and ingestion-state tables are migration-managed
-- [ ] Schema initialization is explicit and non-destructive by default
+- [x] Fresh database can be initialized through migrations
+- [x] Existing database can be brought under migration tracking without destructive reset
+- [x] App tables and ingestion-state tables are migration-managed
+- [x] Schema initialization is explicit and non-destructive by default
 - [ ] CI passes on every PR
 - [ ] A limited ingestion run works outside the local dev environment
 - [ ] API health endpoint works in deployed environment
@@ -466,7 +477,7 @@ reproducible deployment baseline.
 - [ ] Phase 3.6 issue-driven workflow is complete
 - [ ] Phase 3.75 deployment baseline is complete
 - [ ] Current ingestion pipeline can run outside the local dev machine
-- [ ] Application/source tables are managed by Alembic migrations
+- [x] Application/source tables are managed by Alembic migrations
 - [ ] dbt will be additive and downstream of ingestion, not a replacement for ingestion logic
 
 ### Database ownership boundary

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -2,23 +2,26 @@
 
 This document is split into two parts:
 
-- Current schema: what exists today in `cs2_analytics/storage/schema.sql`
+- Current schema: what exists today in Alembic and `cs2_analytics/storage/schema.sql`
 - Planned schema direction: candidates for follow-up schema cleanup, dbt, and
   later orchestration
 
 Current intent:
 
-- `cs2_analytics/storage/schema.sql` remains the source of truth for the current implementation.
+- Alembic migrations own application/source schema for setup and deployment.
+- `cs2_analytics/storage/schema.sql` remains a readable reference for the current
+  implementation and should stay aligned with migrations during the transition.
 - The ingestion-state lifecycle schema is implemented.
 - Active match, map, and demo controllers delegate per-item workflow to stage
   services; the next major architecture phase is dbt.
 
 ---
 
-## Current Schema (Source of Truth)
+## Current Schema Reference
 
-Use `cs2_analytics/storage/schema.sql` as final authority.
-Treat this as the working contract for the current codebase.
+Use the initial Alembic migration as the executable setup path. Treat
+`cs2_analytics/storage/schema.sql` as the readable schema reference for the
+current codebase.
 
 ### Core tables
 
@@ -232,6 +235,7 @@ See `docs/dbt_models.md` for later-phase dbt planning.
 
 ## Notes
 
-- Do not assume planned tables or fields exist until they are added to `schema.sql`.
+- Do not assume planned tables or fields exist until they are added to Alembic
+  migrations and the schema reference.
 - Treat current table names and future semantic roles separately.
 - For implementation work, align code and docs to the current section above first.

--- a/docs/ingestion_lifecycle.md
+++ b/docs/ingestion_lifecycle.md
@@ -3,8 +3,9 @@
 Status: Phase 1 decisions implemented in Phase 2
 
 This document captures the lifecycle semantics now implemented in the
-`*_ingestion_state` tables. The implementation source of truth remains
-`cs2_analytics/storage/schema.sql`.
+`*_ingestion_state` tables. Alembic migrations are now the executable setup
+path, and `cs2_analytics/storage/schema.sql` remains the readable schema
+reference during the migration ownership transition.
 
 ## Decisions So Far
 

--- a/docs/schema_target_pre_dbt.md
+++ b/docs/schema_target_pre_dbt.md
@@ -4,13 +4,13 @@ This is the intended parsed-source schema normalization target captured before
 dbt implementation. It documents a later cleanup path for the match, map, and
 player source tables.
 
-`cs2_analytics/storage/schema.sql` remains the source of truth until this target
-is implemented.
+Alembic migrations are now the executable setup path, while
+`cs2_analytics/storage/schema.sql` remains the readable schema reference during
+the migration ownership transition.
 
 Current status:
 
-- Phase 3.5 dbt readiness is complete for the active schema in
-  `cs2_analytics/storage/schema.sql`.
+- Phase 3.5 dbt readiness is complete for the active application/source schema.
 - This document is planning guidance for a later focused schema/model/storage
   normalization pass.
 - The changes below are not blockers for initial dbt staging over the current

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -112,6 +112,10 @@ outside the requested scope.
 Agents must not add dbt, Airflow, demo expansion, CT/T splits, eco-adjusted
 stats, or unrelated analytics scope unless explicitly requested.
 
+During Phase 3.75 and later, Alembic owns application/source schema changes.
+Keep `cs2_analytics/storage/schema.sql` aligned as a readable reference when
+schema migrations change application tables.
+
 ## Human Review Policy
 
 Human review is required before merge for:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "requests",
     "psycopg2-binary",
     "sqlalchemy",
+    "alembic",
     "loguru",
     "python-dotenv",
     "schedule",
@@ -72,7 +73,7 @@ include = ["cs2_analytics*", "api*"]
 exclude = ["tests*"]
 
 [tool.setuptools.package-data]
-cs2_analytics = ["storage/schema.sql"]
+cs2_analytics = ["storage/schema.sql", "alembic.ini", "alembic/script.py.mako"]
 
 # MyPy Configuration
 [tool.mypy]

--- a/tests/storage/test_alembic_migrations.py
+++ b/tests/storage/test_alembic_migrations.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import tomllib
@@ -30,7 +31,12 @@ def _table_block(migration_sql: str, table_name: str) -> str:
 def test_alembic_is_project_dependency() -> None:
     pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
 
-    assert "alembic" in pyproject["project"]["dependencies"]
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert any(
+        re.match(r"^alembic(\s|$|[<>=!~\[])", dependency.strip().lower())
+        for dependency in dependencies
+    )
 
 
 def test_alembic_env_does_not_render_plaintext_password_url() -> None:

--- a/tests/storage/test_alembic_migrations.py
+++ b/tests/storage/test_alembic_migrations.py
@@ -1,3 +1,4 @@
+import ast
 import re
 from pathlib import Path
 
@@ -18,14 +19,69 @@ def _migration_sql() -> str:
     return MIGRATION_PATH.read_text(encoding="utf-8")
 
 
-def _table_block(migration_sql: str, table_name: str) -> str:
-    start_marker = f'op.create_table(\n        "{table_name}",'
-    start_index = migration_sql.index(start_marker)
-    next_table_index = migration_sql.find("    op.create_table(", start_index + 1)
-    index_start = migration_sql.find("    op.create_index(", start_index + 1)
-    candidates = [value for value in (next_table_index, index_start) if value != -1]
-    end_index = min(candidates) if candidates else len(migration_sql)
-    return migration_sql[start_index:end_index]
+def _migration_tree() -> ast.Module:
+    return ast.parse(_migration_sql())
+
+
+def _is_op_call(node: ast.Call, name: str) -> bool:
+    return (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == name
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+    )
+
+
+def _string_constant(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _create_table_calls() -> dict[str, ast.Call]:
+    table_calls: dict[str, ast.Call] = {}
+    for node in ast.walk(_migration_tree()):
+        if not isinstance(node, ast.Call) or not _is_op_call(node, "create_table"):
+            continue
+        table_name = _string_constant(node.args[0])
+        if table_name is not None:
+            table_calls[table_name] = node
+    return table_calls
+
+
+def _column_calls(table_call: ast.Call) -> dict[str, ast.Call]:
+    columns: dict[str, ast.Call] = {}
+    for arg in table_call.args[1:]:
+        if (
+            isinstance(arg, ast.Call)
+            and isinstance(arg.func, ast.Attribute)
+            and arg.func.attr == "Column"
+        ):
+            column_name = _string_constant(arg.args[0])
+            if column_name is not None:
+                columns[column_name] = arg
+    return columns
+
+
+def _has_bool_keyword(call: ast.Call, name: str, expected: bool) -> bool:
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value is expected
+    return False
+
+
+def _index_names() -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(_migration_tree()):
+        if isinstance(node, ast.Call) and _is_op_call(node, "create_index"):
+            index_name = _string_constant(node.args[0])
+            if index_name is not None:
+                names.add(index_name)
+        elif isinstance(node, ast.Call) and _is_op_call(node, "execute"):
+            sql = _string_constant(node.args[0])
+            if sql is not None:
+                names.update(re.findall(r"CREATE INDEX ([a-z0-9_]+)", sql))
+    return names
 
 
 def test_alembic_is_project_dependency() -> None:
@@ -48,7 +104,7 @@ def test_alembic_env_does_not_render_plaintext_password_url() -> None:
 
 
 def test_initial_migration_defines_application_tables_and_indexes() -> None:
-    migration_sql = _migration_sql()
+    table_calls = _create_table_calls()
 
     for table_name in (
         "teams",
@@ -66,7 +122,9 @@ def test_initial_migration_defines_application_tables_and_indexes() -> None:
         "scrape_runs",
         "player_metrics",
     ):
-        assert f'"{table_name}"' in migration_sql
+        assert table_name in table_calls
+
+    index_names = _index_names()
 
     for index_name in (
         "idx_matches_date",
@@ -82,11 +140,11 @@ def test_initial_migration_defines_application_tables_and_indexes() -> None:
         "idx_map_ingestion_state_pending",
         "idx_demo_ingestion_state_pending",
     ):
-        assert index_name in migration_sql
+        assert index_name in index_names
 
 
 def test_initial_migration_preserves_ingestion_lifecycle_fields() -> None:
-    migration_sql = _migration_sql()
+    table_calls = _create_table_calls()
     required_columns = (
         "status",
         "first_seen_at",
@@ -106,15 +164,15 @@ def test_initial_migration_preserves_ingestion_lifecycle_fields() -> None:
         "map_ingestion_state",
         "demo_ingestion_state",
     ):
-        table_sql = _table_block(migration_sql, table_name)
+        column_names = set(_column_calls(table_calls[table_name]))
         for column_name in required_columns:
-            assert column_name in table_sql
-        assert "inserted_at" not in table_sql
-        assert "last_inserted_at" not in table_sql
+            assert column_name in column_names
+        assert "inserted_at" not in column_names
+        assert "last_inserted_at" not in column_names
 
 
 def test_initial_migration_preserves_explicit_source_id_primary_keys() -> None:
-    migration_sql = _migration_sql()
+    table_calls = _create_table_calls()
 
     for table_name, column_name in (
         ("teams", "team_id"),
@@ -124,6 +182,6 @@ def test_initial_migration_preserves_explicit_source_id_primary_keys() -> None:
         ("match_ingestion_state", "match_id"),
         ("map_ingestion_state", "map_id"),
     ):
-        table_sql = _table_block(migration_sql, table_name)
-        assert f'"{column_name}", sa.Integer(), primary_key=True' in table_sql
-        assert "autoincrement=False" in table_sql
+        columns = _column_calls(table_calls[table_name])
+        assert _has_bool_keyword(columns[column_name], "primary_key", True)
+        assert _has_bool_keyword(columns[column_name], "autoincrement", False)

--- a/tests/storage/test_alembic_migrations.py
+++ b/tests/storage/test_alembic_migrations.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import tomllib
+
+MIGRATION_PATH = (
+    Path(__file__).parents[2]
+    / "cs2_analytics"
+    / "alembic"
+    / "versions"
+    / "20260521_0001_initial_application_schema.py"
+)
+PYPROJECT_PATH = Path(__file__).parents[2] / "pyproject.toml"
+
+
+def _migration_sql() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _table_block(migration_sql: str, table_name: str) -> str:
+    start_marker = f'op.create_table(\n        "{table_name}",'
+    start_index = migration_sql.index(start_marker)
+    next_table_index = migration_sql.find("    op.create_table(", start_index + 1)
+    index_start = migration_sql.find("    op.create_index(", start_index + 1)
+    candidates = [value for value in (next_table_index, index_start) if value != -1]
+    end_index = min(candidates) if candidates else len(migration_sql)
+    return migration_sql[start_index:end_index]
+
+
+def test_alembic_is_project_dependency() -> None:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+
+    assert "alembic" in pyproject["project"]["dependencies"]
+
+
+def test_initial_migration_defines_application_tables_and_indexes() -> None:
+    migration_sql = _migration_sql()
+
+    for table_name in (
+        "teams",
+        "player_info",
+        "matches",
+        "maps",
+        "players",
+        "player_team_history",
+        "player_aliases",
+        "player_transfers",
+        "match_ingestion_state",
+        "map_ingestion_state",
+        "demo_ingestion_state",
+        "demo_files",
+        "scrape_runs",
+        "player_metrics",
+    ):
+        assert f'"{table_name}"' in migration_sql
+
+    for index_name in (
+        "idx_matches_date",
+        "idx_maps_match_id",
+        "idx_players_map_id",
+        "idx_players_player_id",
+        "idx_players_team_name",
+        "idx_player_stats",
+        "idx_player_info_team_id",
+        "idx_player_transfers_player_id",
+        "idx_player_team_history_player_id",
+        "idx_match_ingestion_state_pending",
+        "idx_map_ingestion_state_pending",
+        "idx_demo_ingestion_state_pending",
+    ):
+        assert index_name in migration_sql
+
+
+def test_initial_migration_preserves_ingestion_lifecycle_fields() -> None:
+    migration_sql = _migration_sql()
+    required_columns = (
+        "status",
+        "first_seen_at",
+        "last_seen_at",
+        "last_attempted_at",
+        "last_processed_at",
+        "last_failed_at",
+        "failure_count",
+        "last_error_message",
+        "source",
+        "priority",
+        "last_updated_at",
+    )
+
+    for table_name in (
+        "match_ingestion_state",
+        "map_ingestion_state",
+        "demo_ingestion_state",
+    ):
+        table_sql = _table_block(migration_sql, table_name)
+        for column_name in required_columns:
+            assert column_name in table_sql
+        assert "inserted_at" not in table_sql
+        assert "last_inserted_at" not in table_sql
+
+
+def test_initial_migration_preserves_explicit_source_id_primary_keys() -> None:
+    migration_sql = _migration_sql()
+
+    for table_name, column_name in (
+        ("teams", "team_id"),
+        ("player_info", "player_id"),
+        ("matches", "match_id"),
+        ("maps", "map_id"),
+        ("match_ingestion_state", "match_id"),
+        ("map_ingestion_state", "map_id"),
+    ):
+        table_sql = _table_block(migration_sql, table_name)
+        assert f'"{column_name}", sa.Integer(), primary_key=True' in table_sql
+        assert "autoincrement=False" in table_sql

--- a/tests/storage/test_alembic_migrations.py
+++ b/tests/storage/test_alembic_migrations.py
@@ -9,6 +9,7 @@ MIGRATION_PATH = (
     / "versions"
     / "20260521_0001_initial_application_schema.py"
 )
+ENV_PATH = Path(__file__).parents[2] / "cs2_analytics" / "alembic" / "env.py"
 PYPROJECT_PATH = Path(__file__).parents[2] / "pyproject.toml"
 
 
@@ -30,6 +31,14 @@ def test_alembic_is_project_dependency() -> None:
     pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
 
     assert "alembic" in pyproject["project"]["dependencies"]
+
+
+def test_alembic_env_does_not_render_plaintext_password_url() -> None:
+    env_sql = ENV_PATH.read_text(encoding="utf-8")
+
+    assert "hide_password=False" not in env_sql
+    assert "create_engine(" in env_sql
+    assert "render_as_string(hide_password=True)" in env_sql
 
 
 def test_initial_migration_defines_application_tables_and_indexes() -> None:

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -135,7 +135,27 @@ def test_initialize_database_can_create_configured_database_first(
     assert migration_calls == [True]
 
 
-def test_initialize_database_wraps_migration_failures_in_typed_error(
+def test_initialize_database_preserves_typed_migration_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration_error = DatabaseOperationError("Failed to apply database migrations.")
+
+    def fail_migrations() -> None:
+        raise migration_error
+
+    monkeypatch.setattr(
+        initialize_db_module,
+        "run_migrations",
+        fail_migrations,
+    )
+
+    with pytest.raises(DatabaseOperationError) as exc_info:
+        initialize_db_module.initialize_database()
+
+    assert exc_info.value is migration_error
+
+
+def test_initialize_database_wraps_unexpected_migration_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def fail_migrations() -> None:

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -1,6 +1,7 @@
 import builtins
-import io
-from pathlib import Path
+import sys
+import types
+from pathlib import Path, PurePath
 
 import pytest
 
@@ -56,26 +57,6 @@ class _RecordingConnection:
         return self.cursor_obj
 
 
-class _RecordingDatabase:
-    instances: list["_RecordingDatabase"] = []
-
-    def __init__(self) -> None:
-        self.indexes_created = False
-        self.closed = False
-        self.instances.append(self)
-
-    def create_indexes(self) -> bool:
-        self.indexes_created = True
-        return True
-
-    def close_db_pool(self) -> None:
-        self.closed = True
-
-
-def _fake_schema_file(*_args, **_kwargs) -> io.StringIO:
-    return io.StringIO("SELECT 1;")
-
-
 def _table_definition(schema_sql: str, table_name: str) -> str:
     start_marker = f"CREATE TABLE IF NOT EXISTS {table_name} ("
     start_index = schema_sql.index(start_marker)
@@ -83,77 +64,87 @@ def _table_definition(schema_sql: str, table_name: str) -> str:
     return schema_sql[start_index:end_index]
 
 
-def test_initialize_database_executes_schema_and_creates_indexes(
+def test_run_migrations_invokes_alembic_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    upgrade_calls: list[tuple[object, str]] = []
+    config_paths: list[str] = []
+    config_options: list[tuple[str, str]] = []
+
+    class _FakeConfig:
+        def __init__(self, path: str) -> None:
+            config_paths.append(path)
+
+        def set_main_option(self, name: str, value: str) -> None:
+            config_options.append((name, value))
+
+    fake_command = types.SimpleNamespace(
+        upgrade=lambda config, revision: upgrade_calls.append((config, revision))
+    )
+    fake_config = types.SimpleNamespace(Config=_FakeConfig)
+    fake_alembic = types.ModuleType("alembic")
+    fake_alembic.command = fake_command
+    fake_alembic.config = fake_config
+
+    monkeypatch.setitem(sys.modules, "alembic", fake_alembic)
+    monkeypatch.setitem(sys.modules, "alembic.command", fake_command)
+    monkeypatch.setitem(sys.modules, "alembic.config", fake_config)
+
+    initialize_db_module.run_migrations()
+
+    assert PurePath(config_paths[0]).parts[-2:] == ("cs2_analytics", "alembic.ini")
+    assert config_options[0][0] == "script_location"
+    assert PurePath(config_options[0][1]).parts[-1:] == ("alembic",)
+    assert config_options[1][0] == "prepend_sys_path"
+    assert upgrade_calls[0][1] == "head"
+
+
+def test_initialize_database_runs_migrations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cursor = _RecordingCursor()
-    connection = _RecordingConnection(cursor)
-    _RecordingDatabase.instances = []
+    migration_calls: list[bool] = []
 
     monkeypatch.setattr(
-        initialize_db_module.psycopg2, "connect", lambda **_: connection
+        initialize_db_module,
+        "run_migrations",
+        lambda: migration_calls.append(True),
     )
-    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
-    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
-    monkeypatch.setattr(
-        builtins,
-        "open",
-        _fake_schema_file,
-    )
-
     initialize_db_module.initialize_database()
 
-    assert connection.entered is True
-    assert connection.exited is True
-    assert cursor.entered is True
-    assert cursor.exited is True
-    assert cursor.executed == [("SELECT 1;", None)]
-    assert _RecordingDatabase.instances[0].indexes_created is True
-    assert _RecordingDatabase.instances[0].closed is True
+    assert migration_calls == [True]
 
 
 def test_initialize_database_can_create_configured_database_first(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cursor = _RecordingCursor()
-    connection = _RecordingConnection(cursor)
     create_database_calls: list[bool] = []
-    _RecordingDatabase.instances = []
+    migration_calls: list[bool] = []
 
-    monkeypatch.setattr(
-        initialize_db_module.psycopg2, "connect", lambda **_: connection
-    )
-    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
     monkeypatch.setattr(
         initialize_db_module,
         "create_database_if_missing",
         lambda: create_database_calls.append(True),
     )
-    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
-    monkeypatch.setattr(builtins, "open", _fake_schema_file)
+    monkeypatch.setattr(
+        initialize_db_module,
+        "run_migrations",
+        lambda: migration_calls.append(True),
+    )
 
     initialize_db_module.initialize_database(create_db=True)
 
     assert create_database_calls == [True]
-    assert cursor.executed == [("SELECT 1;", None)]
-    assert _RecordingDatabase.instances[0].indexes_created is True
+    assert migration_calls == [True]
 
 
-def test_initialize_database_wraps_schema_failures_in_typed_error(
+def test_initialize_database_wraps_migration_failures_in_typed_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cursor = _RecordingCursor(should_fail=True)
-    connection = _RecordingConnection(cursor)
+    def fail_migrations() -> None:
+        raise RuntimeError("migration failed")
 
     monkeypatch.setattr(
-        initialize_db_module.psycopg2, "connect", lambda **_: connection
-    )
-    monkeypatch.setattr(initialize_db_module, "Database", _RecordingDatabase)
-    monkeypatch.setattr(initialize_db_module.os.path, "dirname", lambda _: "fake_dir")
-    monkeypatch.setattr(
-        builtins,
-        "open",
-        _fake_schema_file,
+        initialize_db_module,
+        "run_migrations",
+        fail_migrations,
     )
 
     with pytest.raises(
@@ -162,8 +153,6 @@ def test_initialize_database_wraps_schema_failures_in_typed_error(
         initialize_db_module.initialize_database()
 
     assert isinstance(exc_info.value.__cause__, RuntimeError)
-    assert connection.exited is True
-    assert cursor.exited is True
 
 
 def test_wipe_database_executes_explicit_drop_table_statements(


### PR DESCRIPTION
## Summary

Adds Alembic as the application/source schema migration path for Phase 3.75 and converts the current `schema.sql` application schema into an initial migration. Updates `manage_db.py` setup behavior through `cs2_analytics.storage.initialize_db` so normal initialization applies `alembic upgrade head` non-destructively.

## Related Issue

Closes #43

## Scope

- Adds Alembic config under `cs2_analytics/alembic.ini` and migration environment under `cs2_analytics/alembic/`.
- Adds initial migration `20260521_0001_initial_application_schema.py` for current application/source tables, constraints, ingestion-state lifecycle fields, and indexes.
- Adds `alembic` as a project dependency and packages Alembic config/template files.
- Updates database initialization to run Alembic migrations while keeping explicit wipe behavior separate.
- Adds focused tests for migration setup, lifecycle fields, source ID primary keys, and initialization behavior.
- Updates README, backlog, architecture, schema, workflow, and agent docs for Alembic schema ownership.

## Out of Scope

- No dbt project or dbt models added.
- No Airflow, Docker runtime, CI, or container orchestration changes.
- No demo pipeline expansion.
- No parsed-source audit field normalization beyond the active schema.
- No SQLAlchemy ORM model refactor.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: `High`

Reason: This changes schema ownership and database initialization behavior by introducing versioned migrations for application/source tables.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes follow the Phase 3.75 Alembic ownership rule; `schema.sql` remains a readable reference.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: `Updated`

Reason: README, architecture docs, schema docs, workflow docs, AGENTS.md, and migration ownership notes were updated for Alembic setup and command usage.

Backlog: `Updated`

Reason: This branch completes the Phase 3.75 Alembic migration slice and updates the related checklist/status items.

## Verification

Commands run:

```sh
.venv\Scripts\python.exe -m alembic -c cs2_analytics\alembic.ini history
.venv\Scripts\python.exe -m alembic -c cs2_analytics\alembic.ini upgrade head --sql
.venv\Scripts\python.exe -m pytest tests\storage\test_initialize_db.py tests\storage\test_alembic_migrations.py
.venv\Scripts\python.exe -m pytest
```

Manual checks:

- Fresh local database was wiped, `alembic upgrade head` created the tables, and `alembic current` plus the `alembic_version` table showed revision `20260521_0001`.

Results:

- Alembic history resolves the initial migration.
- Offline upgrade SQL renders successfully.
- Focused tests pass.
- Full suite passes: `104 passed, 3 skipped`.
- Known residual warning: pytest cache warning about `.pytest_cache` path creation on Windows.

## Review Notes

Human review required because this is schema/migration/deployment-impacting work. Please focus on whether the initial migration accurately mirrors `cs2_analytics/storage/schema.sql`, whether ingestion-state lifecycle fields remain stable, and whether the existing-database `stamp head` guidance is clear.