### PR TITLE
Fail loudly on map stat parse failures instead of writing zeros

### DIFF
--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -230,18 +230,20 @@ class MapParser:
     def _extract_player_identity(self, cols) -> tuple[str, str, int]:
         """Extracts player display identity from the first row cell."""
         name_tag = cols[0].find("a")
-        player_url = self._extract_player_url(name_tag)
-        player_id = self._extract_numeric_id(player_url) if player_url else -1
         player_name = self._extract_player_name(cols, name_tag)
-        return player_name, player_url or "", player_id
+        player_url = self._extract_player_url(name_tag)
+        if not player_url:
+            raise MapParseError(
+                f"Failed to extract player URL for {player_name!r} "
+                "from map stats page."
+            )
+        player_id = self._extract_numeric_id(player_url)
+        return player_name, player_url, player_id
 
     def _extract_player_url(self, name_tag) -> str | None:
         """Extracts the absolute player URL when one is present."""
-        try:
-            if name_tag and "href" in name_tag.attrs:
-                return f"https://www.hltv.org{name_tag['href']}"
-        except Exception:
-            return None
+        if name_tag and "href" in name_tag.attrs:
+            return f"https://www.hltv.org{name_tag['href']}"
         return None
 
     def _extract_player_stats(
@@ -252,13 +254,18 @@ class MapParser:
         assists, flash_assists = self._extract_assists(cols, column_indexes["assists"])
         deaths, traded_deaths = self._extract_deaths(cols, column_indexes["deaths"])
         opening_kills, opening_deaths = self._parse_colon_pair(
-            self._extract_metric_text(cols, column_indexes["opkd"], ["st-opkd"])
+            self._extract_metric_text(cols, column_indexes["opkd"], ["st-opkd"]),
+            metric="opening duels",
         )
         multi_kills = self._parse_int_value(
-            self._extract_metric_text(cols, column_indexes["mks"], ["st-mks"])
+            self._extract_metric_text(cols, column_indexes["mks"], ["st-mks"]),
+            metric="multi-kills",
         )
         clutches_won = self._parse_int_value(
-            self._extract_metric_text(cols, column_indexes["clutches"], ["st-clutches"])
+            self._extract_metric_text(
+                cols, column_indexes["clutches"], ["st-clutches"]
+            ),
+            metric="clutches won",
         )
         round_swing = self._parse_percent_value(
             self._extract_metric_text(
@@ -266,7 +273,8 @@ class MapParser:
                 column_indexes["round_swing"],
                 ["st-roundSwing"],
                 prefer_hidden=False,
-            )
+            ),
+            metric="round swing",
         )
         kast = self._extract_kast(cols, column_indexes["kast"])
         adr = self._extract_adr(cols, column_indexes["adr"])
@@ -295,12 +303,12 @@ class MapParser:
             self._extract_metric_text(cols, kills_idx, ["st-kills"]),
             "No player kills logged.",
         )
-        return self._parse_pair(kills_text)
+        return self._parse_pair(kills_text, metric="kills")
 
     def _extract_assists(self, cols, assists_idx: int) -> tuple[int, int]:
         """Extracts assists and flash assists from the player row."""
         assists_text = self._extract_metric_text(cols, assists_idx, ["st-assists"])
-        return self._parse_pair(assists_text)
+        return self._parse_pair(assists_text, metric="assists")
 
     def _extract_deaths(self, cols, deaths_idx: int) -> tuple[int, int]:
         """Extracts deaths and traded deaths from the player row."""
@@ -308,62 +316,47 @@ class MapParser:
             self._extract_metric_text(cols, deaths_idx, ["st-deaths"]),
             "No player deaths logged.",
         )
-        return self._parse_pair(deaths_text)
+        return self._parse_pair(deaths_text, metric="deaths")
 
     def _extract_kast(self, cols, kast_idx: int) -> float:
         """Extracts KAST as a decimal ratio."""
+        kast_text = self._extract_metric_text(
+            cols,
+            kast_idx,
+            ["st-kast"],
+            prefer_hidden=False,
+        )
         try:
-            kast_text = self._extract_metric_text(
-                cols,
-                kast_idx,
-                ["st-kast"],
-                prefer_hidden=False,
-            ).replace("%", "")
-            return round(float(kast_text) / 100, 3)
-        except ValueError:
-            logger.warning(
-                "Could not parse KAST from: %s",
-                self._extract_metric_text(cols, kast_idx, ["st-kast"]),
-            )
-            return 0.0
+            return round(float(kast_text.replace("%", "")) / 100, 3)
+        except ValueError as e:
+            raise MapParseError(f"Failed to parse KAST value: {kast_text!r}") from e
 
     def _extract_adr(self, cols, adr_idx: int) -> float:
         """Extracts ADR as a float value."""
+        adr_text = self._extract_metric_text(
+            cols,
+            adr_idx,
+            ["st-adr"],
+            prefer_hidden=False,
+        )
         try:
-            return float(
-                self._extract_metric_text(
-                    cols,
-                    adr_idx,
-                    ["st-adr"],
-                    prefer_hidden=False,
-                )
-            )
-        except ValueError:
-            logger.warning(
-                "Could not parse ADR from: %s",
-                self._extract_metric_text(cols, adr_idx, ["st-adr"]),
-            )
-            return 0.0
+            return float(adr_text)
+        except ValueError as e:
+            raise MapParseError(f"Failed to parse ADR value: {adr_text!r}") from e
 
     def _extract_rating(self, cols, rating_idx: int) -> float:
         """Extracts rating as a float value."""
+        rating_text = self._extract_metric_text(
+            cols,
+            rating_idx,
+            ["st-rating"],
+            prefer_hidden=False,
+        )
+        rating_clean = rating_text.replace("+", "").replace("-", "").replace("%", "")
         try:
-            rating_text = self._extract_metric_text(
-                cols,
-                rating_idx,
-                ["st-rating"],
-                prefer_hidden=False,
-            )
-            rating_clean = (
-                rating_text.replace("+", "").replace("-", "").replace("%", "")
-            )
             return float(rating_clean)
-        except (ValueError, IndexError):
-            logger.warning(
-                "Could not parse Rating from: %s",
-                self._extract_metric_text(cols, rating_idx, ["st-rating"]),
-            )
-            return 0.0
+        except ValueError as e:
+            raise MapParseError(f"Failed to parse rating value: {rating_text!r}") from e
 
     def _build_player(
         self,
@@ -612,7 +605,7 @@ class MapParser:
 
         return self._column_text_or_empty(cols, fallback_idx)
 
-    def _parse_pair(self, text: str) -> tuple[int, int]:
+    def _parse_pair(self, text: str, *, metric: str) -> tuple[int, int]:
         """Parses values like '19(10)' into tuple (19, 10)."""
         match = re.search(r"(\d+)\s*\((\d+)\)", text)
         if match:
@@ -621,7 +614,7 @@ class MapParser:
         single = re.search(r"(\d+)", text)
         if single:
             return int(single.group(1)), 0
-        return 0, 0
+        raise MapParseError(f"Failed to parse {metric} value: {text!r}")
 
     def _require_metric_text(self, text: str, message: str) -> str:
         """Raises a parsing error when a required metric cell is missing."""
@@ -633,24 +626,31 @@ class MapParser:
         match = re.search(r"/(\d+)/", url)
         if match:
             return int(match.group(1))
-        return -1
+        raise MapParseError(f"Failed to extract player id from player URL: {url!r}")
 
-    def _parse_colon_pair(self, text: str) -> tuple[int, int]:
-        """Parses values like '5 : 0' into tuple (5, 0)."""
+    def _parse_colon_pair(self, text: str, *, metric: str) -> tuple[int, int]:
+        """Parses values like '5 : 0' into tuple (5, 0).
+
+        Falls back to zeros with a warning because these secondary stats can
+        legitimately render as empty cells.
+        """
         match = re.search(r"(\d+)\s*:\s*(\d+)", text)
         if match:
             return int(match.group(1)), int(match.group(2))
+        logger.warning("Could not parse %s from %r; defaulting to 0", metric, text)
         return 0, 0
 
-    def _parse_int_value(self, text: str) -> int:
+    def _parse_int_value(self, text: str, *, metric: str) -> int:
         match = re.search(r"-?\d+", text)
         if match:
             return int(match.group(0))
+        logger.warning("Could not parse %s from %r; defaulting to 0", metric, text)
         return 0
 
-    def _parse_percent_value(self, text: str) -> float:
+    def _parse_percent_value(self, text: str, *, metric: str) -> float:
         """Parses values like '+14.68%' into 0.1468."""
         match = re.search(r"([+-]?\d+(?:\.\d+)?)\s*%", text)
         if match:
             return round(float(match.group(1)) / 100, 4)
+        logger.warning("Could not parse %s from %r; defaulting to 0", metric, text)
         return 0.0

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -307,7 +307,10 @@ class MapParser:
 
     def _extract_assists(self, cols, assists_idx: int) -> tuple[int, int]:
         """Extracts assists and flash assists from the player row."""
-        assists_text = self._extract_metric_text(cols, assists_idx, ["st-assists"])
+        assists_text = self._require_metric_text(
+            self._extract_metric_text(cols, assists_idx, ["st-assists"]),
+            "No player assists logged.",
+        )
         return self._parse_pair(assists_text, metric="assists")
 
     def _extract_deaths(self, cols, deaths_idx: int) -> tuple[int, int]:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -755,7 +755,9 @@ deployment baseline work, and dbt.
 These are correctness and readability improvements that do not gate Phase 4 but
 should be addressed before the repo is considered v1.0.
 
-- [ ] Stop silently coercing parse failures to `0` — log or route to explicit failure path (`map_parser.py:329`, `:347`, `:365`, `:247`)
+- [x] Stop silently coercing parse failures to `0` — required stats now raise
+      `MapParseError` into the failed ingestion state, secondary stats log a
+      warning before defaulting (#75)
 - [ ] Add a coverage `fail-under` threshold and wire it into CI so the floor is enforced
 - [ ] Test untested failure branches: date-parse warning, scraper close-failure, parser fallback paths
 - [ ] Batch N+1 storage writes using `executemany` (`match_storage.py`, `map_storage.py`, `player_storage.py`)

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -95,6 +95,7 @@ def _build_map_row_soup(
     player_cell: str = '<a href="/player/22/test-player">TestPlayer</a>',
     kast: str = "70.0%",
     kills: str = "20 (10)",
+    assists: str = "2 (0)",
     adr: str = "80.0",
     rating: str = "1.01",
     swing: str = "+1.00%",
@@ -132,7 +133,7 @@ def _build_map_row_soup(
                   <td class="st-kast">{kast}</td>
                   <td class="st-clutches">0</td>
                   <td class="st-kills">{kills}</td>
-                  <td class="st-assists">2 (0)</td>
+                  <td class="st-assists">{assists}</td>
                   <td class="st-deaths">10 (1)</td>
                   <td class="st-adr">{adr}</td>
                   <td class="st-roundSwing">{swing}</td>
@@ -580,6 +581,20 @@ def test_map_parser_raises_typed_error_for_unparseable_rating() -> None:
     soup = _build_map_row_soup(rating="N/A")
 
     with pytest.raises(MapParseError, match="Failed to parse rating value"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_missing_assists() -> None:
+    soup = _build_map_row_soup(assists="")
+
+    with pytest.raises(MapParseError, match="No player assists logged."):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_unparseable_assists() -> None:
+    soup = _build_map_row_soup(assists="-")
+
+    with pytest.raises(MapParseError, match="Failed to parse assists value"):
         _parse_map_row_soup(soup)
 
 

--- a/tests/parsers/test_parser_exceptions.py
+++ b/tests/parsers/test_parser_exceptions.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
 from bs4 import BeautifulSoup
 
 from cs2_analytics.exceptions import MapParseError, MatchParseError
+from cs2_analytics.parsers import map_parser as map_parser_module
 from cs2_analytics.parsers.map_parser import MapParser
 from cs2_analytics.parsers.match_parser import MatchParser
 
@@ -84,6 +87,70 @@ def _build_map_soup(html_override: str | None = None) -> BeautifulSoup:
         </html>
         """,
         "html.parser",
+    )
+
+
+def _build_map_row_soup(
+    *,
+    player_cell: str = '<a href="/player/22/test-player">TestPlayer</a>',
+    kast: str = "70.0%",
+    kills: str = "20 (10)",
+    adr: str = "80.0",
+    rating: str = "1.01",
+    swing: str = "+1.00%",
+) -> BeautifulSoup:
+    """Builds a one-row map stats page with substitutable metric cells."""
+    return _build_map_soup(
+        f"""
+        <html>
+          <body>
+            <div class="match-info-box">
+              <div class="small-text">Map</div>
+              Inferno
+            </div>
+            <table class="stats-table totalstats">
+              <thead>
+                <tr>
+                  <th class="st-teamname">BIG</th>
+                  <th>Op. K-D</th>
+                  <th>MKs</th>
+                  <th>KAST</th>
+                  <th>1vsX</th>
+                  <th>K (hs)</th>
+                  <th>A (f)</th>
+                  <th>D (t)</th>
+                  <th>ADR</th>
+                  <th>Swing</th>
+                  <th>Rating 3.0</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="st-player">{player_cell}</td>
+                  <td class="st-opkd">1 : 1</td>
+                  <td class="st-mks">1</td>
+                  <td class="st-kast">{kast}</td>
+                  <td class="st-clutches">0</td>
+                  <td class="st-kills">{kills}</td>
+                  <td class="st-assists">2 (0)</td>
+                  <td class="st-deaths">10 (1)</td>
+                  <td class="st-adr">{adr}</td>
+                  <td class="st-roundSwing">{swing}</td>
+                  <td class="st-rating">{rating}</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+        </html>
+        """
+    )
+
+
+def _parse_map_row_soup(soup: BeautifulSoup) -> list:
+    return MapParser().parse_map(
+        soup,
+        map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
+        map_id=2,
     )
 
 
@@ -493,3 +560,58 @@ def test_map_parser_raises_typed_error_for_missing_deaths() -> None:
             map_url="https://www.hltv.org/stats/matches/mapstatsid/2/test-map",
             map_id=2,
         )
+
+
+def test_map_parser_raises_typed_error_for_unparseable_kast() -> None:
+    soup = _build_map_row_soup(kast="N/A")
+
+    with pytest.raises(MapParseError, match="Failed to parse KAST value"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_unparseable_adr() -> None:
+    soup = _build_map_row_soup(adr="N/A")
+
+    with pytest.raises(MapParseError, match="Failed to parse ADR value"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_unparseable_rating() -> None:
+    soup = _build_map_row_soup(rating="N/A")
+
+    with pytest.raises(MapParseError, match="Failed to parse rating value"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_unparseable_kills() -> None:
+    soup = _build_map_row_soup(kills="-")
+
+    with pytest.raises(MapParseError, match="Failed to parse kills value"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_missing_player_link() -> None:
+    soup = _build_map_row_soup(player_cell="TestPlayer")
+
+    with pytest.raises(MapParseError, match="Failed to extract player URL"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_raises_typed_error_for_player_url_without_id() -> None:
+    soup = _build_map_row_soup(player_cell='<a href="/player/no-id">TestPlayer</a>')
+
+    with pytest.raises(MapParseError, match="Failed to extract player id"):
+        _parse_map_row_soup(soup)
+
+
+def test_map_parser_logs_and_defaults_unparseable_round_swing() -> None:
+    soup = _build_map_row_soup(swing="n/a")
+
+    with mock.patch.object(map_parser_module.logger, "warning") as warning_mock:
+        players = _parse_map_row_soup(soup)
+
+    assert len(players) == 1
+    assert players[0].round_swing == 0.0
+    warning_mock.assert_called_once_with(
+        "Could not parse %s from %r; defaulting to 0", "round swing", "n/a"
+    )


### PR DESCRIPTION
## Summary

Stops the map parser from silently coercing parse failures to `0`/`-1`/`None`. Required per-player stats now raise `MapParseError`, which routes the map to the failed ingestion state through the existing controller path. Secondary stats keep a zero default but log a warning with the metric name and raw cell text.

## Related Issue

Closes #75

## Scope

- `cs2_analytics/parsers/map_parser.py`
  - KAST / ADR / rating: raise `MapParseError` (with raw text) instead of warn + `0.0`
  - kills / assists / deaths pair parsing: raise instead of silent `(0, 0)`
  - player identity: missing profile link or id-less player URL raises instead of writing `player_url=""` / `player_id=-1` (which could collide on the `players (map_id, player_id)` primary key)
  - removed the broad `except Exception` swallow in `_extract_player_url`; unexpected errors surface through the `parse_map` boundary
  - opening duels, multi-kills, clutches won, round swing: zero default kept (an empty cell can legitimately mean zero) but now logged with context
- `tests/parsers/test_parser_exceptions.py`: failure-path tests for each new raise plus the logged round-swing fallback
- `docs/backlog.md`: checked off the v1.0 polish item

## Out of Scope

- Schema changes
- Map fetch/retry flow changes
- The other v1.0 polish items (coverage gate, demo subsystem move, etc.)

## Risk Level

Risk level: Medium

Reason: Parser behavior change with contained impact. Maps whose stat cells are unparseable now fail ingestion (visible, re-processable) instead of persisting zeros. If the source ever renders a player row without a profile link, that map now fails instead of storing a `-1` id row.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Documentation: Update not needed

Reason: No architecture, setup, or interface changes; parser failure semantics stay inside the existing parse-error boundary.

Backlog: Updated

Reason: Checked off the "stop silently coercing parse failures" v1.0 polish item.

## Verification

Commands run:

- `uv run pytest` (full suite)
- `uv run ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501`

Results:

- 148 passed
- Lint clean

## Review Notes

The main judgment call is the required-vs-secondary split: kills, assists, deaths, KAST, ADR, rating, and player identity are treated as required (raise on failure); opening duels, multi-kills, clutches, and round swing default to zero with a warning because empty cells there can legitimately mean zero. Flag if you want any of those moved to the raising side.