### PR TITLE
Add tests for untested scraper failure branches (#77)

### DIFF
--- a/tests/scrapers/test_match_scraper.py
+++ b/tests/scrapers/test_match_scraper.py
@@ -1,0 +1,29 @@
+"""Tests for the fetch-only match scraper."""
+
+import pytest
+
+from cs2_analytics.exceptions import MatchScrapeError
+from cs2_analytics.scrapers import match_scraper as match_scraper_module
+from cs2_analytics.scrapers.match_scraper import MatchScraper
+
+
+class _FailingQuitDriver:
+    def __init__(self, *args, **kwargs) -> None:
+        self.quit_calls = 0
+
+    def quit(self) -> None:
+        self.quit_calls += 1
+        raise RuntimeError("browser already gone")
+
+
+def test_close_failure_raises_typed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(match_scraper_module, "Driver", _FailingQuitDriver)
+    scraper = MatchScraper()
+
+    with pytest.raises(
+        MatchScrapeError, match="Failed to close match scraper driver."
+    ) as exc_info:
+        scraper.close()
+
+    assert scraper.driver.quit_calls == 1
+    assert isinstance(exc_info.value.__cause__, RuntimeError)

--- a/tests/scrapers/test_results_scraper.py
+++ b/tests/scrapers/test_results_scraper.py
@@ -1,7 +1,11 @@
 """Tests for the fetch-only results scraper."""
 
+import datetime as dt
+from unittest import mock
+
 import pytest
 
+from cs2_analytics.exceptions import ResultsScrapeError
 from cs2_analytics.scrapers import results_scraper as results_scraper_module
 from cs2_analytics.scrapers.results_scraper import ResultsScraper
 
@@ -12,6 +16,17 @@ class _FakeDriver:
 
     def quit(self) -> None:
         self.quit_called = True
+
+
+class _FakePageDriver:
+    """Serves a fixed results page for _extract_matches_from_page tests."""
+
+    def __init__(self, page_source: str) -> None:
+        self.page_source = page_source
+        self.loaded_urls: list[str] = []
+
+    def get(self, url: str) -> None:
+        self.loaded_urls.append(url)
 
 
 @pytest.fixture
@@ -111,3 +126,53 @@ def test_extract_match_id(scraper: ResultsScraper) -> None:
         scraper._extract_match_id("https://www.hltv.org/matches/12345/a-vs-b") == 12345
     )
     assert scraper._extract_match_id("https://www.hltv.org/results") is None
+
+
+def test_extract_matches_from_page_warns_and_skips_unparseable_date(
+    scraper: ResultsScraper,
+) -> None:
+    scraper.driver = _FakePageDriver(
+        """
+        <html>
+          <body>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for not-a-date</div>
+              <div class="result-con">
+                <a href="/matches/111/a-vs-b"></a>
+              </div>
+            </div>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for May 5th 2025</div>
+              <div class="result-con">
+                <a href="/matches/222/c-vs-d"></a>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+    )
+    scraper.start_date = dt.date(2025, 1, 1)
+    scraper.end_date = dt.date(2025, 12, 31)
+
+    with mock.patch.object(results_scraper_module.logger, "warning") as warning_mock:
+        matches, stop = scraper._extract_matches_from_page(
+            "https://www.hltv.org/results?offset=0"
+        )
+
+    warning_mock.assert_called_once_with("Could not parse date: %s", "not-a-date")
+    assert matches == ["https://www.hltv.org/matches/222/c-vs-d"]
+    assert stop is False
+
+
+def test_close_failure_raises_typed_error(scraper: ResultsScraper) -> None:
+    def failing_quit() -> None:
+        raise RuntimeError("browser already gone")
+
+    scraper.driver.quit = failing_quit
+
+    with pytest.raises(
+        ResultsScrapeError, match="Failed to close results scraper driver."
+    ) as exc_info:
+        scraper.close()
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)


### PR DESCRIPTION
## Summary

Closes #77.

Adds focused tests for the failure branches listed in the issue that were still untested:

- **Results scraper date-parse warning** (`results_scraper.py`): a results section with an unparseable date header logs `Could not parse date: ...` and is skipped, while later sections on the same page are still parsed.
- **Scraper close-failure branches**: `ResultsScraper.close()` and `MatchScraper.close()` raise their typed errors (`ResultsScrapeError` / `MatchScrapeError`) when the driver quit fails, with the original exception chained as `__cause__`.

The map-parser pointers in the issue (`map_parser.py` player URL, KAST, ADR, rating branches) were already covered by tests added in #103 when those branches switched from silent zero-defaults to raising `MapParseError`, so no new parser tests are needed.

## Verification

- `python -m pytest` — 147 passed, including the 3 new tests
- New files pass the CI lint target (`ruff check --select E,F --ignore E501`) and `ruff format --check`

## Documentation check

No docs updated: test-only change, no behavior, setup, architecture, or workflow changes.