### PR TITLE
Add design decisions and live demo links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,18 +318,33 @@ more lifecycle discipline than a queue requires — every outcome must be
 recorded explicitly — in exchange for an ingestion run that is resumable,
 idempotent, and observable.
 
-### One source, no pluggable-source abstraction
+### Stable grains and idempotent writes before analytics
 
-The pipeline ingests from a single upstream site, and there is deliberately
-no generic "source adapter" interface. An abstraction over one
-implementation would be speculative complexity: it could not be validated
-against a second source and would slow down changes to the only source that
-exists. The existing layer boundaries already isolate site-specific logic —
-scrapers and parsers are the only layers that know about the upstream
-markup — so supporting a second source later means adding a scraper and a
-parser, not restructuring the pipeline. The accepted cost is that
-site-specific assumptions live in those two layers rather than behind a
-formal interface.
+The parsed source tables were locked to explicit grains before any
+analytics work: `matches` is one row per match, `maps` one row per played
+map, `players` one row per player per map. Storage writes are upserts that
+refresh trusted fields, so re-running ingestion over the same matches never
+duplicates rows. This was done ahead of the planned dbt layer because
+transformation models are only as trustworthy as their sources — building
+dbt on tables that could drift or duplicate would push data-quality
+firefighting downstream where it is hardest to debug. The tradeoff is
+slower feature delivery up front: schema and write-path discipline landed
+before any user-visible analytics did.
+
+### Simple, managed deployment first
+
+The first cloud deployment uses deliberately simple, proven parts: Render
+for the API and PostgreSQL, GitHub Pages for the frontend, and a manual
+GitHub Actions workflow as the scraper runner — no Kubernetes, no Airflow, no
+custom domain. Render builds the repository's own Dockerfile, so production
+runs the same container image and the same entrypoints used locally through
+Docker Compose (`python run_api.py` for the API, `python main.py` for the
+pipeline) — one runtime to debug instead of a separate cloud configuration.
+Production validation is read-only by policy: health checks and DB-backed
+reads, with write-based smoke tests restricted to disposable databases. The tradeoff is fewer operational
+capabilities (no scheduling, manual migrations) in exchange for a
+deployment simple enough to reason about while the data layer is still
+evolving.
 
 ### Demo parsing deferred behind a preserved boundary
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # Counter-Strike 2 Pro Match Analytics Tool
 
 [![CI](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml)
+[![Frontend CI](https://github.com/dardenkyle/CS2-analytics/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/frontend-ci.yml)
+[![Deploy Frontend](https://github.com/dardenkyle/CS2-analytics/actions/workflows/deploy-frontend.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/deploy-frontend.yml)
+
+**Live demo:** [dardenkyle.github.io/CS2-analytics](https://dardenkyle.github.io/CS2-analytics/) —
+a public dashboard showing top players served live from the production
+database. The API behind it is also public:
+[cs2-analytics.onrender.com/docs](https://cs2-analytics.onrender.com/docs).
+(The API runs on a free tier and can take up to ~30 seconds to wake after
+idle periods.)
 
 ## Project Overview
 
 This project is a Counter-Strike 2 analytics tool focused on collecting professional match, map, and player data and turning it into reliable, queryable analytics data.
+
+The system is deployed end to end: a Python ingestion pipeline writes to
+PostgreSQL, a FastAPI service on Render serves player statistics, and a React
+SPA on GitHub Pages presents them publicly.
 
 The current ingestion architecture uses PostgreSQL-backed ingestion-state tables, thin controllers for batch orchestration, and stage services for per-item match/map/demo workflow boundaries.
 
@@ -28,11 +41,16 @@ The current ingestion architecture uses PostgreSQL-backed ingestion-state tables
 
 ## Tech Stack
 
-- Python 3.14+
+- Python 3.12
 - SeleniumBase and BeautifulSoup for web scraping
-- PostgreSQL for structured data storage
+- PostgreSQL for structured data storage, with Alembic-managed migrations
 - Pandas and NumPy for analytics/data processing
-- FastAPI for API work
+- FastAPI for the public read API (deployed on Render)
+- React, TypeScript, and Vite for the public frontend (deployed on GitHub
+  Pages)
+- Docker and Docker Compose for the container runtime
+- GitHub Actions for CI (backend and frontend gates) and deployment
+- uv with a committed lockfile for reproducible Python installs
 
 ## Project Structure
 
@@ -61,6 +79,7 @@ CS2-Analytics/
 |   `-- utils/
 |-- docs/
 |-- logs/
+|-- scripts/
 |-- tests/
 |-- demos/
 |-- parsed_data/
@@ -265,10 +284,69 @@ results discovery
 -> relational storage
 ```
 
+## Design Decisions & Tradeoffs
+
+Short reasoning behind the choices that shaped the system. Full ADR-style
+records live in `docs/architecture/decision_log.md`.
+
+### Layered pipeline boundaries
+
+Controllers, stage services, scrapers, parsers, and storage are separate
+layers with one job each: controllers own batch coordination and retry
+policy, stage services own a single item's fetch-parse-persist workflow,
+scrapers only fetch, parsers only parse, and storage centralizes writes.
+The tradeoff is more indirection than a small project strictly needs — but
+each layer is testable without the others (parsers run against saved HTML,
+no browser), scraping failures stay contained to the layer that talks to
+the network, and later stages (dbt, new sources) attach without rewrites.
+This split came from experience, not upfront design: controllers originally
+absorbed per-item work until the mixed responsibilities made retry behavior
+hard to reason about.
+
+### Ingestion state over work queues
+
+Discovered matches, maps, and demos live in PostgreSQL-backed
+ingestion-state tables (`pending`, `processing`, `processed`, `failed`,
+`skipped`) rather than a disposable work queue. Rows are keyed by source ID,
+so rediscovery refreshes existing rows instead of duplicating work, and a
+rerun after a crash resumes from state instead of starting over. The
+`skipped` versus `failed` distinction is deliberate: `skipped` records an
+intentional decision not to process (for example a forfeited match with no
+stats), while `failed` means processing was attempted and exhausted its
+retries. Collapsing the two would make failure metrics lie. The tradeoff is
+more lifecycle discipline than a queue requires — every outcome must be
+recorded explicitly — in exchange for an ingestion run that is resumable,
+idempotent, and observable.
+
+### One source, no pluggable-source abstraction
+
+The pipeline ingests from a single upstream site, and there is deliberately
+no generic "source adapter" interface. An abstraction over one
+implementation would be speculative complexity: it could not be validated
+against a second source and would slow down changes to the only source that
+exists. The existing layer boundaries already isolate site-specific logic —
+scrapers and parsers are the only layers that know about the upstream
+markup — so supporting a second source later means adding a scraper and a
+parser, not restructuring the pipeline. The accepted cost is that
+site-specific assumptions live in those two layers rather than behind a
+formal interface.
+
+### Demo parsing deferred behind a preserved boundary
+
+Demo files introduce a different workload class: large binary downloads,
+temporary-file lifecycle, long parses, and event-level extraction. Rather
+than bolt that onto the match/map surface, demo processing is deferred
+until the analytics layer (dbt) exists and downstream demo needs are
+concrete. The boundary is kept, not deleted: `DemoStageService` and the
+demo ingestion-state table preserve the stage shape, so demo expansion
+plugs into the same controller/stage-service pattern later. The tradeoff
+is no event-level stats yet, in exchange for keeping the active pipeline
+small enough to harden and deploy.
+
 ## Data Insights & Usage (planned)
 
 - Current API surface includes a player-oriented read path for top players by
-  average rating.
+  average rating, shown live on the public demo page.
 - View per-match player performance.
 - Compare teams' win rates on specific maps.
 - Identify key players in matchups.
@@ -282,6 +360,8 @@ See `docs/` for architecture and roadmap details.
 Current architecture direction:
 
 - Phases 2, 3, 3.5, 3.6, and 3.75 are complete.
+- Frontend Phase A shipped the public GitHub Pages demo backed by the live
+  API (see `docs/frontend_backlog.md`).
 - Phase 3.9 (environment and tooling hardening) is in progress.
 - Phase 4 (dbt transformation layer) follows Phase 3.9. Entry criteria include
   v1.0 hardening items for ingestion layer correctness and atomic writes.


### PR DESCRIPTION
## Summary

Makes the README work as the project's front door for portfolio reviewers: the live demo and public API are now linked at the top (previously the README had no path to the deployed system), and a new "Design Decisions & Tradeoffs" section explains the reasoning behind the architecture — the why, not just the what.

## Related Issue

Closes #82

## Scope

README.md only:

- Header: live demo link (`dardenkyle.github.io/CS2-analytics`), public API docs link, frontend CI + Pages deploy badges, free-tier cold-start caveat.
- Project overview: one paragraph stating the system is deployed end to end.
- New "Design Decisions & Tradeoffs" section (all four items from the issue, condensed from `docs/architecture/decision_log.md` and `docs/ingestion_lifecycle.md`): layered pipeline boundaries; ingestion state over work queues with the `skipped` vs `failed` distinction; single-source scope without a pluggable-source abstraction; demo parsing deferred behind a preserved boundary. Each entry names the tradeoff accepted.
- Drift fixes: Python 3.14+ -> 3.12, tech stack updated (frontend, Docker, GitHub Actions, uv, Alembic), `scripts/` added to the project tree, roadmap notes mention shipped frontend Phase A.

## Out of Scope

- Architecture or code changes (per issue).
- Full ADR documentation — the section links to `docs/architecture/decision_log.md` for depth.
- The placeholder contact email (`dardenkyle@example.com`) — flagged for the owner to decide separately.
- The stale "Python 3.14+" wording in `CLAUDE.md` (agent-facing doc, not README; can ride along a future tooling branch).

## Risk Level

Risk level: Low

Reason: Docs-only; no executable behavior described changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

The new section documents these boundaries; it does not change them.

## Documentation Check

Documentation: Updated

Reason: The change is the documentation.

Backlog: Update not needed

Reason: No roadmap status, phase status, or branch sequencing changes; #82 is a standalone maintenance issue not tracked as a backlog checklist item (it appears only as an interleave suggestion in the frontend backlog prose).

## Verification

Commands run:

- Docs-only change; per `docs/workflow.md`, tests are not required. Content accuracy was sourced from `docs/architecture/decision_log.md` (ADR-0001, -0002, -0005) and `docs/ingestion_lifecycle.md` (status model), and links were spot-checked against the live deployment.

Results:

- All four issue items are covered with their tradeoffs; the section reads in well under 5 minutes.

## Review Notes

- Voice/emphasis in the Design Decisions section is the main thing to review — the facts come from the ADRs, but the framing is written for a reviewer/interviewer audience. Edit freely.
- The "single-source scope" rationale is not recorded in any ADR; it is written here from the project's actual boundaries. If you want it as ADR-0009 in the decision log, that can be a tiny follow-up.
