### PR TITLE
Add Phase 3.75 CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-type-test:
     name: Lint, Type Check, And Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.14"
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-type-test:
+    name: Lint, Type Check, And Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: cs2_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: change_me
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d cs2_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      ENVIRONMENT: development
+      DEBUG_MODE: "false"
+      API_HOST: 127.0.0.1
+      API_PORT: "8000"
+      API_CORS_ORIGINS: http://localhost:3000,http://127.0.0.1:3000,http://localhost:8501,http://127.0.0.1:8501
+      DB_NAME: cs2_db
+      DB_USER: postgres
+      DB_PASS: change_me
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Lint
+        run: python -m ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501
+
+      - name: Type check runtime code
+        run: python -m mypy api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip
+
+      - name: Run migrations
+        run: python -m alembic -c cs2_analytics/alembic.ini upgrade head
+
+      - name: Run tests
+        run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Counter-Strike 2 Pro Match Analytics Tool
 
+[![CI](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml)
+
 ## Project Overview
 
 This project is a Counter-Strike 2 analytics tool focused on collecting professional match, map, and player data and turning it into reliable, queryable analytics data.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -376,8 +376,11 @@ In progress. The `phase3.75-env-config-hardening` branch completed the first
 deployment-baseline slice by making runtime configuration environment-driven
 and production-safe. The `phase3.75-alembic-migrations` branch added Alembic
 configuration and an initial migration for the current application/source
-schema. The `phase3.75-container-runtime` branch adds the local Docker runtime
-baseline for PostgreSQL, migrations, the API, and pipeline runs.
+schema. The `phase3.75-container-runtime` branch added the local Docker runtime
+baseline for PostgreSQL, migrations, the API, and pipeline runs. The
+`phase3.75-ci-gate` branch added the minimum GitHub Actions merge gate for
+installation, focused linting, initial runtime type checking, migrations, and
+tests.
 
 Rationale:
 Phase 3.5 confirms that the parsed-source tables are stable enough for dbt, but
@@ -401,7 +404,7 @@ assumptions work outside the local development machine.
 - [x] Add a dedicated pipeline runner command or module entrypoint
 - [x] Add a dedicated API runner command or deployment-safe Uvicorn command
 - [ ] Add `/health` endpoint for API health checks
-- [ ] Add GitHub Actions CI for lint, type check, and tests
+- [x] Add GitHub Actions CI for lint, type check, and tests
 - [ ] Add a deployment smoke test path:
       migrations -> limited ingestion -> API health/top players check
 - [x] Document local Docker startup and production deployment variables
@@ -444,9 +447,16 @@ assumptions work outside the local development machine.
    runs. Runtime artifacts such as logs, demos, and parsed data are mounted from
    the working tree and excluded from the image.
 
-4. [ ] `phase3.75-ci-gate`
+4. [x] `phase3.75-ci-gate`
        Add GitHub Actions for install, lint, type check, and tests. CI should become
        the minimum merge gate before dbt begins.
+
+   CI now runs on pull requests and pushes to `main`. The gate installs dev
+   dependencies, runs a focused `python -m ruff` `E,F` lint over runtime code,
+   type checks API and runner entrypoints with `python -m mypy`, applies
+   Alembic migrations against a PostgreSQL service container, and runs
+   `python -m pytest`. Broader Ruff rules, formatting checks, and full-package
+   MyPy remain follow-up tightening work.
 
 5. [ ] `phase3.75-deployment-smoke-test`
        Add a small deployment verification path that proves the container can run
@@ -466,7 +476,7 @@ assumptions work outside the local development machine.
 - [x] Existing database can be brought under migration tracking without destructive reset
 - [x] App tables and ingestion-state tables are migration-managed
 - [x] Schema initialization is explicit and non-destructive by default
-- [ ] CI passes on every PR
+- [x] CI passes on every PR
 - [ ] A limited ingestion run works outside the local dev environment
 - [ ] API health endpoint works in deployed environment
 - [ ] There is a temporary scheduled/manual runner path before Airflow

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -29,7 +29,8 @@ Airflow comes after dbt.
    notes.
 7. Request human review for medium-risk, high-risk, schema, deployment,
    dependency, CI, or architecture-boundary changes.
-8. Merge only after review concerns and verification gaps are resolved.
+8. Merge only after CI passes, review concerns are resolved, and verification
+   gaps are closed.
 
 ## Branch Naming
 
@@ -129,6 +130,17 @@ Human review is required before merge for:
 
 Low-risk docs and template changes may still be reviewed, but they are intended
 to be small and fast to evaluate.
+
+## CI Gate
+
+GitHub Actions CI runs on pull requests and pushes to `main`. The minimum gate
+installs development dependencies, runs focused `python -m ruff` `E,F` linting
+over runtime code, type checks API and runner entrypoints with
+`python -m mypy`, applies Alembic migrations against PostgreSQL, and runs
+`python -m pytest`.
+
+Broader Ruff rules, formatting checks, and full-package MyPy may be added later
+once the project is ready to enforce stricter gates.
 
 ## Documentation Check
 


### PR DESCRIPTION
## Summary

Adds the Phase 3.75 GitHub Actions CI gate for pull requests and pushes to `main`.

The workflow installs dev dependencies, runs focused Ruff linting, scoped MyPy checks for API/runner entrypoints, applies Alembic migrations against a PostgreSQL service container, and runs the full pytest suite. Also adds a README CI badge and updates workflow/backlog docs to reflect CI as the minimum merge gate before dbt.

## Related Issue

Closes #45

## Scope

- Added `.github/workflows/ci.yml`
- Added CI badge to `README.md`
- Updated `docs/backlog.md`
- Updated `docs/workflow.md`

## Out of Scope

- Full-package MyPy cleanup
- Full Ruff rule enforcement
- Formatting gate
- Deployment smoke test
- `/health` endpoint
- dbt, Airflow, or demo expansion

## Risk Level

Risk level: Medium

Reason: Adds CI behavior and PR merge gating, but does not change runtime ingestion code, schema, migrations, or deployment targets.

## Architecture And Roadmap Check

- No ingestion responsibilities moved into dbt.
- No schema, lifecycle, parser, scraper, storage, controller, or stage-service behavior changed.
- Phase 3.75 CI gate is now complete.
- Stricter lint/type/format gates remain follow-up tightening work.

## Documentation Check

Documentation: Updated

Reason: CI changes affect test commands and agent/developer workflow.

Backlog: Updated

Reason: This branch completes the `phase3.75-ci-gate` roadmap item and marks the CI PR gate exit criterion complete.

## Verification

Commands run:

```sh
python -m ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501
python -m mypy api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip
python -m alembic -c cs2_analytics/alembic.ini upgrade head
python -m pytest