### PR TITLE
Frontend A4: Polish public demo experience

### DIFF
--- a/docs/frontend_backlog.md
+++ b/docs/frontend_backlog.md
@@ -42,11 +42,12 @@ Create the first public frontend experience: a polished project introduction
 and a simple top players list backed by the live Render API.
 
 Status:
-In progress. A1 (project shell), the frontend CI gate, A2 (top players view),
-and A3 (GitHub Pages deploy) are complete. The public URL goes live when the
-A3 branch merges to `main` with the repository's Pages source set to GitHub
-Actions. A4 (demo polish) is next and should confirm the Phase A exit
-criteria against the live URL.
+Complete. A1 (project shell), the frontend CI gate, A2 (top players view),
+A3 (GitHub Pages deploy), and A4 (demo polish) are done. The demo is live at
+`https://dardenkyle.github.io/CS2-analytics/`, backed by the production API,
+and the exit criteria below were verified against the live URL. Phase B
+starts only after the next user goal is clear (see the decision questions
+at the bottom of this document).
 
 A1 implementation notes:
 
@@ -199,7 +200,7 @@ A2 implementation notes:
    - no backend CORS change is needed; production already allows the
      `https://dardenkyle.github.io` origin
 
-5. [ ] `phasea-frontend-demo-polish`
+5. [x] `phasea-frontend-demo-polish`
        Polish the first demo so it is portfolio-ready and comfortable for
        potential employers to review quickly.
 
@@ -225,11 +226,21 @@ A2 implementation notes:
 
 ### Phase A exit criteria
 
-- [ ] A public GitHub Pages URL is available
-- [ ] The SPA introduces the project and shows top players from the Render API
-- [ ] The app handles loading, empty, and error states gracefully
-- [ ] The app is usable on desktop and mobile
-- [ ] Deployment from `main` is documented and repeatable
+All verified against the live URL after the A3 merge:
+
+- [x] A public GitHub Pages URL is available
+      (`https://dardenkyle.github.io/CS2-analytics/`; page, hashed assets,
+      and deep-link fallback all confirmed serving)
+- [x] The SPA introduces the project and shows top players from the Render API
+      (live data confirmed in production and in headless-browser renders)
+- [x] The app handles loading, empty, and error states gracefully
+      (error and cold-start states exercised against unreachable and hanging
+      endpoints during A2)
+- [x] The app is usable on desktop and mobile
+      (verified at 1440px and 390px)
+- [x] Deployment from `main` is documented and repeatable
+      (`docs/deployment.md` Frontend GitHub Pages Deployment section;
+      redeploys run on every `main` push touching `frontend/**`)
 
 ### Related work outside the frontend
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,14 @@
       name="description"
       content="CS2 Analytics — an end-to-end data platform that collects professional Counter-Strike 2 match data and serves player analytics from a live API."
     />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="CS2 Analytics" />
+    <meta
+      property="og:description"
+      content="End-to-end Counter-Strike 2 analytics: a Python ingestion pipeline, PostgreSQL, and a live FastAPI service behind a public player dashboard."
+    />
+    <meta property="og:url" content="https://dardenkyle.github.io/CS2-analytics/" />
+    <meta name="twitter:card" content="summary" />
     <title>CS2 Analytics</title>
   </head>
   <body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -278,6 +278,13 @@ main {
   font-weight: 600;
 }
 
+.data-note {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--text);
+  opacity: 0.85;
+}
+
 /* Highlights */
 
 .highlights {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,7 +133,7 @@ function Hero() {
       </h1>
       <p className="hero-sub">
         CS2 Analytics collects professional match, map, and player data through a
-        resilient Python ingestion pipeline, stores it in PostgreSQL, and serves
+        resilient Python ingestion pipeline, persists it to PostgreSQL, and serves
         player statistics from a live FastAPI service.
       </p>
       <div className="hero-actions">
@@ -213,6 +213,14 @@ function Footer() {
         ·{' '}
         <a href={`${API_BASE_URL}/docs`} target="_blank" rel="noreferrer">
           Live API
+        </a>{' '}
+        ·{' '}
+        <a
+          href={`${GITHUB_URL}#design-decisions--tradeoffs`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Design decisions
         </a>
       </p>
     </footer>

--- a/frontend/src/components/TopPlayers.tsx
+++ b/frontend/src/components/TopPlayers.tsx
@@ -109,7 +109,7 @@ function PlayersTable({ players }: { players: TopPlayer[] }) {
           <tr>
             <th scope="col" className="rank-col">#</th>
             <th scope="col">Player</th>
-            <th scope="col" className="num-col">Maps</th>
+            <th scope="col" className="num-col">Maps played</th>
             <th scope="col" className="num-col">Avg rating</th>
           </tr>
         </thead>
@@ -146,7 +146,13 @@ export function TopPlayersSection() {
         (state.players.length === 0 ? (
           <EmptyState />
         ) : (
-          <PlayersTable players={state.players} />
+          <>
+            <PlayersTable players={state.players} />
+            <p className="data-note">
+              Rankings reflect matches ingested so far; historical backfill is
+              ongoing, so map counts are still small.
+            </p>
+          </>
         ))}
     </section>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,12 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // GitHub Pages serves the app as a project page under /CS2-analytics/, so
-// production builds prefix asset URLs with that path. The dev server stays
-// at / so local development matches the README URL.
+// production builds prefix asset URLs with that path. vite preview serves
+// the built output and must use the same base (its command is 'serve', so
+// isPreview is the discriminator). Only the dev server stays at / to match
+// the README URL.
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/CS2-analytics/' : '/',
+export default defineConfig(({ command, isPreview }) => ({
+  base: command === 'build' || isPreview ? '/CS2-analytics/' : '/',
   plugins: [react()],
 }))


### PR DESCRIPTION
## Summary

Final Phase A branch (A4): polishes the live demo for portfolio review, fixes a `vite preview` base-path regression found during verification, and closes out the Phase A exit criteria — all five verified against the live URL.

## Related Issue

Closes #63

## Scope

- `frontend/vite.config.ts` (fix): `vite preview` runs with command `serve`, so the A3 conditional gave it base `/` while built assets referenced `/CS2-analytics/` — asset requests fell through to the SPA fallback and returned HTML, blanking the page. Base is now keyed on `command === 'build' || isPreview`. Production was never affected.
- `frontend/index.html`: Open Graph + Twitter card meta for link previews.
- `frontend/src/components/TopPlayers.tsx`: "Maps played" column header; data-context note under the table (rankings reflect matches ingested so far; backfill ongoing) so small map counts read as expected rather than as a bug.
- `frontend/src/App.tsx` / `App.css`: hero wording ("persists to PostgreSQL"), footer link to the README's Design Decisions section, note styling.
- `docs/frontend_backlog.md`: Phase A status set to complete; all five exit criteria checked with verification notes; A4 branch entry checked.

## Out of Scope

- Second analytics view, charting library, authentication, backend/API changes (per issue).
- Phase B work — gated on the decision questions in the frontend backlog.

## Risk Level

Risk level: Low

Reason: Frontend copy/meta polish, a local-preview config fix, and docs. No API, schema, or pipeline changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Frontend and docs only.

## Documentation Check

Documentation: Update not needed

Reason: No setup, configuration, or deployment behavior changes; frontend verification steps were already documented in `frontend/README.md` during A1/A2.

Backlog: Updated

Reason: This branch completes Phase A — status, exit criteria, and the branch entry are all updated in `docs/frontend_backlog.md`.

## Verification

Commands run:

- `npm run build` and `npm run lint` — pass.
- `vite preview` asset check: the JS bundle now serves at its full 199 kB (previously 1.2 kB of fallback HTML) and the page renders under `/CS2-analytics/`.
- Headless-browser renders at 1440px and 390px with live production data; owner independently confirmed the preview fix in a real browser.

Results:

- All states and both widths render correctly with the new copy and data note.
- Phase A exit criteria verified against `https://dardenkyle.github.io/CS2-analytics/` (page, assets, deep-link fallback, live data, responsive layout, documented deploys).

## Review Notes

- The preview regression came from the A3 review fix itself — worth a glance at the new `vite.config.ts` comment explaining the `command`/`isPreview` distinction so it doesn't regress a third time.
- Merging this triggers a Pages redeploy (frontend files changed), which publishes the polish live.
