### PR TITLE
Decompose overlong controller run loops and reset_scraper (#80)

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -4,6 +4,7 @@ import time
 from contextlib import suppress
 
 from cs2_analytics.controllers.retry_utils import (
+    BatchRunState,
     is_retryable_scraper_error,
     mark_item_failed,
     reset_scraper,
@@ -18,6 +19,11 @@ from cs2_analytics.storage.player_storage import store_players
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger("map_controller")
+
+ROTATE_EVERY = 8
+INTER_MAP_DELAY_SECONDS = 0.75
+RETRY_BACKOFF_SECONDS = 3.0
+MAX_ATTEMPTS = 3
 
 
 class MapController:
@@ -41,102 +47,133 @@ class MapController:
         selected = self.state.fetch_with_match_context(batch_size)
         logger.info("%d pending maps selected from ingestion state", len(selected))
 
-        rotate_every = 8
-        inter_map_delay_seconds = 0.75
-        retry_backoff_seconds = 3.0
-        processed_since_reset = 0
-        succeeded = 0
-        failed = 0
-        retries = 0
-
-        scraper = self.scraper
+        run_state: BatchRunState[MapScraper] = BatchRunState(scraper=self.scraper)
         try:
             for map_id, map_url, match_id, map_order in selected:
-                if processed_since_reset >= rotate_every:
-                    logger.info(
-                        "Rotating map scraper session after %d processed maps",
-                        processed_since_reset,
-                    )
-                    scraper = self._reset_scraper(scraper)
-                    processed_since_reset = 0
-
+                self._rotate_scraper_if_due(run_state)
                 self.state.mark_as_processing(map_id)
-                max_attempts = 3
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        result = self.stage_service.process_item(
-                            map_id,
-                            map_url,
-                            scraper=scraper,
-                            match_id=match_id,
-                            map_order=map_order,
-                        )
-                        if result.succeeded:
-                            succeeded += 1
-                            logger.info("Stored map: %s", map_id)
-                        else:
-                            failed += 1
-                            logger.warning(
-                                "Map %s was not processed: %s",
-                                map_id,
-                                result.message,
-                            )
-
-                        processed_since_reset += 1
-                        time.sleep(inter_map_delay_seconds)
-                        break
-
-                    except Exception as e:
-                        should_retry = (
-                            attempt < max_attempts
-                            and self._is_recoverable_scraper_error(e)
-                        )
-
-                        if should_retry:
-                            retries += 1
-                            logger.warning(
-                                "Retryable scraper error for map %s (attempt %d/%d): %s",
-                                map_id,
-                                attempt,
-                                max_attempts,
-                                e,
-                            )
-                            time.sleep(retry_backoff_seconds * attempt)
-                            scraper = self._reset_scraper(scraper)
-                            continue
-
-                        if (
-                            attempt == max_attempts
-                            and self._is_recoverable_scraper_error(e)
-                        ):
-                            logger.error(
-                                "Exhausted retries for map %s after %d attempts; marking failed and continuing.",
-                                map_id,
-                                max_attempts,
-                            )
-                        mark_item_failed(
-                            self.state,
-                            map_id,
-                            e,
-                            logger=logger,
-                            log_message="Error processing map %s on attempt %d/%d: %s",
-                            attempt=attempt,
-                            max_attempts=max_attempts,
-                        )
-                        failed += 1
-                        break
+                self._process_map_with_retries(
+                    map_id, map_url, match_id, map_order, run_state
+                )
         finally:
             with suppress(Exception):
-                scraper.close()
+                run_state.scraper.close()
 
         logger.info(
             "MapController summary: selected=%d succeeded=%d failed=%d retries=%d",
             len(selected),
-            succeeded,
-            failed,
-            retries,
+            run_state.succeeded,
+            run_state.failed,
+            run_state.retries,
         )
         logger.info("MapController complete.")
+
+    def _rotate_scraper_if_due(self, run_state: BatchRunState[MapScraper]) -> None:
+        """Swaps in a fresh scraper session after enough processed maps."""
+        if run_state.processed_since_reset < ROTATE_EVERY:
+            return
+        logger.info(
+            "Rotating map scraper session after %d processed maps",
+            run_state.processed_since_reset,
+        )
+        run_state.scraper = self._reset_scraper(run_state.scraper)
+        run_state.processed_since_reset = 0
+
+    def _process_map_with_retries(
+        self,
+        map_id: int,
+        map_url: str,
+        match_id: int | None,
+        map_order: int | None,
+        run_state: BatchRunState[MapScraper],
+    ) -> None:
+        """Runs one map through the stage service, retrying transient errors."""
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                self._record_stage_outcome(
+                    map_id, map_url, match_id, map_order, run_state
+                )
+                return
+            except Exception as e:
+                if attempt < MAX_ATTEMPTS and self._is_recoverable_scraper_error(e):
+                    self._recover_from_retryable_error(map_id, attempt, e, run_state)
+                else:
+                    self._mark_terminal_failure(map_id, attempt, e, run_state)
+                    return
+
+    def _record_stage_outcome(
+        self,
+        map_id: int,
+        map_url: str,
+        match_id: int | None,
+        map_order: int | None,
+        run_state: BatchRunState[MapScraper],
+    ) -> None:
+        """Processes one map and applies success/pacing bookkeeping."""
+        result = self.stage_service.process_item(
+            map_id,
+            map_url,
+            scraper=run_state.scraper,
+            match_id=match_id,
+            map_order=map_order,
+        )
+        if result.succeeded:
+            run_state.succeeded += 1
+            logger.info("Stored map: %s", map_id)
+        else:
+            run_state.failed += 1
+            logger.warning(
+                "Map %s was not processed: %s",
+                map_id,
+                result.message,
+            )
+
+        run_state.processed_since_reset += 1
+        time.sleep(INTER_MAP_DELAY_SECONDS)
+
+    def _recover_from_retryable_error(
+        self,
+        map_id: int,
+        attempt: int,
+        error: Exception,
+        run_state: BatchRunState[MapScraper],
+    ) -> None:
+        """Backs off and resets the scraper before the next attempt."""
+        run_state.retries += 1
+        logger.warning(
+            "Retryable scraper error for map %s (attempt %d/%d): %s",
+            map_id,
+            attempt,
+            MAX_ATTEMPTS,
+            error,
+        )
+        time.sleep(RETRY_BACKOFF_SECONDS * attempt)
+        run_state.scraper = self._reset_scraper(run_state.scraper)
+
+    def _mark_terminal_failure(
+        self,
+        map_id: int,
+        attempt: int,
+        error: Exception,
+        run_state: BatchRunState[MapScraper],
+    ) -> None:
+        """Marks the map failed after a non-retryable or exhausted error."""
+        if attempt == MAX_ATTEMPTS and self._is_recoverable_scraper_error(error):
+            logger.error(
+                "Exhausted retries for map %s after %d attempts; marking failed and continuing.",
+                map_id,
+                MAX_ATTEMPTS,
+            )
+        mark_item_failed(
+            self.state,
+            map_id,
+            error,
+            logger=logger,
+            log_message="Error processing map %s on attempt %d/%d: %s",
+            attempt=attempt,
+            max_attempts=MAX_ATTEMPTS,
+        )
+        run_state.failed += 1
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         return is_retryable_scraper_error(error)

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -4,6 +4,7 @@ import time
 from contextlib import suppress
 
 from cs2_analytics.controllers.retry_utils import (
+    BatchRunState,
     is_retryable_scraper_error,
     mark_item_failed,
     reset_scraper,
@@ -21,6 +22,13 @@ from cs2_analytics.storage.match_storage import store_matches
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger("match_controller")
+
+ROTATE_EVERY = 8
+INTER_MATCH_DELAY_SECONDS = 1.1
+RETRY_BACKOFF_SECONDS = 3.0
+MAX_ATTEMPTS = 3
+COOLDOWN_AFTER_CONSECUTIVE_ERRORS = 2
+COOLDOWN_SECONDS = 8.0
 
 
 class MatchController:
@@ -48,112 +56,129 @@ class MatchController:
         selected = self.match_state.fetch(limit=batch_size)
         logger.info("%d pending matches selected from ingestion state", len(selected))
 
-        rotate_every = 8
-        inter_match_delay_seconds = 1.1
-        retry_backoff_seconds = 3.0
-        processed_since_reset = 0
-        consecutive_recoverable_errors = 0
-        succeeded = 0
-        failed = 0
-        retries = 0
-
-        scraper = self.scraper
+        run_state: BatchRunState[MatchScraper] = BatchRunState(scraper=self.scraper)
         try:
             for match_id, match_url in selected:
-                if processed_since_reset >= rotate_every:
-                    logger.info(
-                        "Rotating scraper session after %d processed matches",
-                        processed_since_reset,
-                    )
-                    scraper = self._reset_scraper(scraper)
-                    processed_since_reset = 0
-
+                self._rotate_scraper_if_due(run_state)
                 self.match_state.mark_as_processing(match_id)
-                max_attempts = 3
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        result = self.stage_service.process_item(
-                            match_id, match_url, scraper=scraper
-                        )
-                        if result.succeeded:
-                            succeeded += 1
-                            logger.info("Stored match: %s", match_id)
-                        else:
-                            failed += 1
-                            logger.warning(
-                                "Match %s was not processed: %s",
-                                match_id,
-                                result.message,
-                            )
-
-                        consecutive_recoverable_errors = 0
-                        processed_since_reset += 1
-                        time.sleep(inter_match_delay_seconds)
-                        break
-
-                    except Exception as e:
-                        should_retry = (
-                            attempt < max_attempts
-                            and self._is_recoverable_scraper_error(e)
-                        )
-
-                        if should_retry:
-                            retries += 1
-                            consecutive_recoverable_errors += 1
-                            logger.warning(
-                                "Retryable scraper error for match %s (attempt %d/%d): %s",
-                                match_id,
-                                attempt,
-                                max_attempts,
-                                e,
-                            )
-
-                            if consecutive_recoverable_errors >= 2:
-                                logger.info(
-                                    "Applying cooldown after %d consecutive recoverable errors",
-                                    consecutive_recoverable_errors,
-                                )
-                                time.sleep(8.0)
-
-                            time.sleep(retry_backoff_seconds * attempt)
-                            scraper = self._reset_scraper(scraper)
-                            continue
-
-                        if (
-                            attempt == max_attempts
-                            and self._is_recoverable_scraper_error(e)
-                        ):
-                            logger.error(
-                                "Exhausted retries for match %s after %d attempts; marking failed and continuing.",
-                                match_id,
-                                max_attempts,
-                            )
-                        mark_item_failed(
-                            self.match_state,
-                            match_id,
-                            e,
-                            logger=logger,
-                            log_message=(
-                                "Error processing match %s on attempt %d/%d: %s"
-                            ),
-                            attempt=attempt,
-                            max_attempts=max_attempts,
-                        )
-                        failed += 1
-                        consecutive_recoverable_errors = 0
-                        break
+                self._process_match_with_retries(match_id, match_url, run_state)
         finally:
             with suppress(Exception):
-                scraper.close()
+                run_state.scraper.close()
 
         logger.info(
             "MatchController summary: selected=%d succeeded=%d failed=%d retries=%d",
             len(selected),
-            succeeded,
-            failed,
-            retries,
+            run_state.succeeded,
+            run_state.failed,
+            run_state.retries,
         )
         logger.info("MatchController complete.")
+
+    def _rotate_scraper_if_due(self, run_state: BatchRunState[MatchScraper]) -> None:
+        """Swaps in a fresh scraper session after enough processed matches."""
+        if run_state.processed_since_reset < ROTATE_EVERY:
+            return
+        logger.info(
+            "Rotating scraper session after %d processed matches",
+            run_state.processed_since_reset,
+        )
+        run_state.scraper = self._reset_scraper(run_state.scraper)
+        run_state.processed_since_reset = 0
+
+    def _process_match_with_retries(
+        self, match_id: int, match_url: str, run_state: BatchRunState[MatchScraper]
+    ) -> None:
+        """Runs one match through the stage service, retrying transient errors."""
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                self._record_stage_outcome(match_id, match_url, run_state)
+                return
+            except Exception as e:
+                if attempt < MAX_ATTEMPTS and self._is_recoverable_scraper_error(e):
+                    self._recover_from_retryable_error(match_id, attempt, e, run_state)
+                else:
+                    self._mark_terminal_failure(match_id, attempt, e, run_state)
+                    return
+
+    def _record_stage_outcome(
+        self, match_id: int, match_url: str, run_state: BatchRunState[MatchScraper]
+    ) -> None:
+        """Processes one match and applies success/pacing bookkeeping."""
+        result = self.stage_service.process_item(
+            match_id, match_url, scraper=run_state.scraper
+        )
+        if result.succeeded:
+            run_state.succeeded += 1
+            logger.info("Stored match: %s", match_id)
+        else:
+            run_state.failed += 1
+            logger.warning(
+                "Match %s was not processed: %s",
+                match_id,
+                result.message,
+            )
+
+        run_state.consecutive_recoverable_errors = 0
+        run_state.processed_since_reset += 1
+        time.sleep(INTER_MATCH_DELAY_SECONDS)
+
+    def _recover_from_retryable_error(
+        self,
+        match_id: int,
+        attempt: int,
+        error: Exception,
+        run_state: BatchRunState[MatchScraper],
+    ) -> None:
+        """Backs off, cools down if errors cluster, and resets the scraper."""
+        run_state.retries += 1
+        run_state.consecutive_recoverable_errors += 1
+        logger.warning(
+            "Retryable scraper error for match %s (attempt %d/%d): %s",
+            match_id,
+            attempt,
+            MAX_ATTEMPTS,
+            error,
+        )
+
+        if (
+            run_state.consecutive_recoverable_errors
+            >= COOLDOWN_AFTER_CONSECUTIVE_ERRORS
+        ):
+            logger.info(
+                "Applying cooldown after %d consecutive recoverable errors",
+                run_state.consecutive_recoverable_errors,
+            )
+            time.sleep(COOLDOWN_SECONDS)
+
+        time.sleep(RETRY_BACKOFF_SECONDS * attempt)
+        run_state.scraper = self._reset_scraper(run_state.scraper)
+
+    def _mark_terminal_failure(
+        self,
+        match_id: int,
+        attempt: int,
+        error: Exception,
+        run_state: BatchRunState[MatchScraper],
+    ) -> None:
+        """Marks the match failed after a non-retryable or exhausted error."""
+        if attempt == MAX_ATTEMPTS and self._is_recoverable_scraper_error(error):
+            logger.error(
+                "Exhausted retries for match %s after %d attempts; marking failed and continuing.",
+                match_id,
+                MAX_ATTEMPTS,
+            )
+        mark_item_failed(
+            self.match_state,
+            match_id,
+            error,
+            logger=logger,
+            log_message=("Error processing match %s on attempt %d/%d: %s"),
+            attempt=attempt,
+            max_attempts=MAX_ATTEMPTS,
+        )
+        run_state.failed += 1
+        run_state.consecutive_recoverable_errors = 0
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         """Returns True for transient scraper failures worth retrying."""

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -1,6 +1,7 @@
 """Controller for scraping and recording match result links."""
 
 import time
+from dataclasses import dataclass
 
 from cs2_analytics.controllers.retry_utils import (
     is_retryable_scraper_error,
@@ -13,6 +14,19 @@ from cs2_analytics.stage_services import ResultsStageService
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger("results_controller")
+
+RETRY_BACKOFF_SECONDS = 3.0
+MAX_ATTEMPTS = 3
+
+
+@dataclass
+class _ResultsRunState:
+    """Tracks the active scraper and outcome counters for one results run."""
+
+    scraper: ResultsScraper
+    status: str = "failed"
+    retries: int = 0
+    terminal_failures: int = 0
 
 
 class ResultsController:
@@ -27,71 +41,86 @@ class ResultsController:
         """Scrapes result pages and records match URLs for downstream stages."""
         logger.info("Running ResultsController with max_matches=%d", max_matches)
 
-        max_attempts = 3
-        scraper = self.scraper
-        retries = 0
-        terminal_failures = 0
-        run_status = "failed"
-
+        run_state = _ResultsRunState(scraper=self.scraper)
         try:
-            for attempt in range(1, max_attempts + 1):
-                try:
-                    recorded = 0
-                    for batch in scraper.iter_match_batches(max_matches=max_matches):
-                        recorded += self.stage_service.record_batch(batch)
-                    run_status = "succeeded"
-                    logger.info("ResultsController complete. recorded=%d", recorded)
-                    return
-                except Exception as e:
-                    is_retryable = self._is_recoverable_scraper_error(e)
-                    should_retry = attempt < max_attempts and is_retryable
-
-                    if should_retry:
-                        retries += 1
-                        logger.warning(
-                            "Retryable results scraper error (attempt %d/%d): %s",
-                            attempt,
-                            max_attempts,
-                            e,
-                        )
-                        time.sleep(3.0 * attempt)
-                        scraper = self._reset_scraper(scraper)
-                        continue
-
-                    terminal_failures += 1
-                    if is_retryable:
-                        logger.error(
-                            "ResultsController exhausted retries after %d attempts; failing stage run.",
-                            max_attempts,
-                        )
-                        failure_message = (
-                            "Results stage failed after exhausting retries "
-                            f"({attempt}/{max_attempts} attempts)."
-                        )
-                    else:
-                        failure_message = (
-                            "Results stage failed on non-retryable error "
-                            f"at attempt {attempt}/{max_attempts}."
-                        )
-                    logger.exception(
-                        "ResultsController failed on attempt %d/%d: %s",
-                        attempt,
-                        max_attempts,
-                        e,
-                    )
-                    raise PipelineError(failure_message) from e
+            self._run_attempts(max_matches, run_state)
         finally:
-            try:
-                scraper.close()
-            except Exception as e:
-                logger.warning("Failed to close results scraper: %s", e)
+            self._close_scraper(run_state)
             logger.info(
                 "ResultsController summary: status=%s retries=%d terminal_failures=%d max_matches=%d",
-                run_status,
-                retries,
-                terminal_failures,
+                run_state.status,
+                run_state.retries,
+                run_state.terminal_failures,
                 max_matches,
             )
+
+    def _run_attempts(self, max_matches: int, run_state: _ResultsRunState) -> None:
+        """Attempts the results stage until it succeeds or retries are exhausted."""
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                recorded = self._record_discovered_batches(max_matches, run_state)
+                run_state.status = "succeeded"
+                logger.info("ResultsController complete. recorded=%d", recorded)
+                return
+            except Exception as e:
+                self._handle_attempt_failure(e, attempt, run_state)
+
+    def _record_discovered_batches(
+        self, max_matches: int, run_state: _ResultsRunState
+    ) -> int:
+        """Streams result pages and records each discovered match batch."""
+        recorded = 0
+        for batch in run_state.scraper.iter_match_batches(max_matches=max_matches):
+            recorded += self.stage_service.record_batch(batch)
+        return recorded
+
+    def _handle_attempt_failure(
+        self, error: Exception, attempt: int, run_state: _ResultsRunState
+    ) -> None:
+        """Backs off and resets for retryable errors; raises PipelineError otherwise."""
+        is_retryable = self._is_recoverable_scraper_error(error)
+
+        if attempt < MAX_ATTEMPTS and is_retryable:
+            run_state.retries += 1
+            logger.warning(
+                "Retryable results scraper error (attempt %d/%d): %s",
+                attempt,
+                MAX_ATTEMPTS,
+                error,
+            )
+            time.sleep(RETRY_BACKOFF_SECONDS * attempt)
+            run_state.scraper = self._reset_scraper(run_state.scraper)
+            return
+
+        run_state.terminal_failures += 1
+        if is_retryable:
+            logger.error(
+                "ResultsController exhausted retries after %d attempts; failing stage run.",
+                MAX_ATTEMPTS,
+            )
+            failure_message = (
+                "Results stage failed after exhausting retries "
+                f"({attempt}/{MAX_ATTEMPTS} attempts)."
+            )
+        else:
+            failure_message = (
+                "Results stage failed on non-retryable error "
+                f"at attempt {attempt}/{MAX_ATTEMPTS}."
+            )
+        logger.exception(
+            "ResultsController failed on attempt %d/%d: %s",
+            attempt,
+            MAX_ATTEMPTS,
+            error,
+        )
+        raise PipelineError(failure_message) from error
+
+    def _close_scraper(self, run_state: _ResultsRunState) -> None:
+        """Closes the active scraper, downgrading close failures to a warning."""
+        try:
+            run_state.scraper.close()
+        except Exception as e:
+            logger.warning("Failed to close results scraper: %s", e)
 
     def _is_recoverable_scraper_error(self, error: Exception) -> bool:
         return is_retryable_scraper_error(error)

--- a/cs2_analytics/controllers/retry_utils.py
+++ b/cs2_analytics/controllers/retry_utils.py
@@ -3,11 +3,21 @@
 import time
 from collections.abc import Callable
 from contextlib import suppress
-from typing import TypeVar
+from dataclasses import dataclass
 
 from cs2_analytics.exceptions import RetryableScrapeError
 
-ScraperT = TypeVar("ScraperT")
+
+@dataclass
+class BatchRunState[ScraperT]:
+    """Tracks the active scraper and outcome counters for one controller batch run."""
+
+    scraper: ScraperT
+    succeeded: int = 0
+    failed: int = 0
+    retries: int = 0
+    processed_since_reset: int = 0
+    consecutive_recoverable_errors: int = 0
 
 
 def is_retryable_scraper_error(error: Exception) -> bool:
@@ -15,7 +25,39 @@ def is_retryable_scraper_error(error: Exception) -> bool:
     return isinstance(error, RetryableScrapeError)
 
 
-def reset_scraper(
+def _close_before_reset(scraper, logger, close_warning_message: str) -> None:
+    """Closes the outgoing scraper, downgrading close failures to a warning."""
+    try:
+        scraper.close()
+    except Exception as e:
+        logger.warning(close_warning_message, e)
+
+
+def _build_scraper[ScraperT](
+    scraper_factory: Callable[[], ScraperT], startup_delay_seconds: float
+) -> ScraperT:
+    """Creates a scraper and waits out its session startup delay."""
+    new_scraper = scraper_factory()
+    time.sleep(startup_delay_seconds)
+    return new_scraper
+
+
+def _discard_unready_scraper(
+    new_scraper,
+    *,
+    logger,
+    not_ready_warning_message: str | None,
+    reset_attempt: int,
+    attempt_total: int,
+) -> None:
+    """Logs and closes a fresh scraper that failed its health check."""
+    if not_ready_warning_message:
+        logger.warning(not_ready_warning_message, reset_attempt, attempt_total)
+    with suppress(Exception):
+        new_scraper.close()
+
+
+def reset_scraper[ScraperT](
     scraper: ScraperT,
     scraper_factory: Callable[[], ScraperT],
     *,
@@ -31,27 +73,25 @@ def reset_scraper(
     fallback_delay_seconds: float | None = None,
 ) -> ScraperT:
     """Closes and recreates a scraper, optionally retrying until a health check passes."""
-    try:
-        scraper.close()
-    except Exception as e:
-        logger.warning(close_warning_message, e)
+    _close_before_reset(scraper, logger, close_warning_message)
 
     attempt_total = max(1, max_reset_attempts)
 
     for reset_attempt in range(1, attempt_total + 1):
-        new_scraper = scraper_factory()
-        time.sleep(startup_delay_seconds)
+        new_scraper = _build_scraper(scraper_factory, startup_delay_seconds)
 
         if health_check is None or health_check(new_scraper):
             if recovery_success_message and reset_attempt > 1:
                 logger.info(recovery_success_message, reset_attempt)
             return new_scraper
 
-        if not_ready_warning_message:
-            logger.warning(not_ready_warning_message, reset_attempt, attempt_total)
-
-        with suppress(Exception):
-            new_scraper.close()
+        _discard_unready_scraper(
+            new_scraper,
+            logger=logger,
+            not_ready_warning_message=not_ready_warning_message,
+            reset_attempt=reset_attempt,
+            attempt_total=attempt_total,
+        )
 
         if reset_attempt < attempt_total:
             time.sleep(between_attempt_delay_seconds)
@@ -59,13 +99,12 @@ def reset_scraper(
     if fallback_warning_message:
         logger.warning(fallback_warning_message)
 
-    fallback_scraper = scraper_factory()
-    time.sleep(
+    return _build_scraper(
+        scraper_factory,
         startup_delay_seconds
         if fallback_delay_seconds is None
-        else fallback_delay_seconds
+        else fallback_delay_seconds,
     )
-    return fallback_scraper
 
 
 def mark_item_failed(

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -767,7 +767,12 @@ should be addressed before the repo is considered v1.0.
       `executemany` batch instead of per-row `execute`, matching the
       `record_many` pattern (#78)
 - [ ] Widen mypy CI target to cover `cs2_analytics` ingestion core, not just the API layer
-- [ ] Break up overlong controller and utility functions (`match_controller.py`, `map_controller.py`, `results_controller.py`, `retry_utils.py`)
+- [x] Break up overlong controller and utility functions
+      (`match_controller.py`, `map_controller.py`, `results_controller.py`,
+      `retry_utils.py`) — controller run loops now delegate to cohesive
+      rotate/retry/outcome helpers over a shared `BatchRunState`, and
+      `reset_scraper` gained close/build/discard helpers; behavior unchanged
+      (#80)
 - [x] Move non-working demo subsystem to a `feature/demo-parsing` branch; add
       deferral note to README — demo link discovery and `demo_ingestion_state`
       remain on `main` (#81, ADR-0014)


### PR DESCRIPTION
## Summary

Closes #80.

Decomposes the four flagged overlong functions into cohesive named helpers, preserving all existing behavior:

- **`retry_utils.py`**: adds `BatchRunState`, a small mutable holder for the active scraper and per-run counters, so helpers can thread the current scraper and stats explicitly instead of via a deeply nested closure. `reset_scraper` now delegates to `_close_before_reset`, `_build_scraper`, and `_discard_unready_scraper`. Type parameters use PEP 695 syntax, which also clears the pre-existing ruff `UP047` finding.
- **`match_controller.py` / `map_controller.py`**: `run()` now iterates the batch and delegates to `_rotate_scraper_if_due`, `_process_*_with_retries`, `_record_stage_outcome`, `_recover_from_retryable_error`, and `_mark_terminal_failure`.
- **`results_controller.py`**: `run()` delegates to `_run_attempts`, `_record_discovered_batches`, `_handle_attempt_failure`, and `_close_scraper`, with the summary log kept in the `finally` block.
- Tunables that were function-locals (rotate cadence, delays, attempt caps, cooldown threshold) are now module-level constants with unchanged values.

## No behavior changes

Log messages and their ordering, counter arithmetic, retry/backoff/cooldown sequencing, exception chaining (`raise PipelineError ... from e`), scraper close semantics in `finally`, and the `_reset_scraper` signatures (monkeypatched by tests) are all preserved. The existing controller tests - which assert exact summary tuples, log strings, reset call counts, and scraper threading to the stage service - pass unchanged.

## Verification

- `python -m pytest` — 150 passed (no test modifications)
- `ruff check cs2_analytics/controllers/` clean under the full project ruleset (including the previously failing `UP047`)
- `ruff format --check` clean; `mypy` clean on `retry_utils.py`

## Documentation check

`docs/backlog.md` updated: the v1.0 Polish checklist item for breaking up overlong controller/utility functions is checked off with a completion note. Architecture docs unaffected - controller/stage-service boundaries and retry semantics are unchanged.
