### PR TITLE
Batch storage upserts with executemany (#78)

### DIFF
--- a/cs2_analytics/storage/map_storage.py
+++ b/cs2_analytics/storage/map_storage.py
@@ -52,23 +52,23 @@ def store_maps(maps: list[Map], cur=None) -> None:
 
 
 def _execute_store_maps(cur, maps: list[Map]) -> None:
-    for map_obj in maps:
-        cur.execute(
-            INSERT_MAPS_QUERY,
-            {
-                "map_id": map_obj.map_id,
-                "match_id": map_obj.match_id,
-                "map_url": map_obj.map_url,
-                "map_order": map_obj.map_order,
-                "map_name": map_obj.map_name,
-                "team1_score": map_obj.team1_score,
-                "team2_score": map_obj.team2_score,
-                "map_winner": map_obj.map_winner,
-                "date": map_obj.date,
-                "inserted_at": map_obj.inserted_at,
-                "last_scraped_at": map_obj.last_scraped_at,
-                "last_updated_at": map_obj.last_updated_at,
-                "data_complete": map_obj.data_complete,
-            },
-        )
+    values = [
+        {
+            "map_id": map_obj.map_id,
+            "match_id": map_obj.match_id,
+            "map_url": map_obj.map_url,
+            "map_order": map_obj.map_order,
+            "map_name": map_obj.map_name,
+            "team1_score": map_obj.team1_score,
+            "team2_score": map_obj.team2_score,
+            "map_winner": map_obj.map_winner,
+            "date": map_obj.date,
+            "inserted_at": map_obj.inserted_at,
+            "last_scraped_at": map_obj.last_scraped_at,
+            "last_updated_at": map_obj.last_updated_at,
+            "data_complete": map_obj.data_complete,
+        }
+        for map_obj in maps
+    ]
+    cur.executemany(INSERT_MAPS_QUERY, values)
     logger.info("Stored %d map records.", len(maps))

--- a/cs2_analytics/storage/match_storage.py
+++ b/cs2_analytics/storage/match_storage.py
@@ -59,27 +59,27 @@ def store_matches(matches: list[Match], cur=None) -> None:
 
 
 def _execute_store_matches(cur, matches: list[Match]) -> None:
-    for match in matches:
-        cur.execute(
-            INSERT_MATCHES_QUERY,
-            {
-                "match_id": match.match_id,
-                "match_url": match.match_url,
-                "team1": match.team1,
-                "team2": match.team2,
-                "score1": match.score1,
-                "score2": match.score2,
-                "winner": match.winner,
-                "event": match.event,
-                "match_type": match.match_type,
-                "forfeit": match.forfeit,
-                "date": match.date,
-                "map_links": str(match.map_links),
-                "demo_links": str(match.demo_links),
-                "last_inserted_at": match.last_inserted_at,
-                "last_scraped_at": match.last_scraped_at,
-                "last_updated_at": match.last_updated_at,
-                "data_complete": match.data_complete,
-            },
-        )
+    values = [
+        {
+            "match_id": match.match_id,
+            "match_url": match.match_url,
+            "team1": match.team1,
+            "team2": match.team2,
+            "score1": match.score1,
+            "score2": match.score2,
+            "winner": match.winner,
+            "event": match.event,
+            "match_type": match.match_type,
+            "forfeit": match.forfeit,
+            "date": match.date,
+            "map_links": str(match.map_links),
+            "demo_links": str(match.demo_links),
+            "last_inserted_at": match.last_inserted_at,
+            "last_scraped_at": match.last_scraped_at,
+            "last_updated_at": match.last_updated_at,
+            "data_complete": match.data_complete,
+        }
+        for match in matches
+    ]
+    cur.executemany(INSERT_MATCHES_QUERY, values)
     logger.info("Stored %d match records.", len(matches))

--- a/cs2_analytics/storage/player_storage.py
+++ b/cs2_analytics/storage/player_storage.py
@@ -68,36 +68,36 @@ def store_players(players: list[Player], cur=None) -> None:
 
 
 def _execute_store_players(cur, players: list[Player]) -> None:
-    for p in players:
-        cur.execute(
-            INSERT_PLAYERS_QUERY,
-            {
-                "map_id": p.map_id,
-                "player_id": p.player_id,
-                "player_name": p.player_name,
-                "player_url": p.player_url,
-                "map_name": p.map_name,
-                "team_name": p.team_name,
-                "kills": p.kills,
-                "headshots": p.headshots,
-                "assists": p.assists,
-                "flash_assists": p.flash_assists,
-                "deaths": p.deaths,
-                "traded_deaths": p.traded_deaths,
-                "opening_kills": p.opening_kills,
-                "opening_deaths": p.opening_deaths,
-                "multi_kills": p.multi_kills,
-                "clutches_won": p.clutches_won,
-                "kast": p.kast,
-                "kd_diff": p.kd_diff,
-                "adr": p.adr,
-                "fk_diff": p.fk_diff,
-                "round_swing": p.round_swing,
-                "rating": p.rating,
-                "last_inserted_at": p.last_inserted_at,
-                "last_scraped_at": p.last_scraped_at,
-                "last_updated_at": p.last_updated_at,
-                "data_complete": p.data_complete,
-            },
-        )
+    values = [
+        {
+            "map_id": p.map_id,
+            "player_id": p.player_id,
+            "player_name": p.player_name,
+            "player_url": p.player_url,
+            "map_name": p.map_name,
+            "team_name": p.team_name,
+            "kills": p.kills,
+            "headshots": p.headshots,
+            "assists": p.assists,
+            "flash_assists": p.flash_assists,
+            "deaths": p.deaths,
+            "traded_deaths": p.traded_deaths,
+            "opening_kills": p.opening_kills,
+            "opening_deaths": p.opening_deaths,
+            "multi_kills": p.multi_kills,
+            "clutches_won": p.clutches_won,
+            "kast": p.kast,
+            "kd_diff": p.kd_diff,
+            "adr": p.adr,
+            "fk_diff": p.fk_diff,
+            "round_swing": p.round_swing,
+            "rating": p.rating,
+            "last_inserted_at": p.last_inserted_at,
+            "last_scraped_at": p.last_scraped_at,
+            "last_updated_at": p.last_updated_at,
+            "data_complete": p.data_complete,
+        }
+        for p in players
+    ]
+    cur.executemany(INSERT_PLAYERS_QUERY, values)
     logger.info("Stored %d player stat records.", len(players))

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -762,7 +762,10 @@ should be addressed before the repo is considered v1.0.
       `MapParseError` into the failed ingestion state, secondary stats log a
       warning before defaulting (#75)
 - [ ] Test untested failure branches: date-parse warning, scraper close-failure, parser fallback paths
-- [ ] Batch N+1 storage writes using `executemany` (`match_storage.py`, `map_storage.py`, `player_storage.py`)
+- [x] Batch N+1 storage writes using `executemany` (`match_storage.py`,
+      `map_storage.py`, `player_storage.py`) — each store call now issues one
+      `executemany` batch instead of per-row `execute`, matching the
+      `record_many` pattern (#78)
 - [ ] Widen mypy CI target to cover `cs2_analytics` ingestion core, not just the API layer
 - [ ] Break up overlong controller and utility functions (`match_controller.py`, `map_controller.py`, `results_controller.py`, `retry_utils.py`)
 - [x] Move non-working demo subsystem to a `feature/demo-parsing` branch; add

--- a/tests/storage/test_map_storage.py
+++ b/tests/storage/test_map_storage.py
@@ -10,7 +10,7 @@ from cs2_analytics.storage import map_storage as map_storage_module
 class _RecordingCursor:
     def __init__(self, should_fail: bool = False) -> None:
         self.should_fail = should_fail
-        self.executed: list[tuple[str, dict[str, object]]] = []
+        self.executed: list[tuple[str, list[dict[str, object]]]] = []
 
     def __enter__(self):
         return self
@@ -18,10 +18,10 @@ class _RecordingCursor:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def execute(self, query: str, params: dict[str, object]) -> None:
+    def executemany(self, query: str, values: list[dict[str, object]]) -> None:
         if self.should_fail:
             raise RuntimeError("insert failed")
-        self.executed.append((query, params))
+        self.executed.append((query, values))
 
 
 class _FakeDb:
@@ -64,7 +64,8 @@ def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) 
 
     map_storage_module.store_maps([_map()])
 
-    query, params = cursor.executed[0]
+    query, values = cursor.executed[0]
+    params = values[0]
     assert "map_url" in query
     assert "map_order" in query
     assert "map_winner" in query
@@ -75,6 +76,19 @@ def test_store_maps_writes_active_map_contract(monkeypatch: pytest.MonkeyPatch) 
     assert params["map_winner"] == "Liquid"
 
 
+def test_store_maps_batches_rows_into_one_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(map_storage_module, "get_db", lambda: _FakeDb(cursor))
+
+    map_storage_module.store_maps([_map(), _map()])
+
+    assert len(cursor.executed) == 1
+    _query, values = cursor.executed[0]
+    assert len(values) == 2
+
+
 def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -83,7 +97,7 @@ def test_store_maps_refreshes_trusted_fields_without_replacing_inserted_at(
 
     map_storage_module.store_maps([_map()])
 
-    query, _params = cursor.executed[0]
+    query, _values = cursor.executed[0]
     conflict_update = _conflict_update_clause(query)
 
     for field_name in (

--- a/tests/storage/test_match_storage.py
+++ b/tests/storage/test_match_storage.py
@@ -10,10 +10,10 @@ from cs2_analytics.storage import match_storage as match_storage_module
 
 class _RecordingCursor:
     def __init__(self) -> None:
-        self.executed: list[tuple[str, dict[str, object]]] = []
+        self.executed: list[tuple[str, list[dict[str, object]]]] = []
 
-    def execute(self, query: str, params: dict[str, object]) -> None:
-        self.executed.append((query, params))
+    def executemany(self, query: str, values: list[dict[str, object]]) -> None:
+        self.executed.append((query, values))
 
 
 class _RecordingConnection:
@@ -106,7 +106,8 @@ def test_store_matches_refreshes_trusted_fields_on_conflict(
 
     match_storage_module.store_matches([_match()])
 
-    query, params = cursor.executed[0]
+    query, values = cursor.executed[0]
+    params = values[0]
     conflict_update = _conflict_update_clause(query)
 
     for field_name in (
@@ -134,6 +135,20 @@ def test_store_matches_refreshes_trusted_fields_on_conflict(
     assert conn.committed is True
     assert conn.rolled_back is False
     assert fake_db.released is True
+
+
+def test_store_matches_batches_rows_into_one_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    conn = _RecordingConnection(cursor)
+    monkeypatch.setattr(match_storage_module, "get_db", lambda: _FakeDb(conn))
+
+    match_storage_module.store_matches([_match(), _match()])
+
+    assert len(cursor.executed) == 1
+    _query, values = cursor.executed[0]
+    assert len(values) == 2
 
 
 def test_store_matches_wraps_database_factory_failures(

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -9,7 +9,7 @@ from cs2_analytics.storage import player_storage as player_storage_module
 
 class _RecordingCursor:
     def __init__(self) -> None:
-        self.executed: list[tuple[str, dict[str, object]]] = []
+        self.executed: list[tuple[str, list[dict[str, object]]]] = []
 
     def __enter__(self):
         return self
@@ -17,8 +17,8 @@ class _RecordingCursor:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def execute(self, query: str, params: dict[str, object]) -> None:
-        self.executed.append((query, params))
+    def executemany(self, query: str, values: list[dict[str, object]]) -> None:
+        self.executed.append((query, values))
 
 
 class _FakeDb:
@@ -76,7 +76,8 @@ def test_store_players_refreshes_context_and_metrics_on_conflict(
 
     player_storage_module.store_players([_player()])
 
-    query, params = cursor.executed[0]
+    query, values = cursor.executed[0]
+    params = values[0]
     conflict_update = _conflict_update_clause(query)
 
     assert "ON CONFLICT (map_id, player_id)" in query
@@ -110,6 +111,19 @@ def test_store_players_refreshes_context_and_metrics_on_conflict(
     assert "last_inserted_at = EXCLUDED.last_inserted_at" not in conflict_update
     assert params["map_id"] == 100
     assert params["player_id"] == 200
+
+
+def test_store_players_batches_rows_into_one_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(player_storage_module, "get_db", lambda: _FakeDb(cursor))
+
+    player_storage_module.store_players([_player(), _player()])
+
+    assert len(cursor.executed) == 1
+    _query, values = cursor.executed[0]
+    assert len(values) == 2
 
 
 def test_store_players_wraps_database_factory_failures(

--- a/tests/storage/test_storage_exceptions.py
+++ b/tests/storage/test_storage_exceptions.py
@@ -9,7 +9,7 @@ from cs2_analytics.storage import match_storage as match_storage_module
 
 
 class _FailingCursor:
-    def execute(self, *args, **kwargs) -> None:
+    def executemany(self, *args, **kwargs) -> None:
         raise RuntimeError("insert failed")
 
 


### PR DESCRIPTION
## Summary

Closes #78.

Replaces the row-at-a-time insert loops in the three parsed-source storage modules with a single batched write per call, following the `executemany` pattern already used by `BaseIngestionState.record_many`:

- `match_storage._execute_store_matches`
- `map_storage._execute_store_maps`
- `player_storage._execute_store_players`

Each helper now builds the full list of parameter dicts and issues one `cur.executemany(query, values)` call instead of N `cur.execute` calls.

## Behavior preserved

- The `INSERT ... ON CONFLICT DO UPDATE` queries are untouched; psycopg2's `executemany` executes the same statement per parameter set inside the same transaction, so upsert conflict semantics are identical to the previous loop.
- Transaction ownership is unchanged (ADR-0013): a caller-provided cursor still joins the caller's transaction; otherwise the write runs in its own `get_cursor` transaction.
- Typed storage errors (`MatchStorageError` / `MapStorageError` / `PlayerStorageError`) still wrap any failure.

## Tests

- Storage test fakes now record `executemany` calls.
- New tests in all three storage test modules assert that a multi-row store issues exactly one batched write with all rows.
- `python -m pytest` — 147 passed.

## Documentation check

`docs/backlog.md` updated: the v1.0 Polish checklist item for batching N+1 storage writes is checked off with a completion note. No other docs affected - no schema, API, setup, architecture-boundary, or workflow changes.
