### PR TITLE
Add frontend roadmap track and issue labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -17,9 +17,37 @@
   color: "0052cc"
   description: "Airflow orchestration work."
 
+- name: "phase: A"
+  color: "0e8a16"
+  description: "Frontend Phase A public top players demo work."
+
+- name: "phase: B"
+  color: "1d76db"
+  description: "Frontend Phase B expansion candidate work."
+
 - name: "phase: deferred"
   color: "bfdadc"
   description: "Deferred work such as demo expansion, API expansion, or later orchestration."
+
+- name: "area: frontend"
+  color: "c5def5"
+  description: "React SPA, GitHub Pages UI, and frontend product experience work."
+
+- name: "area: backend"
+  color: "bfd4f2"
+  description: "Python backend, server-side runtime, and backend integration work."
+
+- name: "area: api"
+  color: "a2eeef"
+  description: "FastAPI routes, schemas, services, and API read behavior."
+
+- name: "area: ingestion"
+  color: "fef2c0"
+  description: "Scrapers, parsers, controllers, stage services, and ingestion lifecycle work."
+
+- name: "area: data"
+  color: "d4c5f9"
+  description: "Database schema, migrations, storage contracts, dbt models, and analytics data shape."
 
 - name: "type: implementation"
   color: "0e8a16"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -20,6 +20,17 @@ Current priorities:
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
   source schema normalization
 - defer demo expansion and Airflow until after the initial dbt layer exists
+- keep frontend product planning in `docs/frontend_backlog.md` so the public
+  GitHub Pages SPA can progress without renumbering backend/data phases
+
+---
+
+## Parallel Product Tracks
+
+Frontend product work uses a lettered phase strategy in
+`docs/frontend_backlog.md`. Phase A starts with a public React SPA demo that
+introduces the project and shows the existing top players API from the
+Render-hosted backend.
 
 ---
 

--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -1,0 +1,188 @@
+# Frontend Backlog
+
+This document tracks the product-facing frontend roadmap for the public React
+SPA. It is intentionally separate from the main backend/data roadmap in
+`docs/backlog.md`.
+
+The frontend roadmap uses lettered phases so it does not conflict with the
+backend architecture phases. Phase A is the first frontend phase.
+
+---
+
+## Current Frontend Scope
+
+Initial audience:
+
+- the project owner
+- potential employers reviewing the project
+
+Initial product goal:
+
+Show a polished public analytics demo that introduces CS2 Analytics and proves
+the deployed API can serve current database-backed player data.
+
+Initial constraints:
+
+- the frontend is a React SPA in `frontend/`
+- the app is hosted on GitHub Pages
+- deployment runs from `main`
+- the app is fully public
+- the app calls the Render-hosted backend API
+- the first visible data surface uses the existing top players API
+- deeper analytics, charts, authentication, and extra API surfaces are deferred
+
+---
+
+## Phase A: Public Top Players Demo
+
+Goal:
+Create the first public frontend experience: a polished project introduction
+and a simple top players list backed by the live Render API.
+
+Status:
+Planned.
+
+### Planned work
+
+- [ ] Create the frontend app shell in `frontend/`
+- [ ] Add public project introduction content for portfolio review
+- [ ] Add a top players data view using the Render-hosted API
+- [ ] Add loading, empty, and error states for the API call
+- [ ] Add responsive styling for desktop and mobile review
+- [ ] Add GitHub Pages deployment from `main`
+- [ ] Document how to configure the frontend API base URL
+- [ ] Add a lightweight frontend verification path
+
+### Suggested branch sequence
+
+1. [ ] `phasea-frontend-project-shell`
+       Create the React SPA foundation in `frontend/` with the first public page
+       structure, project introduction, and basic responsive styling.
+
+   Proposed issue:
+   **Frontend A1: Create public project shell**
+
+   Suggested labels:
+   `phase: A`, `area: frontend`, `type: implementation`,
+   `priority: medium`, `risk: medium`
+
+   Acceptance criteria:
+   - `frontend/` contains the React SPA foundation
+   - the first screen introduces CS2 Analytics clearly
+   - the page looks presentable on desktop and mobile
+   - no API integration is required in this branch
+
+   Out of scope:
+   - GitHub Pages deployment
+   - new backend endpoints
+   - charts or deeper analytics
+
+2. [ ] `phasea-top-players-api-view`
+       Add the first live data surface by calling the existing top players API
+       and rendering a simple list of players.
+
+   Proposed issue:
+   **Frontend A2: Show top players from the Render API**
+
+   Suggested labels:
+   `phase: A`, `area: frontend`, `type: implementation`,
+   `priority: medium`, `risk: low`
+
+   Acceptance criteria:
+   - the frontend reads the API base URL from configuration
+   - the app calls the top players API from the browser
+   - top players render in a clean, scannable list
+   - loading, empty, and error states are visible and polished
+   - failed API calls do not break the page
+
+   Out of scope:
+   - authentication
+   - pagination
+   - sorting/filtering beyond what the API already supports
+   - new API endpoints
+
+3. [ ] `phasea-github-pages-deploy`
+       Add the GitHub Pages deployment path so the SPA builds and publishes from
+       `main`.
+
+   Proposed issue:
+   **Frontend A3: Deploy frontend to GitHub Pages from main**
+
+   Suggested labels:
+   `phase: A`, `area: frontend`, `type: deployment`,
+   `priority: medium`, `risk: medium`
+
+   Acceptance criteria:
+   - GitHub Actions builds the SPA from `frontend/`
+   - pushes to `main` publish the app to GitHub Pages
+   - SPA routing works after page refreshes on GitHub Pages
+   - the deployed app uses the configured Render API base URL
+   - deployment setup is documented in the existing deployment or workflow docs
+
+   Out of scope:
+   - backend deployment changes
+   - custom domain setup
+   - private previews or environment-specific deployments
+
+4. [ ] `phasea-frontend-demo-polish`
+       Polish the first demo so it is portfolio-ready and comfortable for
+       potential employers to review quickly.
+
+   Proposed issue:
+   **Frontend A4: Polish public demo experience**
+
+   Suggested labels:
+   `phase: A`, `area: frontend`, `type: implementation`,
+   `priority: low`, `risk: low`
+
+   Acceptance criteria:
+   - the page communicates what the project does without long explanations
+   - project links and API/demo context are easy to find
+   - top players remain the primary data proof point
+   - responsive layout is checked at common desktop and mobile widths
+   - frontend verification steps are documented
+
+   Out of scope:
+   - second analytics view
+   - visual charting library
+   - authentication
+   - backend/API changes
+
+### Phase A exit criteria
+
+- [ ] A public GitHub Pages URL is available
+- [ ] The SPA introduces the project and shows top players from the Render API
+- [ ] The app handles loading, empty, and error states gracefully
+- [ ] The app is usable on desktop and mobile
+- [ ] Deployment from `main` is documented and repeatable
+
+---
+
+## Phase B: Frontend Expansion Candidates
+
+Goal:
+Decide the next frontend product surface only after Phase A proves the public
+demo path.
+
+Status:
+Candidate backlog. Do not start until Phase A is complete and the next user
+goal is clear.
+
+Suggested phase label:
+`phase: B`
+
+### Candidate work
+
+- [ ] Add a match list view if the backend exposes match read APIs
+- [ ] Add a player detail view if the backend exposes player detail APIs
+- [ ] Add a small data freshness indicator
+- [ ] Add basic filters once the API supports them
+- [ ] Add project/process notes for portfolio reviewers
+
+### Decision questions before Phase B
+
+- Which second data surface matters most for a portfolio review: matches,
+  players, teams, or ingestion status?
+- Should the next frontend branch wait for dbt-backed read models?
+- Should the frontend stay a small demo, or begin moving toward a fuller public
+  analytics product?

--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -23,7 +23,10 @@ the deployed API can serve current database-backed player data.
 
 Initial constraints:
 
-- the frontend is a React SPA in `frontend/`
+- the public frontend target is a React SPA under `frontend/`
+- `frontend/` currently contains a Streamlit debug app at `frontend/app.py`;
+  Phase A should decide whether to replace it, move it, or retire it before
+  adding the React app scaffold
 - the app is hosted on GitHub Pages
 - deployment runs from `main`
 - the app is fully public
@@ -45,6 +48,7 @@ Planned.
 ### Planned work
 
 - [ ] Create the frontend app shell in `frontend/`
+- [ ] Decide how to handle the existing `frontend/app.py` Streamlit debug app
 - [ ] Add public project introduction content for portfolio review
 - [ ] Add a top players data view using the Render-hosted API
 - [ ] Add loading, empty, and error states for the API call
@@ -56,8 +60,9 @@ Planned.
 ### Suggested branch sequence
 
 1. [ ] `phasea-frontend-project-shell`
-       Create the React SPA foundation in `frontend/` with the first public page
-       structure, project introduction, and basic responsive styling.
+       Decide how to handle the existing Streamlit debug app, then create the
+       React SPA foundation in `frontend/` with the first public page structure,
+       project introduction, and basic responsive styling.
 
    Proposed issue:
    **Frontend A1: Create public project shell**
@@ -67,7 +72,9 @@ Planned.
    `priority: medium`, `risk: medium`
 
    Acceptance criteria:
-   - `frontend/` contains the React SPA foundation
+   - The branch explicitly replaces, moves, or retires the existing
+     `frontend/app.py` Streamlit debug app
+   - `frontend/` contains the React SPA foundation after that decision
    - the first screen introduces CS2 Analytics clearly
    - the page looks presentable on desktop and mobile
    - no API integration is required in this branch

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -59,7 +59,17 @@ Use exactly one phase label when possible:
 - `phase: 3.75`
 - `phase: 4`
 - `phase: 5`
+- `phase: A`
+- `phase: B`
 - `phase: deferred`
+
+Use one or more area labels when they add useful routing context:
+
+- `area: frontend`
+- `area: backend`
+- `area: api`
+- `area: ingestion`
+- `area: data`
 
 Use type labels to describe the main kind of work:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -51,7 +51,7 @@ Bugfix branches may use:
 
 ## Labels
 
-Apply labels that describe phase, type, priority, and risk.
+Apply labels that describe phase, area, type, priority, and risk.
 
 Use exactly one phase label when possible:
 


### PR DESCRIPTION
## Summary

- Add a dedicated frontend backlog using lettered phases, starting with Phase A for the public React/GitHub Pages demo.
- Link the frontend backlog from the main roadmap without renumbering backend/data phases.
- Add frontend Phase A/B labels and area labels for frontend, backend, API, ingestion, and data triage.
- Update workflow docs to describe the new phase and area labels.

## Scope

- Docs-only roadmap planning.
- Label taxonomy metadata.
- No frontend implementation yet.

## Out of scope

- No React app scaffold.
- No GitHub Pages workflow.
- No API changes.
- No backend, schema, dbt, Airflow, or ingestion changes.

## Documentation check

Updated:
- `docs/backlog.md`
- `docs/frontend_backlog.md`
- `docs/workflow.md`
- `.github/labels.yml`

README update not needed because this PR does not add frontend setup, build, or deployment commands.

## Verification

- `git diff --check main...HEAD`

Tests not run because this is docs/label metadata only.