### PR TITLE
Frontend A3: Deploy frontend to GitHub Pages from main

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,73 @@
+name: Deploy Frontend To GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-frontend.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Node.js
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Add SPA fallback for deep links
+        run: cp dist/index.html dist/404.html
+
+      - name: Upload Pages artifact
+        # actions/upload-pages-artifact@v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        with:
+          path: frontend/dist
+
+  deploy:
+    name: Deploy To GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        # actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -111,6 +111,30 @@ Pages origin. For a project page such as
 `https://dardenkyle.github.io/CS2-analytics`, the browser origin is
 `https://dardenkyle.github.io`.
 
+## Frontend GitHub Pages Deployment
+
+The public React SPA deploys to GitHub Pages through
+`.github/workflows/deploy-frontend.yml`. Pushes to `main` that touch
+`frontend/**` (or the workflow file) build the SPA with Node 24 (`npm ci`,
+`npm run build`) and publish `frontend/dist` to the `github-pages`
+environment. The workflow can also be run manually from the Actions tab.
+
+Deployment details:
+
+- The app is served as a project page at
+  `https://dardenkyle.github.io/CS2-analytics/`, so Vite's `base` is set to
+  `/CS2-analytics/` in `frontend/vite.config.ts`.
+- The build copies `index.html` to `404.html` so deep links and refreshes
+  serve the SPA instead of the GitHub Pages 404 page.
+- The deployed app calls the Render API using the base URL configured in
+  `frontend/src/config.ts` (see `frontend/README.md` for the
+  `VITE_API_BASE_URL` override).
+- One-time repository setup: Settings -> Pages -> Build and deployment ->
+  Source must be set to "GitHub Actions".
+
+Frontend deploys are independent of the Render API service: publishing the
+SPA never changes backend runtime, schema, or data.
+
 ## First Cloud Deployment Status
 
 The first Render API deployment is available at:
@@ -247,7 +271,7 @@ Render API environment variables:
 | `DEBUG_MODE=false` | Render environment variable |
 | `API_HOST=0.0.0.0` | Render environment variable |
 | `API_PORT` | Must resolve to Render's web service `PORT` value |
-| `API_CORS_ORIGINS` | Render environment variable containing the GitHub Pages origin |
+| `API_CORS_ORIGINS` | Render environment variable with the comma-separated browser origin allowlist: the GitHub Pages origin, plus local frontend dev origins as needed |
 | `DB_NAME` | Render PostgreSQL connection setting |
 | `DB_USER` | Render PostgreSQL connection setting |
 | `DB_PASS` | Render secret |

--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -42,8 +42,11 @@ Create the first public frontend experience: a polished project introduction
 and a simple top players list backed by the live Render API.
 
 Status:
-In progress. A1 (project shell), the frontend CI gate, and A2 (top players
-view) are complete. A3 (GitHub Pages deploy) is next.
+In progress. A1 (project shell), the frontend CI gate, A2 (top players view),
+and A3 (GitHub Pages deploy) are complete. The public URL goes live when the
+A3 branch merges to `main` with the repository's Pages source set to GitHub
+Actions. A4 (demo polish) is next and should confirm the Phase A exit
+criteria against the live URL.
 
 A1 implementation notes:
 
@@ -62,6 +65,16 @@ A1 implementation notes:
   `access-control-allow-origin: https://dardenkyle.github.io`, so A3 needs no
   backend CORS change.
 
+A2 implementation notes:
+
+- The Render `API_CORS_ORIGINS` allowlist was expanded during A2 to include
+  local frontend dev origins alongside the GitHub Pages origin, because
+  browsers block responses for origins outside the allowlist. Details in
+  `frontend/README.md`; keep exact values in the Render dashboard rather than
+  docs.
+- The loading state switches to cold-start messaging after five seconds to
+  cover the Render free-tier wake-up delay.
+
 ### Planned work
 
 - [x] Create the frontend app shell in `frontend/`
@@ -72,7 +85,8 @@ A1 implementation notes:
 - [x] Add loading, empty, and error states for the API call
 - [x] Add responsive styling for desktop and mobile review
 - [x] Add a frontend build and lint CI job for pull requests (#88)
-- [ ] Add GitHub Pages deployment from `main`
+- [x] Add GitHub Pages deployment from `main`
+  (`.github/workflows/deploy-frontend.yml`; see `docs/deployment.md`)
 - [x] Document how to configure the frontend API base URL
   (`VITE_API_BASE_URL` override with a code default; see `frontend/README.md`)
 - [x] Add a lightweight frontend verification path
@@ -154,7 +168,7 @@ A1 implementation notes:
    - sorting/filtering beyond what the API already supports
    - new API endpoints
 
-4. [ ] `phasea-github-pages-deploy`
+4. [x] `phasea-github-pages-deploy`
        Add the GitHub Pages deployment path so the SPA builds and publishes from
        `main`.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,8 +3,10 @@
 Public React SPA for CS2 Analytics. Introduces the project and shows live
 top players data from the Render-hosted API.
 
-Built with React, TypeScript, and Vite. Deployment to GitHub Pages is added
-in a later Phase A branch.
+Built with React, TypeScript, and Vite. Pushes to `main` that touch
+`frontend/**` deploy to GitHub Pages at
+`https://dardenkyle.github.io/CS2-analytics/` via
+`.github/workflows/deploy-frontend.yml` (see `docs/deployment.md`).
 
 ## Requirements
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// GitHub Pages serves the app as a project page under /CS2-analytics/,
+// so built asset URLs must be prefixed with that path.
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/CS2-analytics/',
   plugins: [react()],
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// GitHub Pages serves the app as a project page under /CS2-analytics/,
-// so built asset URLs must be prefixed with that path.
+// GitHub Pages serves the app as a project page under /CS2-analytics/, so
+// production builds prefix asset URLs with that path. The dev server stays
+// at / so local development matches the README URL.
 // https://vite.dev/config/
-export default defineConfig({
-  base: '/CS2-analytics/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/CS2-analytics/' : '/',
   plugins: [react()],
-})
+}))


### PR DESCRIPTION
## Summary

Adds the GitHub Pages deployment path (Phase A3): pushes to `main` that touch `frontend/**` build the SPA and publish it to `https://dardenkyle.github.io/CS2-analytics/`. This is the final step to a public URL for the Phase A demo. Also folds in two documentation syncs from A2 review: the `API_CORS_ORIGINS` table row and the missing A2 implementation notes.

## Related Issue

Closes #62

## Scope

- `.github/workflows/deploy-frontend.yml` (new): Node 24 build of `frontend/`, SPA 404 fallback (`index.html` -> `404.html`), publish `frontend/dist` via the official SHA-pinned Pages actions; `workflow_dispatch` for manual redeploys; serialized by a concurrency group.
- `frontend/vite.config.ts`: `base: '/CS2-analytics/'` for project-page asset paths.
- `docs/deployment.md`: new Frontend GitHub Pages Deployment section; `API_CORS_ORIGINS` row generalized (allowlist now includes local dev origins after A2; exact values live in the Render dashboard).
- `docs/frontend_backlog.md`: A2 implementation notes added; A3 planned work and branch entry marked complete; status points at A4.
- `frontend/README.md`: deployment note replaced with the real workflow and public URL.

## Out of Scope

- Backend deployment changes (none; frontend deploys cannot touch the API, schema, or data).
- Custom domain, private previews, environment-specific deploys (per issue).
- Demo polish (A4, #63).

## Risk Level

Risk level: Medium

Reason: Deployment/CI change per `docs/workflow.md`. Additive: a new workflow with `pages`/`id-token` permissions scoped to itself; existing CI and the Render runtime are untouched.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

No backend code touched.

## Documentation Check

Documentation: Updated

Reason: `docs/deployment.md` documents the new deployment path and corrects the CORS row; `frontend/README.md` documents the public URL. Required because this change affects deployment behavior.

Backlog: Updated

Reason: `docs/frontend_backlog.md` marks A3 complete, adds the A2 notes that were missing, and updates Phase A status/sequencing.

## Verification

Commands run:

- `npm run build` with the new base, then `vite preview`: `/CS2-analytics/` serves the page, root redirects to it, hashed asset URLs resolve under the prefix (curl checks for 200s).
- `npm run lint` passes.
- GitHub Pages enabled via API with `build_type=workflow`; the URL is reserved.
- `workflow_dispatch` from this branch is not possible (GitHub only registers new workflows once they exist on the default branch), so the publish step runs first on merge.

Results:

- Base-path build verified locally; the frontend CI gate on this PR runs the same install/build commands.
- First real publish happens on merge; post-merge validation is loading the public URL and confirming the top players table populates from the Render API (CORS for the Pages origin was verified live in A1).

## Review Notes

- The deploy job uses GitHub's stock `upload-pages-artifact`/`deploy-pages` actions, SHA-pinned like the other workflows.
- No client router exists, so the `404.html` copy makes any deep link render the single page — revisit if routing is added in Phase B.
- One-time setup (Pages source = GitHub Actions) is already done via API and documented in `docs/deployment.md`.
