### PR TITLE
Enforce a 75% coverage floor in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
       - name: Run migrations
         run: uv run alembic -c cs2_analytics/alembic.ini upgrade head
 
-      - name: Run tests
-        run: uv run pytest
+      - name: Run tests with coverage gate
+        run: uv run pytest --cov

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -756,7 +756,9 @@ These are correctness and readability improvements that do not gate Phase 4 but
 should be addressed before the repo is considered v1.0.
 
 - [ ] Stop silently coercing parse failures to `0` — log or route to explicit failure path (`map_parser.py:329`, `:347`, `:365`, `:247`)
-- [ ] Add a coverage `fail-under` threshold and wire it into CI so the floor is enforced
+- [x] Add a coverage `fail-under` threshold and wire it into CI so the floor
+      is enforced — `fail_under = 75` in `pyproject.toml`, CI runs
+      `pytest --cov` (#76)
 - [ ] Test untested failure branches: date-parse warning, scraper close-failure, parser fallback paths
 - [ ] Batch N+1 storage writes using `executemany` (`match_storage.py`, `map_storage.py`, `player_storage.py`)
 - [ ] Widen mypy CI target to cover `cs2_analytics` ingestion core, not just the API layer

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -151,7 +151,8 @@ GitHub Actions CI runs on pull requests and pushes to `main`. The minimum gate
 installs development dependencies, runs focused `python -m ruff` `E,F` linting
 over runtime code, type checks API and runner entrypoints with
 `python -m mypy`, applies Alembic migrations against PostgreSQL, and runs
-`python -m pytest`.
+`python -m pytest --cov`, which enforces the coverage floor set by
+`fail_under` in `pyproject.toml`.
 
 A separate frontend gate (`.github/workflows/frontend-ci.yml`) runs only when
 a pull request or push to `main` touches `frontend/**`. It installs

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -150,9 +150,9 @@ to be small and fast to evaluate.
 GitHub Actions CI runs on pull requests and pushes to `main`. The minimum gate
 installs development dependencies, runs focused `python -m ruff` `E,F` linting
 over runtime code, type checks API and runner entrypoints with
-`python -m mypy`, applies Alembic migrations against PostgreSQL, and runs
-`python -m pytest --cov`, which enforces the coverage floor set by
-`fail_under` in `pyproject.toml`.
+`python -m mypy`, applies Alembic migrations against PostgreSQL, and runs the
+pytest suite with coverage enabled, which enforces the coverage floor set by
+`fail_under` in `pyproject.toml` and fails the build below it.
 
 A separate frontend gate (`.github/workflows/frontend-ci.yml`) runs only when
 a pull request or push to `main` touches `frontend/**`. It installs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ omit = [
 ]
 
 [tool.coverage.report]
+# Honest floor measured at 75.09% total coverage; raise as coverage improves.
+fail_under = 75
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",


### PR DESCRIPTION
## Summary

Adds a real coverage gate: `fail_under = 75` in the coverage config (measured baseline is 75.09%) and the CI test step now runs `pytest --cov` so the build fails if coverage drops below the floor.

## Related Issue

Closes #76

## Scope

- `pyproject.toml`: `fail_under = 75` in `[tool.coverage.report]`
- `.github/workflows/ci.yml`: test step runs `uv run pytest --cov`
- `docs/workflow.md`: CI gate section documents the coverage floor
- `docs/backlog.md`: checked off the v1.0 polish item

## Out of Scope

- Increasing coverage beyond the current baseline (separate effort)
- Changing which files are included in coverage scope

## Risk Level

Risk level: Medium

Reason: CI change (requires human review per workflow policy). No runtime behavior changes; worst case is a false-negative build failure if a future PR drops coverage below 75%.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Documentation: Updated

Reason: CI behavior changed, so the workflow CI gate section now documents the coverage floor.

Backlog: Updated

Reason: Checked off the "coverage fail-under threshold" v1.0 polish item.

## Verification

Commands run:

- `uv run pytest --cov` — exits 0, reports "Required test coverage of 75.0% reached. Total coverage: 75.09%"
- `uv run pytest --cov --cov-fail-under=80` — exits 1, reports "FAIL Required test coverage of 80% not reached", proving the gate fails below threshold

Results:

- 141 passed; gate passes at the current level and fails below it

## Review Notes

The floor is intentionally the truncated current number (75, actual 75.09%), leaving almost no headroom by design: any PR that meaningfully reduces coverage fails. PRs #103 (adds tested code) and the demo-subsystem removal (#81, removes largely untested code) both push coverage up, so merge order does not matter.