### PR TITLE
Frontend A2: Show top players from the Render API

### DIFF
--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -42,9 +42,8 @@ Create the first public frontend experience: a polished project introduction
 and a simple top players list backed by the live Render API.
 
 Status:
-In progress. The A1 project shell is complete: the Streamlit debug app is
-retired and `frontend/` now contains the React + TypeScript + Vite SPA with
-the public introduction page. A2 (top players view) is next.
+In progress. A1 (project shell), the frontend CI gate, and A2 (top players
+view) are complete. A3 (GitHub Pages deploy) is next.
 
 A1 implementation notes:
 
@@ -69,12 +68,13 @@ A1 implementation notes:
 - [x] Decide how to handle the existing `frontend/app.py` Streamlit debug app
   (retired; the React SPA replaces it)
 - [x] Add public project introduction content for portfolio review
-- [ ] Add a top players data view using the Render-hosted API
-- [ ] Add loading, empty, and error states for the API call
+- [x] Add a top players data view using the Render-hosted API
+- [x] Add loading, empty, and error states for the API call
 - [x] Add responsive styling for desktop and mobile review
 - [x] Add a frontend build and lint CI job for pull requests (#88)
 - [ ] Add GitHub Pages deployment from `main`
-- [ ] Document how to configure the frontend API base URL
+- [x] Document how to configure the frontend API base URL
+  (`VITE_API_BASE_URL` override with a code default; see `frontend/README.md`)
 - [x] Add a lightweight frontend verification path
   (`npm run build` and `npm run lint`, documented in `frontend/README.md`)
 
@@ -130,7 +130,7 @@ A1 implementation notes:
    - frontend unit tests or a test runner
    - changes to the Python CI jobs
 
-3. [ ] `phasea-top-players-api-view`
+3. [x] `phasea-top-players-api-view`
        Add the first live data surface by calling the existing top players API
        and rendering a simple list of players.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,7 @@
 # CS2 Analytics Frontend
 
-Public React SPA for CS2 Analytics. Introduces the project and, in later
-Phase A branches, shows live player data from the Render-hosted API.
+Public React SPA for CS2 Analytics. Introduces the project and shows live
+top players data from the Render-hosted API.
 
 Built with React, TypeScript, and Vite. Deployment to GitHub Pages is added
 in a later Phase A branch.
@@ -9,6 +9,25 @@ in a later Phase A branch.
 ## Requirements
 
 - Node.js 24 LTS (or any recent LTS release)
+
+## Configuration
+
+The API base URL defaults to the production Render service in
+`src/config.ts`. It is a public URL (Vite bakes it into the built bundle), so
+no `.env` file is committed. Override it at build time with
+`VITE_API_BASE_URL`, for example in a gitignored `frontend/.env.local`:
+
+```sh
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+Note on local development against the production API: the browser only
+receives responses when the API's CORS allowlist (`API_CORS_ORIGINS` on the
+Render service) includes your page origin. If `http://localhost:5173` is not
+in that allowlist, the top players call fails with a CORS error in dev even
+though the deployed GitHub Pages site works. Either add the localhost origins
+to the Render environment variable or run the API locally and use the
+override above.
 
 ## Development
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -175,6 +175,103 @@ main {
   margin-bottom: 12px;
 }
 
+/* Top players */
+
+.players-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 20px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+
+.players-status p {
+  font-size: 15px;
+}
+
+.players-error {
+  border-color: rgba(240, 82, 82, 0.4);
+}
+
+.pulse-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 1.2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+}
+
+.players-table-wrap {
+  margin-top: 24px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow-x: auto;
+}
+
+.players-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 15px;
+}
+
+.players-table th,
+.players-table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.players-table thead th {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text);
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border);
+}
+
+.players-table tbody tr:not(:last-child) td {
+  border-bottom: 1px solid var(--border);
+}
+
+.players-table .rank-col {
+  width: 48px;
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+.players-table .num-col {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.players-table .player-name {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.players-table .rating {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 /* Highlights */
 
 .highlights {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -218,6 +218,12 @@ main {
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .pulse-dot {
+    animation: none;
+  }
+}
+
 .players-table-wrap {
   margin-top: 24px;
   border: 1px solid var(--border);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import './App.css'
+import { API_BASE_URL } from './config'
+import { TopPlayersSection } from './components/TopPlayers'
 
 const GITHUB_URL = 'https://github.com/dardenkyle/CS2-analytics'
-const API_BASE_URL = 'https://cs2-analytics.onrender.com'
 
 interface PipelineStage {
   step: string
@@ -38,7 +39,7 @@ const PIPELINE_STAGES: PipelineStage[] = [
     step: '05',
     title: 'Present',
     description:
-      'This site is the public face of the system. A live top-players leaderboard backed by the API lands here next.',
+      'This site is the public face of the system. The top players table above is fetched live from the production database through that API.',
   },
 ]
 
@@ -224,6 +225,7 @@ function App() {
       <Header />
       <main>
         <Hero />
+        <TopPlayersSection />
         <PipelineSection />
         <HighlightsSection />
         <TechStackSection />

--- a/frontend/src/components/TopPlayers.tsx
+++ b/frontend/src/components/TopPlayers.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react'
+import { API_BASE_URL } from '../config'
+
+const MIN_MAPS = 1
+const LIMIT = 10
+const COLD_START_HINT_DELAY_MS = 5000
+
+interface TopPlayer {
+  player_name: string
+  maps_played: number
+  avg_rating: number
+}
+
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; players: TopPlayer[] }
+
+function useTopPlayers() {
+  const [state, setState] = useState<FetchState>({ status: 'loading' })
+  const [attempt, setAttempt] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const url = `${API_BASE_URL}/api/top_players?min_maps=${MIN_MAPS}&limit=${LIMIT}`
+
+    setState({ status: 'loading' })
+
+    fetch(url, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`The API responded with status ${response.status}`)
+        }
+        return response.json() as Promise<TopPlayer[]>
+      })
+      .then((players) => {
+        setState({ status: 'success', players })
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) {
+          return
+        }
+        const message =
+          error instanceof Error ? error.message : 'Unexpected error'
+        setState({ status: 'error', message })
+      })
+
+    return () => controller.abort()
+  }, [attempt])
+
+  const retry = () => setAttempt((current) => current + 1)
+
+  return { state, retry }
+}
+
+function LoadingState() {
+  const [showColdStartHint, setShowColdStartHint] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setShowColdStartHint(true),
+      COLD_START_HINT_DELAY_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <div className="players-status" role="status">
+      <span className="pulse-dot" aria-hidden="true" />
+      <p>
+        {showColdStartHint
+          ? 'Waking the API — the free-tier instance sleeps when idle and can take up to 30 seconds to respond.'
+          : 'Loading top players…'}
+      </p>
+    </div>
+  )
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="players-status players-error" role="alert">
+      <p>Could not load top players. {message}.</p>
+      <button type="button" className="button" onClick={onRetry}>
+        Try again
+      </button>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="players-status">
+      <p>
+        No players matched the current filters. The database may be between
+        ingestion runs — check back soon.
+      </p>
+    </div>
+  )
+}
+
+function PlayersTable({ players }: { players: TopPlayer[] }) {
+  return (
+    <div className="players-table-wrap">
+      <table className="players-table">
+        <thead>
+          <tr>
+            <th scope="col" className="rank-col">#</th>
+            <th scope="col">Player</th>
+            <th scope="col" className="num-col">Maps</th>
+            <th scope="col" className="num-col">Avg rating</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((player, index) => (
+            <tr key={player.player_name}>
+              <td className="rank-col">{index + 1}</td>
+              <td className="player-name">{player.player_name}</td>
+              <td className="num-col">{player.maps_played}</td>
+              <td className="num-col rating">{player.avg_rating.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function TopPlayersSection() {
+  const { state, retry } = useTopPlayers()
+
+  return (
+    <section className="section" id="top-players">
+      <h2>Top players, live from the API</h2>
+      <p className="section-sub">
+        The {LIMIT} highest-rated players currently in the production database,
+        fetched from the deployed REST API when this page loads.
+      </p>
+      {state.status === 'loading' && <LoadingState />}
+      {state.status === 'error' && (
+        <ErrorState message={state.message} onRetry={retry} />
+      )}
+      {state.status === 'success' &&
+        (state.players.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <PlayersTable players={state.players} />
+        ))}
+    </section>
+  )
+}

--- a/frontend/src/components/TopPlayers.tsx
+++ b/frontend/src/components/TopPlayers.tsx
@@ -101,7 +101,10 @@ function EmptyState() {
 function PlayersTable({ players }: { players: TopPlayer[] }) {
   return (
     <div className="players-table-wrap">
-      <table className="players-table">
+      <table
+        className="players-table"
+        aria-label="Top players by average rating"
+      >
         <thead>
           <tr>
             <th scope="col" className="rank-col">#</th>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -10,5 +10,10 @@ const DEFAULT_API_BASE_URL = 'https://cs2-analytics.onrender.com'
  *
  *   VITE_API_BASE_URL=http://localhost:8000
  */
-export const API_BASE_URL: string =
-  import.meta.env.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL
+const configured: string | undefined = import.meta.env.VITE_API_BASE_URL
+
+export const API_BASE_URL: string = (
+  configured === undefined || configured === ''
+    ? DEFAULT_API_BASE_URL
+    : configured
+).replace(/\/+$/, '')

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,14 @@
+const DEFAULT_API_BASE_URL = 'https://cs2-analytics.onrender.com'
+
+/**
+ * Base URL for the CS2 Analytics API.
+ *
+ * This is a public URL (it ships in the built bundle either way), so the
+ * default lives here in code and no .env file is committed. Override it with
+ * VITE_API_BASE_URL at build time, for example in frontend/.env.local
+ * (gitignored) to point at a locally running API:
+ *
+ *   VITE_API_BASE_URL=http://localhost:8000
+ */
+export const API_BASE_URL: string =
+  import.meta.env.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL


### PR DESCRIPTION
## Summary

Adds the first live data surface to the public frontend (Phase A2): a top players table fetched from the production API on page load, rendered between the hero and the pipeline section. Loading, error, and empty states are explicit, including cold-start messaging for the Render free-tier wake-up delay, and a failed call never breaks the page.

## Related Issue

Closes #61

## Scope

- `frontend/src/components/TopPlayers.tsx`: fetch hook with abort-on-unmount and explicit loading/error/success states; table renders rank, player, maps, and average rating; error state has a retry button; loading switches to "waking the API" messaging after five seconds.
- `frontend/src/config.ts`: API base URL configuration — defaults to the production Render URL (public value), overridable at build time with `VITE_API_BASE_URL` (e.g. gitignored `frontend/.env.local`).
- `frontend/src/App.tsx` / `App.css`: section wiring, Present-stage copy update, table and status styling.
- `frontend/README.md`: configuration section (default, override, CORS caveat).
- `docs/frontend_backlog.md`: A2 items and branch entry checked off, Phase A status updated.

## Out of Scope

- Authentication, pagination, sorting/filtering beyond the existing API (per issue).
- New API endpoints or backend changes.
- GitHub Pages deployment (A3, #62).

## Risk Level

Risk level: Low

Reason: Frontend-only change on the public read path; failure modes are handled in the component and cannot affect backend, schema, or ingestion behavior.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

No backend code touched.

## Documentation Check

Documentation: Updated

Reason: `frontend/README.md` documents the new API base URL configuration and the CORS requirement discovered during verification.

Backlog: Updated

Reason: `docs/frontend_backlog.md` marks A2 planned work and the branch entry complete and updates the Phase A status.

## Verification

Commands run:

- `npm run build` (includes TypeScript checking) and `npm run lint` — both pass.
- Headless-Chrome screenshots: success state with live production data (desktop 1440px and mobile 390px), error state (unreachable API shows the red panel with retry), cold-start messaging (manually verified in the browser after 5s against a hanging endpoint).
- Live production check in the browser: top players table loads on localhost from the Render API after the `API_CORS_ORIGINS` allowlist gained the localhost dev origins.

Results:

- All states render correctly at desktop and mobile widths; no horizontal scroll.
- A blocked or failed API call leaves the rest of the page fully usable.
- This PR touches `frontend/**`, so the new frontend CI gate (#88) runs on it — its first live pull request.

## Review Notes

- During verification we found the Render `API_CORS_ORIGINS` allowlist only contained the GitHub Pages origin; browsers on localhost were blocked. The variable now includes the localhost dev origins (dashboard change, documented in the README). The deployed Pages site never needed this.
- The response is trusted as `TopPlayer[]` without runtime schema validation — reasonable for a first-party API; can revisit if the API surface grows.
- `min_maps=1&limit=10` are constants in the component; sorting/filtering UI is deferred per the issue.
