### PR TITLE
Add deterministic deployment smoke path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
 COPY pyproject.toml README.md ./
 COPY api ./api
 COPY cs2_analytics ./cs2_analytics
+COPY scripts ./scripts
 
 RUN python -m pip install --upgrade pip \
     && python -m pip install .

--- a/README.md
+++ b/README.md
@@ -183,6 +183,22 @@ The API is available at `http://localhost:8000` by default. See
 `docs/deployment.md` for Docker build, environment variable, runtime data, and
 container command details.
 
+Run the deterministic deployment smoke path after PostgreSQL, migrations, and
+the API are available:
+
+```sh
+docker compose up -d db
+docker compose --profile tools run --rm migrate
+docker compose up -d app
+docker compose --profile tools run --rm smoke
+```
+
+The smoke path seeds a tiny fixed-ID dataset, checks `/health`, verifies the API
+can query PostgreSQL through the top players read path, and removes the smoke
+rows before exiting. It should run against a local or deployment-validation
+database, not a production analytics database, and does not depend on live
+website scraping.
+
 ### 7. Run the Pipeline
 
 ```sh

--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,11 @@ from cs2_analytics.config import API_CORS_ORIGINS, API_DEBUG
 from .routes import players
 
 
+def health_payload() -> dict[str, str]:
+    """Return the stable API health response."""
+    return {"status": "ok", "service": "cs2-analytics-api"}
+
+
 def create_app() -> FastAPI:
     """
     Creates and configures the FastAPI application.
@@ -29,11 +34,11 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     def health() -> dict[str, str]:
-        return {"status": "ok", "service": "cs2-analytics-api"}
+        return health_payload()
 
     @app.get("/")
     def root_health() -> dict[str, str]:
-        return health()
+        return health_payload()
 
     return app
 

--- a/api/main.py
+++ b/api/main.py
@@ -27,9 +27,13 @@ def create_app() -> FastAPI:
 
     app.include_router(players.router, prefix="/api", tags=["Players"])
 
-    @app.get("/")
+    @app.get("/health")
     def health() -> dict[str, str]:
         return {"status": "ok", "service": "cs2-analytics-api"}
+
+    @app.get("/")
+    def root_health() -> dict[str, str]:
+        return health()
 
     return app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "python -c \"import os, urllib.request; port = os.environ.get('API_PORT', '8000'); urllib.request.urlopen('http://127.0.0.1:' + port + '/', timeout=5).read()\"",
+          "python -c \"import os, urllib.request; port = os.environ.get('API_PORT', '8000'); urllib.request.urlopen('http://127.0.0.1:' + port + '/health', timeout=5).read()\"",
         ]
       interval: 30s
       timeout: 5s
@@ -75,6 +75,22 @@ services:
     shm_size: "2gb"
     depends_on:
       db:
+        condition: service_healthy
+
+  smoke:
+    image: cs2-analytics:local
+    build:
+      context: .
+    profiles: ["tools"]
+    environment:
+      <<: *app_environment
+      SMOKE_API_BASE_URL: "http://app:${API_PORT:-8000}"
+      SMOKE_API_TIMEOUT_SECONDS: "10"
+    command: ["python", "scripts/deployment_smoke.py"]
+    depends_on:
+      db:
+        condition: service_healthy
+      app:
         condition: service_healthy
 
 volumes:

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -114,9 +114,15 @@ changing ingestion responsibilities:
 - API: `python run_api.py`
 - migrations: `python manage_db.py --init`
 - pipeline: `python main.py`
+- deployment smoke: `python scripts/deployment_smoke.py`
 
-`docker-compose.yml` provides local PostgreSQL plus app, migration, and
-pipeline services. Runtime artifacts such as logs, downloaded demos, and parsed
+`docker-compose.yml` provides local PostgreSQL plus app, migration, pipeline,
+and smoke services. The smoke service is deterministic: it verifies migrated
+source tables, removes stale fixed-ID smoke rows, seeds source rows through
+existing storage upserts, checks `/health`, confirms the top players API can
+query PostgreSQL, and removes the fixed-ID rows before exiting. It should run
+against a local or deployment-validation database rather than a production
+analytics database. Runtime artifacts such as logs, downloaded demos, and parsed
 data stay mounted from the working tree and are not baked into the image.
 
 dbt will be added after the deployment baseline and must remain downstream of

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -410,9 +410,21 @@ assumptions work outside the local development machine.
 - [x] Add a deployment smoke test path:
       migrations -> deterministic source-row seed/read/cleanup -> API health/top players check
 - [x] Document local Docker startup and production deployment variables
-- [ ] Choose first deployment target for the API and worker
-- [ ] Choose temporary scheduling strategy for scraper runs before Airflow
-- [ ] Confirm the system can run without relying on local machine state
+- [ ] Choose first deployment target for the API runtime
+- [ ] Choose first deployment target for pipeline/worker runs
+- [ ] Document the API + worker deployment topology
+- [ ] Document staging/production environment variables and secret source
+- [ ] Define migration order for deployment startup or release
+- [ ] Define read-only production validation checks:
+      Alembic version -> `/health` -> DB-backed API read
+- [ ] Define smoke/staging database policy for write-based smoke tests
+- [ ] Choose temporary pre-Airflow runner strategy:
+      manual job, scheduled platform job, or GitHub Actions manual dispatch
+- [ ] Confirm containerized Selenium/Chromium can run in the chosen worker environment
+- [ ] Confirm runtime artifacts do not rely on local machine state:
+      logs, demos, parsed data, browser cache, and temporary files
+- [ ] Document rollback/recovery expectations for failed deploys or migrations
+- [ ] Run one limited live ingestion validation in a staging/smoke environment
 
 ### Suggested branch sequence
 
@@ -474,9 +486,20 @@ assumptions work outside the local development machine.
    intentionally avoids live HLTV scraping so deployment checks do not fail when
    the upstream website is unavailable or changes markup.
 
-6. [ ] `phase3.75-first-cloud-deploy`
+6. [ ] `phase3.75-first-cloud-deploy-plan`
+       Choose the first API and worker deployment targets, document the intended
+       topology, define staging/production environment variables and secret
+       sources, define migration order, define smoke/staging database policy,
+       define read-only production validation checks, choose the temporary
+       pre-Airflow runner strategy, and document rollback/recovery expectations.
+
+7. [ ] `phase3.75-first-cloud-deploy`
        Deploy the API and pipeline runner to the chosen initial platform. Keep the
-       deployment simple and low-cost. Do not add Airflow yet.
+       deployment simple and low-cost. Run migrations in the chosen release flow,
+       run the deterministic smoke path against staging or smoke infrastructure,
+       run read-only production validation after deploy, confirm
+       Selenium/Chromium works in the worker environment, and run one limited
+       live ingestion validation in staging/smoke. Do not add Airflow yet.
 
 ### Phase 3.75 exit criteria
 
@@ -491,7 +514,16 @@ assumptions work outside the local development machine.
 - [x] CI passes on every PR
 - [x] A deterministic source-row seed/read/cleanup smoke path works outside the local dev environment
 - [x] API health endpoint works in deployed environment
+- [ ] First API and worker deployment targets are chosen and documented
+- [ ] Staging/production environment variables and secret source are documented
+- [ ] Deployment migration order is documented
+- [ ] Smoke/staging database policy is documented for write-based smoke tests
+- [ ] Read-only production validation checks are defined
+- [ ] Containerized Selenium/Chromium works in the chosen worker environment
+- [ ] Runtime artifacts do not rely on local machine state
+- [ ] Rollback/recovery expectations are documented
 - [ ] There is a temporary scheduled/manual runner path before Airflow
+- [ ] One limited live ingestion validation passes in staging/smoke
 
 ---
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -380,7 +380,9 @@ schema. The `phase3.75-container-runtime` branch added the local Docker runtime
 baseline for PostgreSQL, migrations, the API, and pipeline runs. The
 `phase3.75-ci-gate` branch added the minimum GitHub Actions merge gate for
 installation, focused linting, initial runtime type checking, migrations, and
-tests.
+tests. The `phase3.75-deployment-smoke-test` branch added a deterministic
+container smoke path for migrations, fixed-ID source-row seed/read/cleanup,
+API health, and a DB-backed top players read check.
 
 Rationale:
 Phase 3.5 confirms that the parsed-source tables are stable enough for dbt, but
@@ -403,10 +405,10 @@ assumptions work outside the local development machine.
 - [x] Add `docker-compose.yml` for local deployment with app/API + PostgreSQL
 - [x] Add a dedicated pipeline runner command or module entrypoint
 - [x] Add a dedicated API runner command or deployment-safe Uvicorn command
-- [ ] Add `/health` endpoint for API health checks
+- [x] Add `/health` endpoint for API health checks
 - [x] Add GitHub Actions CI for lint, type check, and tests
-- [ ] Add a deployment smoke test path:
-      migrations -> limited ingestion -> API health/top players check
+- [x] Add a deployment smoke test path:
+      migrations -> deterministic source-row seed/read/cleanup -> API health/top players check
 - [x] Document local Docker startup and production deployment variables
 - [ ] Choose first deployment target for the API and worker
 - [ ] Choose temporary scheduling strategy for scraper runs before Airflow
@@ -458,9 +460,19 @@ assumptions work outside the local development machine.
    `python -m pytest`. Broader Ruff rules, formatting checks, and full-package
    MyPy remain follow-up tightening work.
 
-5. [ ] `phase3.75-deployment-smoke-test`
+5. [x] `phase3.75-deployment-smoke-test`
        Add a small deployment verification path that proves the container can run
-       migrations, execute a limited ingestion pass, and start the API.
+       migrations, execute a deterministic source-row smoke pass, and start the
+       API.
+
+   The deployment smoke path now runs through compose with PostgreSQL,
+   migrations, and the API, then executes `scripts/deployment_smoke.py`. The
+   script verifies migrated source tables, removes stale fixed-ID smoke rows,
+   seeds deterministic match/map/player rows through existing storage upserts,
+   checks `/health`, confirms the API can query PostgreSQL through
+   `/api/top_players`, and removes the fixed-ID smoke rows before exiting. It
+   intentionally avoids live HLTV scraping so deployment checks do not fail when
+   the upstream website is unavailable or changes markup.
 
 6. [ ] `phase3.75-first-cloud-deploy`
        Deploy the API and pipeline runner to the chosen initial platform. Keep the
@@ -477,8 +489,8 @@ assumptions work outside the local development machine.
 - [x] App tables and ingestion-state tables are migration-managed
 - [x] Schema initialization is explicit and non-destructive by default
 - [x] CI passes on every PR
-- [ ] A limited ingestion run works outside the local dev environment
-- [ ] API health endpoint works in deployed environment
+- [x] A deterministic source-row seed/read/cleanup smoke path works outside the local dev environment
+- [x] API health endpoint works in deployed environment
 - [ ] There is a temporary scheduled/manual runner path before Airflow
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,11 +24,10 @@ docker compose up --build app
 ```
 
 The API binds to `0.0.0.0` in the container and is published on
-`http://localhost:8000` by default. Check the root health response or FastAPI
-docs:
+`http://localhost:8000` by default. Check the health response or FastAPI docs:
 
 ```sh
-curl http://localhost:8000/
+curl http://localhost:8000/health
 curl http://localhost:8000/docs
 ```
 
@@ -66,6 +65,30 @@ results discovery -> match processing -> map processing
 
 Demo download and parsing remain deferred.
 
+## Deployment Smoke Test
+
+Run the deterministic deployment smoke path after PostgreSQL, migrations, and
+the API are available:
+
+```sh
+docker compose up -d db
+docker compose --profile tools run --rm migrate
+docker compose up -d app
+docker compose --profile tools run --rm smoke
+```
+
+The smoke script validates that migrations created the expected source tables,
+cleans up any stale fixed-ID smoke rows, seeds a tiny fixed-ID match/map/player
+dataset through the existing storage upsert functions, checks `GET /health`,
+checks `GET /api/top_players?min_maps=1&limit=100` for the seeded smoke player,
+and removes the fixed-ID smoke rows before exiting.
+
+This path is intentionally deterministic and does not call HLTV. Live scraping
+can be checked manually with the pipeline command above, but deployment smoke
+tests should not fail because the upstream website is unavailable or has
+changed markup. Run it against local, smoke, staging, or otherwise disposable
+deployment-validation databases rather than a production analytics database.
+
 ## Environment
 
 Compose provides container-safe defaults for local development. Override these
@@ -81,6 +104,8 @@ through your shell environment or a local `.env` file when needed.
 | `DB_USER` | `postgres` | PostgreSQL user. |
 | `DB_PASS` | `change_me` | PostgreSQL password for local compose only. |
 | `POSTGRES_HOST_PORT` | `5432` | Host port mapped to the PostgreSQL container. |
+| `SMOKE_API_BASE_URL` | `http://app:8000` | API base URL used by the compose smoke service. |
+| `SMOKE_API_TIMEOUT_SECONDS` | `10` | HTTP timeout used by the smoke script. |
 
 The application container always uses `DB_HOST=db` and `DB_PORT=5432` when
 running through compose.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for local and deployment workflows."""

--- a/scripts/deployment_smoke.py
+++ b/scripts/deployment_smoke.py
@@ -1,0 +1,224 @@
+"""Deterministic deployment smoke checks for the containerized runtime."""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+
+from cs2_analytics.models.map import Map
+from cs2_analytics.models.match import Match
+from cs2_analytics.models.player import Player
+from cs2_analytics.storage.database import Database
+from cs2_analytics.storage.map_storage import store_maps
+from cs2_analytics.storage.match_storage import store_matches
+from cs2_analytics.storage.player_storage import store_players
+from cs2_analytics.utils.log_manager import get_logger
+
+logger = get_logger(__name__)
+
+REQUIRED_TABLES = ("matches", "maps", "players")
+SMOKE_MATCH_ID = 930_000_001
+SMOKE_MAP_ID = 930_000_101
+SMOKE_PLAYER_ID = 930_000_201
+SMOKE_PLAYER_NAME = "Smoke Test Player"
+
+
+def main() -> int:
+    """Run deterministic deployment smoke checks."""
+    smoke_data_touched = False
+    try:
+        api_base_url = os.getenv("SMOKE_API_BASE_URL", "http://127.0.0.1:8000").rstrip(
+            "/"
+        )
+        timeout_seconds = read_timeout_seconds()
+        verify_migrated_tables()
+        cleanup_smoke_source_rows()
+        smoke_data_touched = True
+        seed_smoke_source_rows()
+        verify_api_health(api_base_url, timeout_seconds)
+        verify_top_players_read(api_base_url, timeout_seconds)
+    except Exception as exc:
+        logger.exception("Deployment smoke check failed: %s", exc)
+        return 1
+    finally:
+        if smoke_data_touched:
+            try:
+                cleanup_smoke_source_rows()
+            except Exception as exc:
+                logger.warning("Failed to clean up deployment smoke data: %s", exc)
+
+    logger.info("Deployment smoke check passed.")
+    return 0
+
+
+def read_timeout_seconds() -> int:
+    """Read the smoke HTTP timeout from the environment."""
+    raw_value = os.getenv("SMOKE_API_TIMEOUT_SECONDS", "10")
+    try:
+        timeout_seconds = int(raw_value)
+    except ValueError as exc:
+        raise RuntimeError("SMOKE_API_TIMEOUT_SECONDS must be an integer.") from exc
+
+    if timeout_seconds <= 0:
+        raise RuntimeError("SMOKE_API_TIMEOUT_SECONDS must be greater than zero.")
+
+    return timeout_seconds
+
+
+def verify_migrated_tables() -> None:
+    """Confirm the expected source tables exist after migrations."""
+    db = Database()
+    missing_tables = []
+
+    with db.get_cursor() as cur:
+        for table_name in REQUIRED_TABLES:
+            cur.execute("SELECT to_regclass(%s);", (f"public.{table_name}",))
+            if cur.fetchone()[0] is None:
+                missing_tables.append(table_name)
+
+    if missing_tables:
+        raise RuntimeError(
+            "Missing migrated tables: " + ", ".join(sorted(missing_tables))
+        )
+
+
+def cleanup_smoke_source_rows() -> None:
+    """Remove fixed-ID smoke rows from source tables."""
+    db = Database()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "DELETE FROM players WHERE map_id = %s AND player_id = %s;",
+            (SMOKE_MAP_ID, SMOKE_PLAYER_ID),
+        )
+        cur.execute("DELETE FROM maps WHERE map_id = %s;", (SMOKE_MAP_ID,))
+        cur.execute("DELETE FROM matches WHERE match_id = %s;", (SMOKE_MATCH_ID,))
+
+
+def seed_smoke_source_rows() -> None:
+    """Seed repeat-safe source rows used by the API readiness check."""
+    now = datetime.now(UTC)
+    match_date = now.isoformat()
+
+    store_matches(
+        [
+            Match(
+                match_id=SMOKE_MATCH_ID,
+                match_url=f"https://smoke.local/matches/{SMOKE_MATCH_ID}",
+                map_links=[(SMOKE_MAP_ID, f"https://smoke.local/stats/maps/{SMOKE_MAP_ID}")],
+                demo_links=[],
+                team1="Smoke Alpha",
+                team2="Smoke Beta",
+                score1=13,
+                score2=7,
+                winner="Smoke Alpha",
+                event="Deployment Smoke",
+                match_type="bo1",
+                forfeit=False,
+                date=match_date,
+                last_inserted_at=now,
+                last_scraped_at=now,
+                last_updated_at=now,
+                data_complete=True,
+            )
+        ]
+    )
+
+    store_maps(
+        [
+            Map(
+                map_id=SMOKE_MAP_ID,
+                match_id=SMOKE_MATCH_ID,
+                map_url=f"https://smoke.local/stats/maps/{SMOKE_MAP_ID}",
+                map_name="Smoke",
+                map_order=1,
+                team1_score=13,
+                team2_score=7,
+                map_winner="Smoke Alpha",
+                date=match_date,
+                inserted_at=now,
+                last_scraped_at=now,
+                last_updated_at=now,
+                data_complete=True,
+            )
+        ]
+    )
+
+    store_players(
+        [
+            Player(
+                map_id=SMOKE_MAP_ID,
+                player_id=SMOKE_PLAYER_ID,
+                player_name=SMOKE_PLAYER_NAME,
+                player_url=f"https://smoke.local/player/{SMOKE_PLAYER_ID}",
+                map_name="Smoke",
+                team_name="Smoke Alpha",
+                kills=30,
+                headshots=20,
+                assists=5,
+                flash_assists=2,
+                deaths=4,
+                traded_deaths=1,
+                opening_kills=6,
+                opening_deaths=1,
+                multi_kills=8,
+                clutches_won=2,
+                kast=95.0,
+                kd_diff=26,
+                adr=150.0,
+                fk_diff=5,
+                round_swing=0.5,
+                rating=9.99,
+                last_inserted_at=now,
+                last_scraped_at=now,
+                last_updated_at=now,
+                data_complete=True,
+            )
+        ]
+    )
+
+
+def verify_api_health(api_base_url: str, timeout_seconds: int) -> None:
+    """Check the stable shallow API health endpoint."""
+    payload = request_json(f"{api_base_url}/health", timeout_seconds)
+    expected_payload = {"status": "ok", "service": "cs2-analytics-api"}
+    if payload != expected_payload:
+        raise RuntimeError(f"Unexpected health payload: {payload!r}")
+
+
+def verify_top_players_read(api_base_url: str, timeout_seconds: int) -> None:
+    """Check that the API can read seeded source data from PostgreSQL."""
+    payload = request_json(
+        f"{api_base_url}/api/top_players?min_maps=1&limit=100",
+        timeout_seconds,
+    )
+    if not isinstance(payload, list):
+        raise RuntimeError(f"Expected top players list, got: {payload!r}")
+
+    smoke_rows = [
+        row
+        for row in payload
+        if isinstance(row, dict) and row.get("player_name") == SMOKE_PLAYER_NAME
+    ]
+    if not smoke_rows:
+        raise RuntimeError("Seeded smoke player was not returned by top players API.")
+
+
+def request_json(url: str, timeout_seconds: int) -> object:
+    """Fetch a JSON endpoint and return the decoded payload."""
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to request {url}") from exc
+
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Endpoint did not return valid JSON: {url}") from exc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_api_runtime_config.py
+++ b/tests/api/test_api_runtime_config.py
@@ -21,3 +21,19 @@ def test_create_app_uses_configured_debug_mode(monkeypatch) -> None:
     app = api_main.create_app()
 
     assert app.debug is True
+
+
+def test_health_endpoint_returns_stable_payload() -> None:
+    app = api_main.create_app()
+
+    route = next(route for route in app.routes if getattr(route, "path", None) == "/health")
+
+    assert route.endpoint() == {"status": "ok", "service": "cs2-analytics-api"}
+
+
+def test_root_endpoint_keeps_health_compatibility() -> None:
+    app = api_main.create_app()
+
+    route = next(route for route in app.routes if getattr(route, "path", None) == "/")
+
+    assert route.endpoint() == {"status": "ok", "service": "cs2-analytics-api"}

--- a/tests/test_deployment_smoke.py
+++ b/tests/test_deployment_smoke.py
@@ -1,0 +1,131 @@
+from datetime import datetime
+
+from scripts import deployment_smoke
+
+
+class _RecordingCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[int, ...]]] = []
+
+    def __enter__(self) -> "_RecordingCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple[int, ...]) -> None:
+        self.executed.append((query, params))
+
+
+class _FakeDatabase:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _RecordingCursor:
+        return self.cursor
+
+
+def test_seed_smoke_source_rows_uses_repeat_safe_source_ids(monkeypatch) -> None:
+    stored: dict[str, list[object]] = {}
+
+    monkeypatch.setattr(
+        deployment_smoke,
+        "store_matches",
+        lambda matches: stored.setdefault("matches", matches),
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "store_maps",
+        lambda maps: stored.setdefault("maps", maps),
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "store_players",
+        lambda players: stored.setdefault("players", players),
+    )
+
+    deployment_smoke.seed_smoke_source_rows()
+
+    match = stored["matches"][0]
+    map_obj = stored["maps"][0]
+    player = stored["players"][0]
+
+    assert match.match_id == deployment_smoke.SMOKE_MATCH_ID
+    assert map_obj.map_id == deployment_smoke.SMOKE_MAP_ID
+    assert map_obj.match_id == deployment_smoke.SMOKE_MATCH_ID
+    assert player.map_id == deployment_smoke.SMOKE_MAP_ID
+    assert player.player_id == deployment_smoke.SMOKE_PLAYER_ID
+    assert player.player_name == deployment_smoke.SMOKE_PLAYER_NAME
+    assert player.rating == 9.99
+    assert isinstance(player.last_updated_at, datetime)
+
+
+def test_cleanup_smoke_source_rows_deletes_fixed_ids_in_dependency_order(
+    monkeypatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(
+        deployment_smoke,
+        "Database",
+        lambda: _FakeDatabase(cursor),
+    )
+
+    deployment_smoke.cleanup_smoke_source_rows()
+
+    assert cursor.executed == [
+        (
+            "DELETE FROM players WHERE map_id = %s AND player_id = %s;",
+            (deployment_smoke.SMOKE_MAP_ID, deployment_smoke.SMOKE_PLAYER_ID),
+        ),
+        ("DELETE FROM maps WHERE map_id = %s;", (deployment_smoke.SMOKE_MAP_ID,)),
+        (
+            "DELETE FROM matches WHERE match_id = %s;",
+            (deployment_smoke.SMOKE_MATCH_ID,),
+        ),
+    ]
+
+
+def test_read_timeout_seconds_rejects_invalid_values(monkeypatch) -> None:
+    monkeypatch.setenv("SMOKE_API_TIMEOUT_SECONDS", "not-an-int")
+
+    try:
+        deployment_smoke.read_timeout_seconds()
+    except RuntimeError as exc:
+        assert "SMOKE_API_TIMEOUT_SECONDS must be an integer." in str(exc)
+    else:
+        raise AssertionError("Expected invalid timeout value to fail")
+
+
+def test_verify_api_health_accepts_stable_payload(monkeypatch) -> None:
+    def fake_request_json(_url: str, _timeout_seconds: int) -> dict[str, str]:
+        return {
+            "status": "ok",
+            "service": "cs2-analytics-api",
+        }
+
+    monkeypatch.setattr(
+        deployment_smoke,
+        "request_json",
+        fake_request_json,
+    )
+
+    deployment_smoke.verify_api_health("http://app:8000", 10)
+
+
+def test_verify_top_players_read_requires_seeded_smoke_player(monkeypatch) -> None:
+    def fake_request_json(_url: str, _timeout_seconds: int) -> list[dict[str, object]]:
+        return [
+            {
+                "player_name": deployment_smoke.SMOKE_PLAYER_NAME,
+                "maps_played": 1,
+                "avg_rating": 9.99,
+            }
+        ]
+
+    monkeypatch.setattr(
+        deployment_smoke,
+        "request_json",
+        fake_request_json,
+    )
+
+    deployment_smoke.verify_top_players_read("http://app:8000", 10)


### PR DESCRIPTION
## Summary

- Added stable `/health` API endpoint while keeping `/` health compatibility.
- Added deterministic deployment smoke script that verifies migrated source tables, seeds fixed-ID match/map/player rows, checks API health and top players read path, then removes smoke rows.
- Added Docker Compose `smoke` service and updated app healthcheck to use `/health`.
- Documented the smoke workflow, non-production DB guidance, and remaining Phase 3.75 deployment tasks.

Closes #46.

## Scope

- API health readiness
- deterministic container smoke validation
- smoke data cleanup
- deployment/backlog documentation

## Out Of Scope

- Production DB write-based smoke tests
- Live HLTV scraping as a deployment gate
- dbt, Airflow, demo expansion, or first cloud deployment

## Verification

- `python -m pytest tests\test_deployment_smoke.py tests\api\test_api_runtime_config.py`
- `python -m ruff check scripts\deployment_smoke.py tests\test_deployment_smoke.py docs\backlog.md --select E,F --ignore E501`
- `python -m pytest`
- `docker compose build smoke`
- `docker compose --profile tools run --rm smoke`
- Confirmed smoke rows were cleaned up from `matches`, `maps`, and `players`