### PR TITLE
Add frontend build and lint job to CI

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,48 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-lint:
+    name: Build And Lint Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Node.js
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and type check
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint

--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -72,6 +72,7 @@ A1 implementation notes:
 - [ ] Add a top players data view using the Render-hosted API
 - [ ] Add loading, empty, and error states for the API call
 - [x] Add responsive styling for desktop and mobile review
+- [x] Add a frontend build and lint CI job for pull requests (#88)
 - [ ] Add GitHub Pages deployment from `main`
 - [ ] Document how to configure the frontend API base URL
 - [x] Add a lightweight frontend verification path
@@ -104,7 +105,31 @@ A1 implementation notes:
    - new backend endpoints
    - charts or deeper analytics
 
-2. [ ] `phasea-top-players-api-view`
+2. [x] `phasea-frontend-ci`
+       Add a frontend build and lint job to the CI gate before the first
+       frontend logic lands, so A2 and later branches merge under automated
+       verification. Tracked by issue #88.
+
+   Proposed issue:
+   **[Task]: Add frontend build and lint job to CI** (#88)
+
+   Suggested labels:
+   `phase: A`, `area: frontend`, `area: tooling`, `type: implementation`,
+   `priority: medium`, `risk: medium`
+
+   Acceptance criteria:
+   - pull requests touching `frontend/**` run `npm ci`, `npm run build`, and
+     `npm run lint`
+   - pull requests that do not touch `frontend/**` skip the frontend job
+   - the job fails the PR gate on TypeScript, build, or lint errors
+   - `docs/workflow.md` documents the frontend CI gate
+
+   Out of scope:
+   - GitHub Pages deployment (A3)
+   - frontend unit tests or a test runner
+   - changes to the Python CI jobs
+
+3. [ ] `phasea-top-players-api-view`
        Add the first live data surface by calling the existing top players API
        and rendering a simple list of players.
 
@@ -128,7 +153,7 @@ A1 implementation notes:
    - sorting/filtering beyond what the API already supports
    - new API endpoints
 
-3. [ ] `phasea-github-pages-deploy`
+4. [ ] `phasea-github-pages-deploy`
        Add the GitHub Pages deployment path so the SPA builds and publishes from
        `main`.
 
@@ -159,7 +184,7 @@ A1 implementation notes:
    - no backend CORS change is needed; production already allows the
      `https://dardenkyle.github.io` origin
 
-4. [ ] `phasea-frontend-demo-polish`
+5. [ ] `phasea-frontend-demo-polish`
        Polish the first demo so it is portfolio-ready and comfortable for
        potential employers to review quickly.
 

--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -120,7 +120,8 @@ A1 implementation notes:
    Acceptance criteria:
    - pull requests touching `frontend/**` run `npm ci`, `npm run build`, and
      `npm run lint`
-   - pull requests that do not touch `frontend/**` skip the frontend job
+   - pull requests that do not touch `frontend/**` do not trigger the
+     frontend workflow
    - the job fails the PR gate on TypeScript, build, or lint errors
    - `docs/workflow.md` documents the frontend CI gate
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -151,8 +151,14 @@ over runtime code, type checks API and runner entrypoints with
 `python -m mypy`, applies Alembic migrations against PostgreSQL, and runs
 `python -m pytest`.
 
-Broader Ruff rules, formatting checks, and full-package MyPy may be added later
-once the project is ready to enforce stricter gates.
+A separate frontend gate (`.github/workflows/frontend-ci.yml`) runs only when
+a pull request or push to `main` touches `frontend/**`. It installs
+dependencies with `npm ci`, then runs `npm run build` (which includes
+TypeScript checking) and `npm run lint`. Pull requests that do not touch the
+frontend skip this job.
+
+Broader Ruff rules, formatting checks, full-package MyPy, and frontend unit
+tests may be added later once the project is ready to enforce stricter gates.
 
 ## Documentation Check
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -155,7 +155,10 @@ A separate frontend gate (`.github/workflows/frontend-ci.yml`) runs only when
 a pull request or push to `main` touches `frontend/**`. It installs
 dependencies with `npm ci`, then runs `npm run build` (which includes
 TypeScript checking) and `npm run lint`. Pull requests that do not touch the
-frontend skip this job.
+frontend do not trigger this workflow at all, so no frontend check appears on
+them. If the frontend check is ever made a required status check, this
+path-filtered behavior needs to be revisited, because required checks that
+never run block merging.
 
 Broader Ruff rules, formatting checks, full-package MyPy, and frontend unit
 tests may be added later once the project is ready to enforce stricter gates.


### PR DESCRIPTION
## Summary

Adds a frontend CI gate so pull requests that touch `frontend/**` are automatically verified with the commands documented in `frontend/README.md`. A1 merged the SPA without CI coverage; this lands before A2 so the first branch with real frontend logic merges under an automated build and lint gate.

## Related Issue

Closes #88

## Scope

- New `.github/workflows/frontend-ci.yml`: path-filtered workflow running `npm ci`, `npm run build` (includes TypeScript checking via `tsc -b`), and `npm run lint` (oxlint) on Node 24 with npm caching, for PRs and pushes to `main` touching `frontend/**` or the workflow file itself.
- `docs/workflow.md`: CI Gate section documents the frontend gate and its skip behavior.
- `docs/frontend_backlog.md`: frontend CI added to Phase A planned work and branch sequence (entry 2, marked complete by this branch); Pages deploy and polish renumber to 4 and 5.

## Out of Scope

- GitHub Pages deployment (A3, #62).
- Frontend unit tests or a test runner.
- Changes to the Python CI jobs in `ci.yml`.

## Risk Level

Risk level: Medium

Reason: CI change, which is a medium-risk category per `docs/workflow.md`. The new workflow is additive and path-filtered, so the existing Python gate is untouched and non-frontend PRs are unaffected.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

No application code changes; CI and docs only.

## Documentation Check

Documentation: Updated

Reason: `docs/workflow.md` CI Gate section now describes the frontend gate, per the documentation rule for CI behavior changes.

Backlog: Updated

Reason: `docs/frontend_backlog.md` records the new branch in the Phase A sequence (this branch alters planned branch sequencing) and marks it complete.

## Verification

Commands run:

- Local mirror of the CI job from a clean install: `npm ci`, `npm run build`, `npm run lint` in `frontend/`.
- Live verification on this PR: the workflow file is included in its own path filter, so the Build And Lint Frontend check runs here.

Results:

- Clean `npm ci` install succeeds against the committed lockfile; build and lint pass locally.
- The Build And Lint Frontend check runs on this PR (workflow file is in its own path filter); see the checks tab for the live result.
- The Python gate runs unchanged.

## Review Notes

- Separate workflow file rather than a job in `ci.yml` because `on.paths` filtering is workflow-level; filtering a single job inside `ci.yml` would need a third-party paths-filter action.
- Action pins follow the existing SHA-pinning convention: same `actions/checkout` pin as `ci.yml`, `actions/setup-node` pinned to the v6.4.0 commit.
- If branch protection later requires the frontend check, note it will show as skipped (not pending) on non-frontend PRs; required-check settings may need path-aware handling at that point.
