### PR TITLE
Document Render deployment baseline and worker validation

### DIFF
--- a/.github/workflows/manual-pipeline-worker.yml
+++ b/.github/workflows/manual-pipeline-worker.yml
@@ -1,0 +1,88 @@
+name: Manual Pipeline Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_pipeline:
+        description: Run the ingestion pipeline after browser validation.
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manual-pipeline-worker
+  cancel-in-progress: false
+
+jobs:
+  worker:
+    name: Validate Worker And Run Pipeline
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    env:
+      ENVIRONMENT: production
+      DEBUG_MODE: "false"
+      API_HOST: 0.0.0.0
+      API_PORT: "8000"
+      API_CORS_ORIGINS: https://dardenkyle.github.io
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASS: ${{ secrets.DB_PASS }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      IMAGE_NAME: cs2-analytics:manual-worker
+
+    steps:
+      - name: Check out repository
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Check required secrets
+        run: |
+          missing=0
+          for name in DB_NAME DB_USER DB_PASS DB_HOST DB_PORT; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing GitHub Actions secret: ${name}"
+              missing=1
+            fi
+          done
+          exit "${missing}"
+
+      - name: Build worker image
+        run: docker build -t "${IMAGE_NAME}" .
+
+      - name: Validate Selenium and Chromium
+        run: |
+          docker run --rm --shm-size=2g \
+            -e ENVIRONMENT \
+            -e DEBUG_MODE \
+            -e API_HOST \
+            -e API_PORT \
+            -e API_CORS_ORIGINS \
+            -e DB_NAME \
+            -e DB_USER \
+            -e DB_PASS \
+            -e DB_HOST \
+            -e DB_PORT \
+            "${IMAGE_NAME}" \
+            python scripts/validate_worker_browser.py
+
+      - name: Run ingestion pipeline
+        if: ${{ inputs.run_pipeline }}
+        run: |
+          docker run --rm --shm-size=2g \
+            -e ENVIRONMENT \
+            -e DEBUG_MODE \
+            -e API_HOST \
+            -e API_PORT \
+            -e API_CORS_ORIGINS \
+            -e DB_NAME \
+            -e DB_USER \
+            -e DB_PASS \
+            -e DB_HOST \
+            -e DB_PORT \
+            "${IMAGE_NAME}" \
+            python main.py

--- a/.github/workflows/manual-pipeline-worker.yml
+++ b/.github/workflows/manual-pipeline-worker.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       run_pipeline:
-        description: Run the ingestion pipeline after browser validation.
+        description: Explicitly run ingestion after browser validation.
         required: true
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ logs/*
 
 # Environment variables
 .env
+.env.*
 .env.local
 
 # Downloaded files & data

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,10 @@ COPY main.py manage_db.py run_api.py ./
 
 RUN useradd --create-home --uid 10001 appuser \
     && mkdir -p /app/logs /app/demos /app/parsed_data \
-    && chown -R appuser:appuser /app
+    && mkdir -p /usr/local/lib/python3.14/site-packages/seleniumbase/drivers \
+    && chown -R appuser:appuser \
+        /app \
+        /usr/local/lib/python3.14/site-packages/seleniumbase/drivers
 
 USER appuser
 

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -122,6 +122,7 @@ changing ingestion responsibilities:
 - migrations: `python manage_db.py --init`
 - pipeline: `python main.py`
 - deployment smoke: `python scripts/deployment_smoke.py`
+- worker browser validation: `python scripts/validate_worker_browser.py`
 
 `docker-compose.yml` provides local PostgreSQL plus app, migration, pipeline,
 and smoke services. The smoke service is deterministic: it verifies migrated
@@ -131,6 +132,13 @@ query PostgreSQL, and removes the fixed-ID rows before exiting. It should run
 against a local or deployment-validation database rather than a production
 analytics database. Runtime artifacts such as logs, downloaded demos, and parsed
 data stay mounted from the working tree and are not baked into the image.
+
+The first cloud worker path is a manual GitHub Actions workflow,
+`Manual Pipeline Worker`, that builds the same Docker image, validates
+Selenium/Chromium inside the container, and optionally runs `python main.py`
+against the configured PostgreSQL database. It is manual-only and serialized so
+scheduled ingestion remains deferred until live match/map batch behavior is
+validated.
 
 dbt will be added after the deployment baseline and must remain downstream of
 ingestion. It should transform stable source tables, not own ingestion logic or

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -140,6 +140,25 @@ against the configured PostgreSQL database. It is manual-only and serialized so
 scheduled ingestion remains deferred until live match/map batch behavior is
 validated.
 
+The first Render API deployment is reachable at
+`https://cs2-analytics.onrender.com`. Production `/health` and DB-backed
+`/api/top_players` validation have passed against Render PostgreSQL, and local
+Docker worker validation has proven that Selenium/Chromium can start inside the
+same application image used by the manual worker path.
+
+Local Docker live pipeline execution also completed in the worker image against
+Render PostgreSQL and reached map processing. The run exposed a map scraper
+validation gap: fetched map HTML can lack the expected `match-info-box` page
+content, after which the parser raises `MapParseError` and the controller marks
+the row failed. This is tracked in issue #57 and should be handled as retryable
+fetch/session hardening, not as a deployment/runtime boundary change.
+
+Write-based deterministic smoke checks are intentionally not run against the
+production Render PostgreSQL database. A separate smoke/staging database is
+deferred until recurring deployment validation needs one; until then,
+production validation stays read-only and limited live ingestion validation is
+used to prove the deployed pipeline path.
+
 dbt will be added after the deployment baseline and must remain downstream of
 ingestion. It should transform stable source tables, not own ingestion logic or
 application/source schema.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -514,6 +514,17 @@ assumptions work outside the local development machine.
        Selenium/Chromium works in the worker environment, and run one limited
        live ingestion validation in staging/smoke. Do not add Airflow yet.
 
+   In progress: the Render API and Render PostgreSQL deployment are reachable,
+   Alembic migrations have run, the production `/health` endpoint returns the
+   expected payload, and the DB-backed top players API returns real ingested
+   player data from Render PostgreSQL. A manual GitHub Actions worker workflow
+   now builds the application Docker image, validates containerized
+   Selenium/Chromium, and can run `python main.py` against the configured
+   PostgreSQL database. Remaining closeout work is to run the workflow in
+   GitHub Actions, record validation results, run or explicitly defer
+   deterministic smoke against separate smoke/staging infrastructure, rotate
+   exposed database credentials, and finalize the deployment documentation.
+
 ### Phase 3.75 exit criteria
 
 - [x] Fresh clone can run through Docker without manual local setup

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -520,10 +520,19 @@ assumptions work outside the local development machine.
    player data from Render PostgreSQL. A manual GitHub Actions worker workflow
    now builds the application Docker image, validates containerized
    Selenium/Chromium, and can run `python main.py` against the configured
-   PostgreSQL database. Remaining closeout work is to run the workflow in
-   GitHub Actions, record validation results, run or explicitly defer
-   deterministic smoke against separate smoke/staging infrastructure, rotate
-   exposed database credentials, and finalize the deployment documentation.
+   PostgreSQL database. Local Docker worker validation passed after granting
+   the non-root app user access to SeleniumBase's driver scratch directory in
+   the image. Deterministic write-based cloud smoke is deferred until a
+   separate disposable smoke/staging database exists; production validation
+   remains read-only by policy. Local Docker live pipeline execution completed
+   in the worker image and reached map processing against Render PostgreSQL.
+   The run exposed a map scraper validation gap: selected map pages can return
+   HTML without the expected `match-info-box`, and the parser currently marks
+   those rows failed instead of treating the fetch as retryable. Remaining
+   closeout work is to track or fix that fetch-validation/retry hardening in
+   issue #57 before recurring worker runs, run the workflow in GitHub Actions
+   after it is available on GitHub, rotate exposed database credentials, and
+   finalize the deployment documentation.
 
 ### Phase 3.75 exit criteria
 
@@ -543,8 +552,8 @@ assumptions work outside the local development machine.
 - [x] Deployment migration order is documented
 - [x] Smoke/staging database policy is documented for write-based smoke tests
 - [x] Read-only production validation checks are defined
-- [ ] Containerized Selenium/Chromium works in the chosen worker environment
-- [ ] Runtime artifacts do not rely on local machine state
+- [x] Containerized Selenium/Chromium works in the chosen worker environment
+- [x] Runtime artifacts do not rely on local machine state
 - [x] Rollback/recovery expectations are documented
 - [x] There is a temporary scheduled/manual runner path before Airflow
 - [ ] One limited live ingestion validation passes in staging/smoke

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -111,6 +111,83 @@ Pages origin. For a project page such as
 `https://dardenkyle.github.io/CS2-analytics`, the browser origin is
 `https://dardenkyle.github.io`.
 
+## First Cloud Deployment Status
+
+The first Render API deployment is available at:
+
+```text
+https://cs2-analytics.onrender.com
+```
+
+Validated production checks:
+
+- `GET https://cs2-analytics.onrender.com/health` returns
+  `{"status":"ok","service":"cs2-analytics-api"}`.
+- `GET https://cs2-analytics.onrender.com/` returns the same compatibility
+  health payload.
+- Alembic migrations have been applied to the Render PostgreSQL database.
+- `GET https://cs2-analytics.onrender.com/api/top_players?min_maps=1&limit=10`
+  returns DB-backed player rows from Render PostgreSQL.
+- Local live ingestion has written real player data to Render PostgreSQL.
+- The Docker worker image builds locally and can start Selenium/Chromium inside
+  the container after the image grants the non-root app user ownership of
+  SeleniumBase's driver scratch directory.
+- Local Docker live pipeline execution completed in the worker image and
+  reached the map stage against Render PostgreSQL. The map stage selected 50
+  pending maps, but the fetched HTML lacked the expected `match-info-box`
+  content and those rows failed with `MapParseError: Failed to extract map name
+  from map stats page.` This confirms the deployment worker path while leaving
+  map fetch validation and retry hardening as follow-up issue #57 before
+  recurring worker runs.
+
+Local worker validation commands:
+
+```powershell
+docker build -t cs2-analytics:manual-worker .
+docker run --rm --shm-size=2g --env-file .env.render `
+  -e ENVIRONMENT=production `
+  -e DEBUG_MODE=false `
+  -e API_HOST=0.0.0.0 `
+  -e API_PORT=8000 `
+  -e API_CORS_ORIGINS=https://dardenkyle.github.io `
+  cs2-analytics:manual-worker `
+  python scripts/validate_worker_browser.py
+```
+
+Run the live pipeline through the same container with:
+
+```powershell
+docker run --rm --shm-size=2g --env-file .env.render `
+  -e ENVIRONMENT=production `
+  -e DEBUG_MODE=false `
+  -e API_HOST=0.0.0.0 `
+  -e API_PORT=8000 `
+  -e API_CORS_ORIGINS=https://dardenkyle.github.io `
+  cs2-analytics:manual-worker `
+  python main.py
+```
+
+Observed local Docker worker result:
+
+```text
+MapController summary: selected=50 succeeded=0 failed=50 retries=0
+CS2 Analytics Pipeline complete.
+```
+
+The manual GitHub Actions workflow is defined in the repository, but it will
+only become runnable from GitHub Actions after the workflow file is pushed and
+available to GitHub. Deterministic write-based smoke remains restricted to a
+separate smoke/staging database and must not be run against the production
+Render PostgreSQL analytics database.
+
+For the first cloud branch, creating a separate Render smoke/staging database is
+deferred to a follow-up because it would add cost and secret/configuration
+maintenance before recurring deployment validation needs it. The deterministic
+smoke script remains the accepted write-based validation path, but cloud smoke
+execution should wait until a disposable validation database exists. Production
+validation remains read-only, and live ingestion validation uses real pipeline
+execution rather than synthetic smoke rows.
+
 ## First Cloud Topology
 
 The first deploy should use separate runtimes for reads and ingestion:
@@ -236,19 +313,24 @@ against a separate minimal Render PostgreSQL database or another disposable
 deployment-validation database. That database does not need to stay running all
 the time.
 
+No write-based deterministic smoke check should run against the first production
+Render PostgreSQL database. Until a separate smoke/staging database exists,
+record the smoke result as deferred by policy and use read-only production
+validation plus limited live ingestion validation for deployment confidence.
+
 Production validation must be read-only:
 
 1. Confirm Alembic reports the expected current revision.
 2. Call the API health endpoint:
 
    ```sh
-   curl https://<render-api-host>/health
+   curl https://cs2-analytics.onrender.com/health
    ```
 
 3. Call a DB-backed read endpoint without inserting synthetic rows, such as:
 
    ```sh
-   curl "https://<render-api-host>/api/top_players?min_maps=1&limit=10"
+   curl "https://cs2-analytics.onrender.com/api/top_players?min_maps=1&limit=10"
    ```
 
 4. Confirm API logs do not show startup, configuration, database, or CORS

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -229,8 +229,9 @@ Run the manual worker from GitHub:
 2. Go to Actions.
 3. Select `Manual Pipeline Worker`.
 4. Choose `Run workflow`.
-5. Keep `run_pipeline` enabled to validate the browser and run ingestion, or
-   disable it to validate only the containerized Selenium/Chromium runtime.
+5. Leave `run_pipeline` disabled to validate only the containerized
+   Selenium/Chromium runtime. Enable it only when intentionally running live
+   ingestion against the configured PostgreSQL database.
 
 The workflow uses a concurrency group so only one manual pipeline worker run
 executes at a time.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,10 +138,25 @@ by the local container runtime, so scraper dependencies such as Chromium,
 ChromiumDriver, SeleniumBase, and Python packages are supplied by the Docker
 image rather than by the host runner.
 
-GitHub Actions should be manual-only at first. Scheduled scraper runs are
-deferred until the match and map batch behavior is validated, especially the
-handoff from a fetched match batch to the number of discovered maps that still
-need processing.
+GitHub Actions is manual-only at first. The workflow lives at
+`.github/workflows/manual-pipeline-worker.yml`, builds the application Docker
+image, validates that Selenium/Chromium can start inside the container, and can
+then run `python main.py` against the configured PostgreSQL database. Scheduled
+scraper runs are deferred until the match and map batch behavior is validated,
+especially the handoff from a fetched match batch to the number of discovered
+maps that still need processing.
+
+Run the manual worker from GitHub:
+
+1. Open the repository in GitHub.
+2. Go to Actions.
+3. Select `Manual Pipeline Worker`.
+4. Choose `Run workflow`.
+5. Keep `run_pipeline` enabled to validate the browser and run ingestion, or
+   disable it to validate only the containerized Selenium/Chromium runtime.
+
+The workflow uses a concurrency group so only one manual pipeline worker run
+executes at a time.
 
 ## Cloud Environment And Secrets
 
@@ -179,6 +194,10 @@ GitHub Actions pipeline secrets:
 | `DB_PASS` | Pipeline database password |
 | `DB_HOST` | Pipeline database host |
 | `DB_PORT` | Pipeline database port |
+
+Use Render's external PostgreSQL host for local migration commands and for the
+GitHub Actions manual worker. The short internal hostname is only reachable
+from Render services on Render's private network.
 
 Secret values must stay out of the repository, docs, logs, and committed
 configuration files. `.env.example` should keep placeholder values only.

--- a/scripts/validate_worker_browser.py
+++ b/scripts/validate_worker_browser.py
@@ -1,0 +1,41 @@
+"""Validate that the container worker can start Selenium/Chromium."""
+
+import sys
+
+from seleniumbase import Driver
+
+from cs2_analytics.utils.log_manager import get_logger
+
+logger = get_logger(__name__)
+
+EXPECTED_TITLE = "CS2 Analytics Worker Browser Check"
+CHECK_URL = (
+    "data:text/html,"
+    "<html><head><title>CS2 Analytics Worker Browser Check</title></head>"
+    "<body>ok</body></html>"
+)
+
+
+def main() -> int:
+    """Start Chromium through SeleniumBase and load a deterministic page."""
+    driver = None
+    try:
+        driver = Driver(uc=True, headless=True)
+        driver.get(CHECK_URL)
+        if driver.title != EXPECTED_TITLE:
+            raise RuntimeError(
+                f"Unexpected browser check title: {driver.title!r}"
+            )
+    except Exception as exc:
+        logger.exception("Worker browser validation failed: %s", exc)
+        return 1
+    finally:
+        if driver is not None:
+            driver.quit()
+
+    logger.info("Worker browser validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Summary

- Document the first Render API/PostgreSQL deployment status and validation results.
- Add a manual GitHub Actions worker path for Docker image build, browser validation, and opt-in ingestion.
- Update Docker worker runtime ownership so SeleniumBase can manage its driver scratch directory as the non-root app user.
- Record the manual worker validation path and defer map fetch retry hardening to #57.

### Related Issue

Part of #55.

This PR does not close #55 because the first cloud deployment task still has remaining closeout work, including recurring-worker readiness after #57 and the remaining deployment validation items.

### Follow-up

- #57 must be fixed before recurring worker runs. Dockerized map fetching can return HTML without expected stats content, causing map rows to fail with `MapParseError`.

### Scope

- Deployment documentation and runtime validation support.
- Manual worker workflow only; no scheduled ingestion.
- No dbt, Airflow, demo expansion, schema changes, or ingestion architecture changes.

### Documentation Check

Updated:
- `docs/deployment.md`
- `docs/backlog.md`
- `docs/architecture/current_state.md`

### Verification

- Render `/health` validated.
- Render DB-backed `/api/top_players?min_maps=1&limit=10` validated.
- Docker worker image built locally.
- `python scripts/validate_worker_browser.py` passed in the Docker worker image.
- Local Docker live pipeline reached map processing against Render PostgreSQL.

### Risk

High, because this records production deployment/runtime validation and adds a manual worker execution path.