### PR TITLE
Fix Docker base image to match the Python 3.12 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -26,10 +26,10 @@ COPY main.py manage_db.py run_api.py ./
 
 RUN useradd --create-home --uid 10001 appuser \
     && mkdir -p /app/logs /app/demos /app/parsed_data \
-    && mkdir -p /usr/local/lib/python3.14/site-packages/seleniumbase/drivers \
+    && mkdir -p /usr/local/lib/python3.12/site-packages/seleniumbase/drivers \
     && chown -R appuser:appuser \
         /app \
-        /usr/local/lib/python3.14/site-packages/seleniumbase/drivers
+        /usr/local/lib/python3.12/site-packages/seleniumbase/drivers
 
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-trixie
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -24,12 +24,13 @@ RUN python -m pip install --upgrade pip \
 
 COPY main.py manage_db.py run_api.py ./
 
-RUN useradd --create-home --uid 10001 appuser \
+RUN site_packages="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" \
+    && useradd --create-home --uid 10001 appuser \
     && mkdir -p /app/logs /app/demos /app/parsed_data \
-    && mkdir -p /usr/local/lib/python3.12/site-packages/seleniumbase/drivers \
+    && mkdir -p "${site_packages}/seleniumbase/drivers" \
     && chown -R appuser:appuser \
         /app \
-        /usr/local/lib/python3.12/site-packages/seleniumbase/drivers
+        "${site_packages}/seleniumbase/drivers"
 
 USER appuser
 


### PR DESCRIPTION
## Summary

Fixes the broken Render deploy of `main`. The Docker image still used `python:3.14-slim`, but #83 narrowed `requires-python` to `>=3.12,<3.13`, so pip inside the image build refuses to install the package (`ERROR: Package 'cs2-analytics' requires a different Python: 3.14.6 not in '<3.13,>=3.12'`) and every deploy exits with status 1.

## Related Issue

Surfaced while validating the A2 frontend work; no pre-existing issue. Deploy failure observed on Render for commit a4728a1.

## Scope

- `Dockerfile`: base image `python:3.14-slim` -> `python:3.12-slim`, and the two hardcoded `python3.14` site-packages paths (SeleniumBase driver directory ownership for the non-root user) -> `python3.12`.

## Out of Scope

- Switching the Docker build from pip to uv (worth considering for consistency with #68/#84; follow-up candidate).
- Stale "Python 3.14+" wording in `README.md` and `CLAUDE.md` (docs cleanup, tracked by the existing backlog line about stale 3.14 targets).
- Frontend A2 work (separate branch in progress).

## Risk Level

Risk level: High

Reason: Deployment/runtime change per `docs/workflow.md` risk levels — it changes the production container's interpreter version. Mitigating: 3.12 is what CI, uv.lock, and all tooling already target; 3.14 was the outlier that could not even build.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

No application code changes; container base image only.

## Documentation Check

Documentation: Update not needed

Reason: No setup commands, environment variables, or workflows change; the Dockerfile now matches what the docs already describe (a containerized runtime aligned with the project toolchain). The stale "Python 3.14+" wording in README/CLAUDE.md predates this fix and is tracked in the backlog's tooling-alignment line.

Backlog: Update not needed

Reason: No roadmap status, phase status, or branch sequencing changes; this is a deploy hotfix.

## Verification

Commands run:

- `Manual Pipeline Worker` workflow dispatched against this branch with `run_pipeline=false` — builds this exact Docker image in GitHub Actions and validates that Selenium/Chromium starts inside it. (Local Docker was unavailable on this machine.)

Results:

- See the workflow run on the Actions tab for this branch; PR merge should wait for it to pass.
- Python CI gate runs on the PR as usual.

## Review Notes

- After merge, Render should auto-deploy `main` successfully; confirm with the read-only production checks (`/health`, `/api/top_players`).
- The pending `API_CORS_ORIGINS` change (adding localhost dev origins) will take effect with the same redeploy.
