### PR TITLE
Harden map fetch validation for blocked stats pages

### DIFF
--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -40,7 +40,7 @@ class MapScraper:
         self.driver = Driver(uc=True, headless=True)
         self.content_wait_seconds = content_wait_seconds
 
-    def __enter__(self) -> MapScraper:
+    def __enter__(self) -> "MapScraper":  # noqa: UP037
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/cs2_analytics/scrapers/map_scraper.py
+++ b/cs2_analytics/scrapers/map_scraper.py
@@ -1,14 +1,28 @@
 """Fetches raw map HTML for downstream parsing."""
 
-import time
-
 from bs4 import BeautifulSoup
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
 from seleniumbase import Driver
 
 from cs2_analytics.exceptions import MapScrapeError, SessionScrapeError
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
+
+REQUIRED_MAP_SELECTOR = "div.match-info-box"
+DEFAULT_CONTENT_WAIT_SECONDS = 10.0
+PAGE_SNIPPET_LIMIT = 300
+CHALLENGE_MARKERS = (
+    "access denied",
+    "captcha",
+    "checking your browser",
+    "cloudflare",
+    "enable javascript",
+    "just a moment",
+    "verify you are human",
+)
 
 
 class MapScraper:
@@ -19,10 +33,14 @@ class MapScraper:
     persistence.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        content_wait_seconds: float = DEFAULT_CONTENT_WAIT_SECONDS,
+    ) -> None:
         self.driver = Driver(uc=True, headless=True)
+        self.content_wait_seconds = content_wait_seconds
 
-    def __enter__(self) -> "MapScraper":
+    def __enter__(self) -> MapScraper:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -32,10 +50,61 @@ class MapScraper:
         """Loads a map page and returns its parsed HTML."""
         try:
             self.driver.get(url)
-            time.sleep(3.0)
+            self._wait_for_map_content(url)
             return BeautifulSoup(self.driver.page_source, "html.parser")
+        except SessionScrapeError:
+            raise
         except Exception as e:
             raise SessionScrapeError(f"Failed to fetch map stats page: {url}") from e
+
+    def _wait_for_map_content(self, url: str) -> None:
+        """Waits until the fetched page contains expected map stats content."""
+        try:
+            WebDriverWait(self.driver, self.content_wait_seconds).until(
+                lambda driver: driver.find_element(
+                    By.CSS_SELECTOR,
+                    REQUIRED_MAP_SELECTOR,
+                )
+            )
+        except TimeoutException as e:
+            marker_flags = self._log_missing_map_content(url)
+            challenge_markers = [
+                marker for marker, is_present in marker_flags.items() if is_present
+            ]
+            if challenge_markers:
+                marker_list = ", ".join(challenge_markers)
+                raise SessionScrapeError(
+                    "Map stats page appears blocked or challenged "
+                    f"after {self.content_wait_seconds:g}s "
+                    f"(markers: {marker_list}): {url}"
+                ) from e
+            raise SessionScrapeError(
+                "Map stats page missing required content "
+                f"after {self.content_wait_seconds:g}s: {url}"
+            ) from e
+
+    def _log_missing_map_content(self, requested_url: str) -> dict[str, bool]:
+        page_source = self.driver.page_source or ""
+        page_source_lower = page_source.lower()
+        marker_flags = {
+            marker.replace(" ", "_"): marker in page_source_lower
+            for marker in CHALLENGE_MARKERS
+        }
+        snippet = " ".join(page_source.split())[:PAGE_SNIPPET_LIMIT]
+
+        logger.warning(
+            "Map stats page missing required selector=%s requested_url=%s "
+            "current_url=%s title=%s page_source_length=%d marker_flags=%s "
+            "page_snippet=%r",
+            REQUIRED_MAP_SELECTOR,
+            requested_url,
+            getattr(self.driver, "current_url", None),
+            getattr(self.driver, "title", None),
+            len(page_source),
+            marker_flags,
+            snippet,
+        )
+        return marker_flags
 
     def close(self) -> None:
         """Closes the Selenium driver."""

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -147,11 +147,14 @@ Docker worker validation has proven that Selenium/Chromium can start inside the
 same application image used by the manual worker path.
 
 Local Docker live pipeline execution also completed in the worker image against
-Render PostgreSQL and reached map processing. The run exposed a map scraper
-validation gap: fetched map HTML can lack the expected `match-info-box` page
-content, after which the parser raises `MapParseError` and the controller marks
-the row failed. This is tracked in issue #57 and should be handled as retryable
-fetch/session hardening, not as a deployment/runtime boundary change.
+Render PostgreSQL and reached map processing. That run exposed a map scraper
+validation gap where fetched map HTML could lack the expected
+`match-info-box` page content. Issue #57 hardened the map scraper so missing,
+incomplete, blocked, or challenged map stats HTML is classified as a retryable
+scraper/session failure before parser handling, with diagnostics for the
+requested URL, current browser URL, page title, source length, challenge marker
+flags, and a short page snippet. Real map parser failures remain parser
+failures.
 
 Write-based deterministic smoke checks are intentionally not run against the
 production Render PostgreSQL database. A separate smoke/staging database is

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -527,12 +527,30 @@ assumptions work outside the local development machine.
    remains read-only by policy. Local Docker live pipeline execution completed
    in the worker image and reached map processing against Render PostgreSQL.
    The run exposed a map scraper validation gap: selected map pages can return
-   HTML without the expected `match-info-box`, and the parser currently marks
-   those rows failed instead of treating the fetch as retryable. Remaining
-   closeout work is to track or fix that fetch-validation/retry hardening in
-   issue #57 before recurring worker runs, run the workflow in GitHub Actions
-   after it is available on GitHub, rotate exposed database credentials, and
-   finalize the deployment documentation.
+   HTML without the expected `match-info-box`. The
+   `fix-map-fetch-validation-retry` branch hardened map fetch validation so
+   missing, incomplete, blocked, or challenged map stats HTML is classified as
+   retryable scraper/session failure before parser handling. Remaining closeout
+   work is to run the workflow in GitHub Actions after it is available on
+   GitHub, rotate exposed database credentials, and finalize the deployment
+   documentation.
+
+8. [x] `fix-map-fetch-validation-retry`
+       Fix issue #57 by hardening map fetch validation when HLTV returns
+       incomplete, challenged, redirected, or otherwise non-stats map HTML.
+       Missing required map page selectors should be classified as retryable
+       scraper/session failures with useful diagnostics, while real parser
+       failures should remain parser failures. Previously failed map rows can be
+       handled by later recovery/reset work; this branch should use the manual
+       worker path to validate map processing before recurring worker runs.
+
+   Map fetch validation now waits for the required map stats selector and logs
+   requested URL, browser URL, title, page-source length, challenge marker
+   flags, and a short page snippet when validation fails. Cloudflare/challenge
+   pages are surfaced as retryable blocked/challenged session failures rather
+   than map parser failures. A limited validation run against Render PostgreSQL
+   confirmed the affected rows no longer use the old map-name parser failure
+   path.
 
 ### Phase 3.75 exit criteria
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,11 +134,12 @@ Validated production checks:
   SeleniumBase's driver scratch directory.
 - Local Docker live pipeline execution completed in the worker image and
   reached the map stage against Render PostgreSQL. The map stage selected 50
-  pending maps, but the fetched HTML lacked the expected `match-info-box`
-  content and those rows failed with `MapParseError: Failed to extract map name
-  from map stats page.` This confirms the deployment worker path while leaving
-  map fetch validation and retry hardening as follow-up issue #57 before
-  recurring worker runs.
+  pending maps, but some fetched HTML lacked the expected `match-info-box`
+  content. Issue #57 hardened map fetch validation so incomplete, blocked, or
+  challenged map stats HTML is classified as a retryable scraper/session
+  failure with diagnostics before parser handling. This confirms the deployment
+  worker path while keeping recurring worker runs paused until broader live
+  ingestion behavior and operations are intentionally resumed.
 
 Local worker validation commands:
 

--- a/tests/scrapers/test_map_scraper.py
+++ b/tests/scrapers/test_map_scraper.py
@@ -1,0 +1,119 @@
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from cs2_analytics.exceptions import SessionScrapeError
+from cs2_analytics.scrapers import map_scraper as map_scraper_module
+from cs2_analytics.scrapers.map_scraper import MapScraper
+
+
+class _FakeDriver:
+    def __init__(self, page_source: str, *, has_required_content: bool) -> None:
+        self.page_source = page_source
+        self.has_required_content = has_required_content
+        self.current_url = "about:blank"
+        self.title = "fake page"
+        self.loaded_urls: list[str] = []
+        self.find_calls: list[tuple[str, str]] = []
+        self.quit_called = False
+
+    def get(self, url: str) -> None:
+        self.loaded_urls.append(url)
+        self.current_url = url
+
+    def find_element(self, by: str, selector: str) -> object:
+        self.find_calls.append((by, selector))
+        if self.has_required_content:
+            return object()
+        raise TimeoutException("missing required content")
+
+    def quit(self) -> None:
+        self.quit_called = True
+
+
+class _FakeWait:
+    def __init__(self, driver: _FakeDriver, _timeout: float) -> None:
+        self.driver = driver
+
+    def until(self, condition) -> object:
+        try:
+            return condition(self.driver)
+        except TimeoutException:
+            raise
+        except Exception as exc:
+            raise TimeoutException("condition timed out") from exc
+
+
+def _build_scraper(
+    monkeypatch: pytest.MonkeyPatch,
+    driver: _FakeDriver,
+) -> MapScraper:
+    monkeypatch.setattr(map_scraper_module, "Driver", lambda **_kwargs: driver)
+    monkeypatch.setattr(map_scraper_module, "WebDriverWait", _FakeWait)
+    return MapScraper(content_wait_seconds=0.1)
+
+
+def test_map_scraper_waits_for_required_match_info_box(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = _FakeDriver(
+        "<html><body><div class='match-info-box'>Ancient</div></body></html>",
+        has_required_content=True,
+    )
+    scraper = _build_scraper(monkeypatch, driver)
+
+    soup = scraper.fetch_soup("https://www.hltv.org/stats/matches/mapstatsid/1/test")
+
+    assert soup.select_one("div.match-info-box") is not None
+    assert driver.loaded_urls == [
+        "https://www.hltv.org/stats/matches/mapstatsid/1/test"
+    ]
+    assert driver.find_calls == [
+        ("css selector", map_scraper_module.REQUIRED_MAP_SELECTOR)
+    ]
+
+
+def test_map_scraper_missing_match_info_box_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = _FakeDriver(
+        "<html><head><title>Just a moment...</title></head>"
+        "<body>Checking your browser before accessing HLTV.</body></html>",
+        has_required_content=False,
+    )
+    warning_calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(
+        map_scraper_module.logger,
+        "warning",
+        lambda *args, **kwargs: warning_calls.append((args, kwargs)),
+    )
+    scraper = _build_scraper(monkeypatch, driver)
+
+    with pytest.raises(
+        SessionScrapeError,
+        match="Map stats page appears blocked or challenged after 0.1s",
+    ):
+        scraper.fetch_soup("https://www.hltv.org/stats/matches/mapstatsid/1/test")
+
+    assert driver.find_calls == [
+        ("css selector", map_scraper_module.REQUIRED_MAP_SELECTOR)
+    ]
+    assert len(warning_calls) == 1
+    assert warning_calls[0][0][0].startswith(
+        "Map stats page missing required selector=%s"
+    )
+
+
+def test_map_scraper_missing_match_info_box_without_challenge_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = _FakeDriver(
+        "<html><body>temporarily incomplete stats page</body></html>",
+        has_required_content=False,
+    )
+    scraper = _build_scraper(monkeypatch, driver)
+
+    with pytest.raises(
+        SessionScrapeError,
+        match="Map stats page missing required content after 0.1s",
+    ):
+        scraper.fetch_soup("https://www.hltv.org/stats/matches/mapstatsid/1/test")


### PR DESCRIPTION
## Summary

- replace the map scraper fixed sleep with an explicit wait for required map stats content
- classify missing, incomplete, blocked, or challenged map stats HTML as retryable scraper/session failure before parser handling
- add diagnostics for failed map fetch validation, including URL, title, source length, challenge markers, and snippet
- update deployment/backlog docs to close out issue #57

Closes #57.

## Scope

In scope:
- `MapScraper.fetch_soup()` validation before returning soup to the parser
- retryable `SessionScrapeError` classification for non-stats/challenge HTML
- focused map scraper tests
- docs updates for Phase 3.75 closeout

Out of scope:
- bypassing Cloudflare or changing scraper identity/network strategy
- changing ingestion-state lifecycle semantics
- keeping blocked rows pending after retry exhaustion
- dbt, Airflow, demo expansion, or frontend work

## Validation

- `python -m pytest tests\scrapers\test_map_scraper.py`
- `python -m ruff check cs2_analytics\scrapers\map_scraper.py tests\scrapers\test_map_scraper.py`
- `python -m pytest` → `116 passed, 3 skipped`
- Limited Render PostgreSQL validation via PgAdmin confirmed affected rows now record blocked/challenged fetch diagnostics instead of the previous `Failed to extract map name from map stats page.` parser error.

## Notes

Rows can still end as `failed` after retry exhaustion. The important behavior change is that Cloudflare/challenge/non-stats HTML is now classified accurately as a retryable fetch/session problem, not a parser failure.