### PR TITLE
Check off the failure-branch testing backlog item (#77)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -763,8 +763,8 @@ should be addressed before the repo is considered v1.0.
       warning before defaulting (#75)
 - [x] Test untested failure branches: date-parse warning, scraper
       close-failure, parser fallback paths — scraper branches gained tests in
-      #106; the parser fallback branches were already covered when #75 made
-      them raise `MapParseError` (#77)
+      #106; the parser fallback branches were already covered by the tests
+      added in #103, which made them raise `MapParseError` (#77)
 - [x] Batch N+1 storage writes using `executemany` (`match_storage.py`,
       `map_storage.py`, `player_storage.py`) — each store call now issues one
       `executemany` batch instead of per-row `execute`, matching the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -761,7 +761,10 @@ should be addressed before the repo is considered v1.0.
 - [x] Stop silently coercing parse failures to `0` — required stats now raise
       `MapParseError` into the failed ingestion state, secondary stats log a
       warning before defaulting (#75)
-- [ ] Test untested failure branches: date-parse warning, scraper close-failure, parser fallback paths
+- [x] Test untested failure branches: date-parse warning, scraper
+      close-failure, parser fallback paths — scraper branches gained tests in
+      #106; the parser fallback branches were already covered when #75 made
+      them raise `MapParseError` (#77)
 - [x] Batch N+1 storage writes using `executemany` (`match_storage.py`,
       `map_storage.py`, `player_storage.py`) — each store call now issues one
       `executemany` batch instead of per-row `execute`, matching the


### PR DESCRIPTION
## Summary

Docs-only follow-up to #106 / #77: checks off the "Test untested failure branches" item in the v1.0 Polish checklist in `docs/backlog.md`, which #106 completed but did not record.

## Documentation check

`docs/backlog.md` updated - that is the entire change.
