### PR TITLE
Plan first cloud deployment target and validation flow

### DIFF
--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -103,6 +103,13 @@ Phase 3.75 deployment baseline comes before dbt. The deployment baseline should
 prove that runtime configuration, migrations, containers, CI, and smoke tests
 work outside the local development machine.
 
+The first cloud deployment plan uses GitHub Pages for the frontend, a Render
+web service for the API, Render PostgreSQL for the database, and a manual
+GitHub Actions workflow for the pipeline/scraper runner. Scheduled scraper
+runs are deferred until match and map batch behavior is validated. Manual
+migrations remain the first release path, with write-based smoke checks limited
+to separate smoke or staging databases and production validation kept read-only.
+
 Normal database setup applies Alembic migrations through
 `alembic -c cs2_analytics/alembic.ini upgrade head` or
 `python manage_db.py --init`. Destructive table wipes remain explicit and

--- a/docs/architecture/decision_log.md
+++ b/docs/architecture/decision_log.md
@@ -176,3 +176,42 @@ Consequences:
   documentation impact.
 - Medium-risk, high-risk, schema, deployment, dependency, CI, and architecture
   changes require human review before merge.
+
+## ADR-0008: Use Render And GitHub Actions For First Cloud Deployment
+
+Status:
+Accepted
+
+Date:
+2026-05-26
+
+Context:
+The project needs a first cloud deployment target before dbt work begins. The
+deployment should stay low-cost and operationally simple, preserve the current
+API and pipeline entrypoints, and avoid introducing Airflow or broader
+ingestion architecture changes.
+
+Decision:
+Use GitHub Pages for the frontend, Render for the API web service, Render
+PostgreSQL for the application database, and GitHub Actions as the manual
+pipeline/scraper runner. Store API runtime secrets in Render environment
+variables and pipeline/deployment secrets in GitHub Actions secrets. Run
+migrations manually from a controlled local environment for the first deploy,
+with a GitHub Actions migration workflow deferred until the release path is
+stable.
+
+Consequences:
+- No custom frontend domain is planned for the first deploy.
+- The Render API CORS allowlist must include the GitHub Pages origin.
+- Scheduled scraper runs remain deferred until match and map batch behavior is
+  validated.
+- Write-based deterministic smoke checks must use a separate minimal smoke or
+  staging database, not the production analytics database.
+- Production validation must be read-only: Alembic current revision, API
+  `/health`, and a DB-backed API read.
+- Rollback relies on a recovery point or exported logical backup before manual
+  migrations, forward-fix migrations when possible, Render API deploy rollback
+  when schema compatibility allows, and database restore for unrecoverable
+  migration mistakes.
+- Pipeline failures are treated as ingestion recovery through lifecycle state
+  inspection and manual retry, not as schema rollback events.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -382,7 +382,11 @@ baseline for PostgreSQL, migrations, the API, and pipeline runs. The
 installation, focused linting, initial runtime type checking, migrations, and
 tests. The `phase3.75-deployment-smoke-test` branch added a deterministic
 container smoke path for migrations, fixed-ID source-row seed/read/cleanup,
-API health, and a DB-backed top players read check.
+API health, and a DB-backed top players read check. The
+`phase3.75-first-cloud-deploy-plan` branch chose GitHub Pages, Render, Render
+PostgreSQL, and GitHub Actions as the first cloud deployment shape and
+documented the validation, migration, smoke database, runner, and recovery
+policies needed before implementation issue #55.
 
 Rationale:
 Phase 3.5 confirms that the parsed-source tables are stable enough for dbt, but
@@ -410,20 +414,20 @@ assumptions work outside the local development machine.
 - [x] Add a deployment smoke test path:
       migrations -> deterministic source-row seed/read/cleanup -> API health/top players check
 - [x] Document local Docker startup and production deployment variables
-- [ ] Choose first deployment target for the API runtime
-- [ ] Choose first deployment target for pipeline/worker runs
-- [ ] Document the API + worker deployment topology
-- [ ] Document staging/production environment variables and secret source
-- [ ] Define migration order for deployment startup or release
-- [ ] Define read-only production validation checks:
+- [x] Choose first deployment target for the API runtime
+- [x] Choose first deployment target for pipeline/worker runs
+- [x] Document the API + worker deployment topology
+- [x] Document staging/production environment variables and secret source
+- [x] Define migration order for deployment startup or release
+- [x] Define read-only production validation checks:
       Alembic version -> `/health` -> DB-backed API read
-- [ ] Define smoke/staging database policy for write-based smoke tests
-- [ ] Choose temporary pre-Airflow runner strategy:
+- [x] Define smoke/staging database policy for write-based smoke tests
+- [x] Choose temporary pre-Airflow runner strategy:
       manual job, scheduled platform job, or GitHub Actions manual dispatch
 - [ ] Confirm containerized Selenium/Chromium can run in the chosen worker environment
 - [ ] Confirm runtime artifacts do not rely on local machine state:
       logs, demos, parsed data, browser cache, and temporary files
-- [ ] Document rollback/recovery expectations for failed deploys or migrations
+- [x] Document rollback/recovery expectations for failed deploys or migrations
 - [ ] Run one limited live ingestion validation in a staging/smoke environment
 
 ### Suggested branch sequence
@@ -486,12 +490,21 @@ assumptions work outside the local development machine.
    intentionally avoids live HLTV scraping so deployment checks do not fail when
    the upstream website is unavailable or changes markup.
 
-6. [ ] `phase3.75-first-cloud-deploy-plan`
+6. [x] `phase3.75-first-cloud-deploy-plan`
        Choose the first API and worker deployment targets, document the intended
        topology, define staging/production environment variables and secret
        sources, define migration order, define smoke/staging database policy,
        define read-only production validation checks, choose the temporary
        pre-Airflow runner strategy, and document rollback/recovery expectations.
+
+   The first cloud plan uses GitHub Pages for the frontend, a Render web
+   service for the API runtime, Render PostgreSQL for the application database,
+   and a manual GitHub Actions workflow for pipeline/scraper runs. Scheduled
+   scraper runs are deferred until match and map batch behavior is validated.
+   Migrations start as a manual local release step, write-based smoke checks use
+   a separate minimal smoke/staging database, production validation is
+   read-only, and recovery prefers pre-migration backups plus forward fixes.
+   Follow-up implementation is tracked in issue #55.
 
 7. [ ] `phase3.75-first-cloud-deploy`
        Deploy the API and pipeline runner to the chosen initial platform. Keep the
@@ -514,15 +527,15 @@ assumptions work outside the local development machine.
 - [x] CI passes on every PR
 - [x] A deterministic source-row seed/read/cleanup smoke path works outside the local dev environment
 - [x] API health endpoint works in deployed environment
-- [ ] First API and worker deployment targets are chosen and documented
-- [ ] Staging/production environment variables and secret source are documented
-- [ ] Deployment migration order is documented
-- [ ] Smoke/staging database policy is documented for write-based smoke tests
-- [ ] Read-only production validation checks are defined
+- [x] First API and worker deployment targets are chosen and documented
+- [x] Staging/production environment variables and secret source are documented
+- [x] Deployment migration order is documented
+- [x] Smoke/staging database policy is documented for write-based smoke tests
+- [x] Read-only production validation checks are defined
 - [ ] Containerized Selenium/Chromium works in the chosen worker environment
 - [ ] Runtime artifacts do not rely on local machine state
-- [ ] Rollback/recovery expectations are documented
-- [ ] There is a temporary scheduled/manual runner path before Airflow
+- [x] Rollback/recovery expectations are documented
+- [x] There is a temporary scheduled/manual runner path before Airflow
 - [ ] One limited live ingestion validation passes in staging/smoke
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,13 +152,23 @@ Render API environment variables:
 | `ENVIRONMENT=production` | Render environment variable |
 | `DEBUG_MODE=false` | Render environment variable |
 | `API_HOST=0.0.0.0` | Render environment variable |
-| `API_PORT` | Map to Render's web service `PORT` value in the service start command or environment |
+| `API_PORT` | Must resolve to Render's web service `PORT` value |
 | `API_CORS_ORIGINS` | Render environment variable containing the GitHub Pages origin |
 | `DB_NAME` | Render PostgreSQL connection setting |
 | `DB_USER` | Render PostgreSQL connection setting |
 | `DB_PASS` | Render secret |
 | `DB_HOST` | Render PostgreSQL connection setting |
 | `DB_PORT` | Render PostgreSQL connection setting |
+
+Render provides the port a web service must bind to through `PORT`. The app
+reads `API_PORT`, so the Render start command should map `PORT` explicitly:
+
+```sh
+API_PORT=$PORT python run_api.py
+```
+
+Keep `API_HOST=0.0.0.0` so the service binds on the container interface Render
+can route to.
 
 GitHub Actions pipeline secrets:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -121,9 +121,10 @@ GitHub Pages frontend
 -> Render PostgreSQL
 
 GitHub Actions manual pipeline workflow
--> python main.py
+-> build/run the application Docker image
+-> execute python main.py inside the container
 -> Render PostgreSQL
--> HLTV fetches through the containerized scraper runtime
+-> HLTV fetches through the containerized Chromium/Selenium runtime
 ```
 
 The API and pipeline should continue using the existing entrypoints:
@@ -131,6 +132,11 @@ The API and pipeline should continue using the existing entrypoints:
 - API: `python run_api.py`
 - migrations: `alembic -c cs2_analytics/alembic.ini upgrade head`
 - pipeline: `python main.py`
+
+The GitHub Actions pipeline workflow should run the same application image used
+by the local container runtime, so scraper dependencies such as Chromium,
+ChromiumDriver, SeleniumBase, and Python packages are supplied by the Docker
+image rather than by the host runner.
 
 GitHub Actions should be manual-only at first. Scheduled scraper runs are
 deferred until the match and map batch behavior is validated, especially the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,6 +89,158 @@ tests should not fail because the upstream website is unavailable or has
 changed markup. Run it against local, smoke, staging, or otherwise disposable
 deployment-validation databases rather than a production analytics database.
 
+## First Cloud Deployment Plan
+
+The first cloud deployment keeps the runtime simple and uses managed services
+that match the current container and script entrypoints.
+
+Planned targets:
+
+- Frontend: GitHub Pages.
+- API runtime: Render web service.
+- Pipeline and scraper runner: GitHub Actions manual workflow.
+- Database: Render PostgreSQL.
+- Secrets: Render environment variables for the API and database connection;
+  GitHub Actions secrets for manual pipeline and deployment workflows.
+- Migrations: manual release step from a controlled local environment first;
+  a GitHub Actions migration workflow can be added later.
+
+No custom domain is planned for the first deploy. The frontend should use the
+default GitHub Pages URL, and the API CORS allowlist should include the GitHub
+Pages origin. For a project page such as
+`https://dardenkyle.github.io/CS2-analytics`, the browser origin is
+`https://dardenkyle.github.io`.
+
+## First Cloud Topology
+
+The first deploy should use separate runtimes for reads and ingestion:
+
+```text
+GitHub Pages frontend
+-> Render API web service
+-> Render PostgreSQL
+
+GitHub Actions manual pipeline workflow
+-> python main.py
+-> Render PostgreSQL
+-> HLTV fetches through the containerized scraper runtime
+```
+
+The API and pipeline should continue using the existing entrypoints:
+
+- API: `python run_api.py`
+- migrations: `alembic -c cs2_analytics/alembic.ini upgrade head`
+- pipeline: `python main.py`
+
+GitHub Actions should be manual-only at first. Scheduled scraper runs are
+deferred until the match and map batch behavior is validated, especially the
+handoff from a fetched match batch to the number of discovered maps that still
+need processing.
+
+## Cloud Environment And Secrets
+
+Render API environment variables:
+
+| Variable | Source |
+| --- | --- |
+| `ENVIRONMENT=production` | Render environment variable |
+| `DEBUG_MODE=false` | Render environment variable |
+| `API_HOST=0.0.0.0` | Render environment variable |
+| `API_PORT` | Map to Render's web service `PORT` value in the service start command or environment |
+| `API_CORS_ORIGINS` | Render environment variable containing the GitHub Pages origin |
+| `DB_NAME` | Render PostgreSQL connection setting |
+| `DB_USER` | Render PostgreSQL connection setting |
+| `DB_PASS` | Render secret |
+| `DB_HOST` | Render PostgreSQL connection setting |
+| `DB_PORT` | Render PostgreSQL connection setting |
+
+GitHub Actions pipeline secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `DB_NAME` | Pipeline database name |
+| `DB_USER` | Pipeline database user |
+| `DB_PASS` | Pipeline database password |
+| `DB_HOST` | Pipeline database host |
+| `DB_PORT` | Pipeline database port |
+
+Secret values must stay out of the repository, docs, logs, and committed
+configuration files. `.env.example` should keep placeholder values only.
+
+## Migration Order
+
+For the first cloud deploy, migrations are a manual release step:
+
+1. Confirm the target database is the intended Render PostgreSQL instance.
+2. Confirm or create a Render PostgreSQL recovery point where the database plan
+   supports it, or take an exported logical backup before continuing.
+3. Apply migrations from a controlled local environment:
+
+   ```sh
+   alembic -c cs2_analytics/alembic.ini upgrade head
+   ```
+
+4. Confirm the database revision is current:
+
+   ```sh
+   alembic -c cs2_analytics/alembic.ini current
+   ```
+
+5. Deploy or restart the Render API service.
+6. Run read-only production validation checks.
+
+Write-based deterministic smoke tests should not run against the production
+analytics database.
+
+## Validation Policy
+
+Use separate validation paths for smoke/staging and production.
+
+Smoke or staging validation may write fixed-ID synthetic rows, but it must run
+against a separate minimal Render PostgreSQL database or another disposable
+deployment-validation database. That database does not need to stay running all
+the time.
+
+Production validation must be read-only:
+
+1. Confirm Alembic reports the expected current revision.
+2. Call the API health endpoint:
+
+   ```sh
+   curl https://<render-api-host>/health
+   ```
+
+3. Call a DB-backed read endpoint without inserting synthetic rows, such as:
+
+   ```sh
+   curl "https://<render-api-host>/api/top_players?min_maps=1&limit=10"
+   ```
+
+4. Confirm API logs do not show startup, configuration, database, or CORS
+   errors.
+
+## Rollback And Recovery
+
+The first deployment should prefer controlled recovery over automatic downgrade
+migrations.
+
+- Before manual migrations, confirm a Render PostgreSQL recovery point or
+  exported logical backup exists.
+- If the API deploy fails before migrations run, roll back the Render web
+  service to the previous deploy.
+- If migrations fail partway, stop the deploy, do not run the pipeline, inspect
+  database state, then restore the pre-migration backup or apply a forward fix
+  migration.
+- If migrations succeed but application behavior fails, roll back the API
+  runtime when the schema remains backward-compatible. Otherwise, apply a
+  forward fix.
+- If the pipeline run fails, treat it as ingestion recovery rather than schema
+  rollback. Inspect lifecycle state, fix code or configuration, and retry
+  manually.
+
+The follow-up implementation branch is `phase3.75-first-cloud-deploy`, tracked
+by issue #55.
+
 ## Environment
 
 Compose provides container-safe defaults for local development. Override these


### PR DESCRIPTION
### Summary

- Choose GitHub Pages for the frontend, Render for the API runtime, Render PostgreSQL for the database, and GitHub Actions manual workflows for the first pipeline/scraper runner.
- Document the first cloud topology, environment/secrets model, manual migration order, smoke/staging database policy, read-only production validation checks, and rollback/recovery expectations.
- Update the architecture current state, decision log, deployment docs, and backlog to mark `phase3.75-first-cloud-deploy-plan` complete while leaving implementation work for #55.

### Related Issue

Closes #47

### Scope

- Docs only.
- No deployment implementation.
- No dbt, Airflow, demo expansion, schema changes, or ingestion architecture changes.

### Documentation Check

Updated:
- `docs/deployment.md`
- `docs/architecture/current_state.md`
- `docs/architecture/decision_log.md`
- `docs/backlog.md`

### Verification

- Ran `git diff --check`.
- Tests not run because this is docs-only.

### Risk

High, because this records deployment/runtime assumptions and validation policy for the first cloud deploy.