### PR TITLE
Widen mypy CI target to the cs2_analytics ingestion core (#79)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: uv run ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501
 
       - name: Type check runtime code
-        run: uv run mypy api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip
+        run: uv run mypy cs2_analytics api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip
 
       - name: Run migrations
         run: uv run alembic -c cs2_analytics/alembic.ini upgrade head

--- a/cs2_analytics/alembic/env.py
+++ b/cs2_analytics/alembic/env.py
@@ -23,7 +23,8 @@ def _database_url() -> URL:
 
 
 def _redacted_database_url() -> str:
-    return _database_url().render_as_string(hide_password=True)
+    rendered: str = _database_url().render_as_string(hide_password=True)
+    return rendered
 
 
 def run_migrations_offline() -> None:

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -9,9 +9,10 @@ from cs2_analytics.utils.log_manager import get_logger
 logger = get_logger(__name__)
 
 
-class BaseIngestionState:
+class BaseIngestionState[IdT: (int, str)]:
     """
     Generic base class for ingestion state tables.
+    IdT is the source-id type for the table (int for match/map, str for demo).
     Subclasses must define:
     - table_name: the DB table to use
     - id_field: the primary key field
@@ -35,7 +36,7 @@ class BaseIngestionState:
         """Return the shared database instance when an operation needs it."""
         return get_db()
 
-    def fetch(self, limit: int = 25) -> list[tuple[int | str, str]]:
+    def fetch(self, limit: int = 25) -> list[tuple[IdT, str]]:
         """Fetches pending items from the ingestion state table."""
         query = f"""
         SELECT {self.id_field}, {self.url_field}
@@ -47,7 +48,8 @@ class BaseIngestionState:
         try:
             with self.db.get_cursor() as cur:
                 cur.execute(query, (limit,))
-                return cur.fetchall()
+                rows: list[tuple[IdT, str]] = cur.fetchall()
+                return rows
         except Exception as e:
             raise self.error_cls(
                 f"Failed to fetch pending items from {self.table_name}."
@@ -55,7 +57,7 @@ class BaseIngestionState:
 
     def queue(
         self,
-        id_value: int | str,
+        id_value: IdT,
         url: str,
         source: str = "unknown",
         priority: int = 0,
@@ -98,7 +100,7 @@ class BaseIngestionState:
 
     def record_many(
         self,
-        items: list[tuple[int | str, str]],
+        items: list[tuple[IdT, str]],
         source: str = "unknown",
         priority: int = 0,
     ) -> None:

--- a/cs2_analytics/ingestion_state/demo_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/demo_ingestion_state.py
@@ -4,7 +4,7 @@ from cs2_analytics.exceptions import DemoIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
-class DemoIngestionState(BaseIngestionState):
+class DemoIngestionState(BaseIngestionState[str]):
     """Ingestion-state manager for demo discovery and processing."""
 
     def __init__(self) -> None:

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -6,7 +6,7 @@ from cs2_analytics.exceptions import MapIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
-class MapIngestionState(BaseIngestionState):
+class MapIngestionState(BaseIngestionState[int]):
     """Ingestion-state manager for map discovery and processing."""
 
     def __init__(self) -> None:
@@ -31,7 +31,8 @@ class MapIngestionState(BaseIngestionState):
         try:
             with self.db.get_cursor() as cur:
                 cur.execute(query, (limit,))
-                return cur.fetchall()
+                rows: list[tuple[int, str, int | None, int | None]] = cur.fetchall()
+                return rows
         except Exception as e:
             raise self.error_cls(
                 "Failed to fetch pending map items with match context."
@@ -43,9 +44,10 @@ class MapIngestionState(BaseIngestionState):
         url: str,
         source: str = "unknown",
         priority: int = 0,
+        cur=None,
+        *,
         match_id: int | None = None,
         map_order: int | None = None,
-        cur=None,
     ) -> None:
         """Add or refresh a map ingestion row with parent match context.
 

--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -4,7 +4,7 @@ from cs2_analytics.exceptions import MatchIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 
-class MatchIngestionState(BaseIngestionState):
+class MatchIngestionState(BaseIngestionState[int]):
     """Ingestion-state manager for match discovery and processing."""
 
     def __init__(self) -> None:

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -234,8 +234,7 @@ class MapParser:
         player_url = self._extract_player_url(name_tag)
         if not player_url:
             raise MapParseError(
-                f"Failed to extract player URL for {player_name!r} "
-                "from map stats page."
+                f"Failed to extract player URL for {player_name!r} from map stats page."
             )
         player_id = self._extract_numeric_id(player_url)
         return player_name, player_url, player_id
@@ -538,6 +537,7 @@ class MapParser:
 
     def _extract_player_name(self, cols, name_tag) -> str:
         """Extracts a non-empty player name from the first stats cell."""
+        player_name: str
         if name_tag:
             player_name = name_tag.get_text(strip=True)
             if player_name:

--- a/cs2_analytics/parsers/match_parser.py
+++ b/cs2_analytics/parsers/match_parser.py
@@ -2,12 +2,27 @@
 
 import datetime as dt
 import re
+from typing import TypedDict
 
 from cs2_analytics.exceptions import MatchParseError
 from cs2_analytics.models.match import Match
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
+
+
+class _MatchMetadata(TypedDict):
+    """Core match fields extracted from a match page."""
+
+    team1: str
+    team2: str
+    score1: int
+    score2: int
+    winner: str
+    event: str
+    match_type: str
+    forfeit: bool
+    match_date: str
 
 
 class MatchParser:
@@ -51,7 +66,7 @@ class MatchParser:
         demo_links = self._extract_demo_links(soup)
         return map_links, demo_links
 
-    def _extract_match_metadata(self, soup) -> dict[str, str | int | bool]:
+    def _extract_match_metadata(self, soup) -> _MatchMetadata:
         """Extracts the core match fields needed to build a Match model."""
         team1, team2 = self._extract_teams(soup)
         logger.debug("Team1: %s Team2: %s", team1, team2)
@@ -191,7 +206,7 @@ class MatchParser:
         """Extracts the event name for the match."""
         event_tag = soup.find("div", class_="event text-ellipsis")
         if event_tag:
-            event_name = event_tag.text.strip()
+            event_name: str = event_tag.text.strip()
             if event_name:
                 return event_name
         raise MatchParseError("Failed to extract event name from match page.")
@@ -228,7 +243,7 @@ class MatchParser:
         map_name_tag = soup.find("div", class_="mapname")
         if not map_name_tag:
             raise MatchParseError("Failed to extract forfeit status from match page.")
-        map_name = map_name_tag.get_text(strip=True)
+        map_name: str = map_name_tag.get_text(strip=True)
         if not map_name:
             raise MatchParseError("Failed to extract forfeit status from match page.")
         return map_name.lower() == "default"

--- a/cs2_analytics/pipeline/__init__.py
+++ b/cs2_analytics/pipeline/__init__.py
@@ -1,9 +1,5 @@
 """Pipeline module for orchestrating the CS2 analytics workflow."""
 
-try:
-    from .cs2_pipeline import CS2AnalyticsPipeline
+from cs2_analytics.pipeline.cs2_pipeline import CS2AnalyticsPipeline
 
-    __all__ = ["CS2AnalyticsPipeline"]
-except ImportError as e:
-    print(f"❌ Error importing pipeline module: {e}")
-    CS2AnalyticsPipeline = None
+__all__ = ["CS2AnalyticsPipeline"]

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -100,7 +100,7 @@ class ResultsScraper:
         except Exception as e:
             raise SessionScrapeError(f"Failed to fetch results page: {url}") from e
 
-        matches = []
+        matches: list[str] = []
         stop_scraping = False
 
         for section in soup.find_all("div", class_="results-sublist"):

--- a/cs2_analytics/storage/database.py
+++ b/cs2_analytics/storage/database.py
@@ -46,9 +46,10 @@ class Database:
 
     def __init__(self):
         """Initialize the database connection pool."""
-        self.pool = _initialize_db_pool()
-        if self.pool is None:
+        pool = _initialize_db_pool()
+        if pool is None:
             raise DatabaseConnectionError("Database connection pool is not available.")
+        self.pool = pool
 
     def get_connection(self):
         """Retrieves a database connection from the pool."""

--- a/cs2_analytics/storage/initialize_db.py
+++ b/cs2_analytics/storage/initialize_db.py
@@ -31,7 +31,7 @@ TABLES_TO_WIPE = (
 )
 
 
-def _connection_kwargs(dbname: str) -> dict[str, str]:
+def _connection_kwargs(dbname: str) -> dict[str, str | int]:
     return {
         "dbname": dbname,
         "user": DB_USER,
@@ -89,9 +89,11 @@ def wipe_database() -> None:
     )
 
     try:
-        with psycopg2.connect(**_connection_kwargs(DB_NAME)) as conn:
-            with conn.cursor() as cur:
-                cur.execute(drop_sql)
+        with (
+            psycopg2.connect(**_connection_kwargs(DB_NAME)) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(drop_sql)
         logger.info("Database tables wiped successfully.")
     except Exception as e:
         raise DatabaseOperationError("Failed to wipe database tables.") from e

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -769,7 +769,11 @@ should be addressed before the repo is considered v1.0.
       `map_storage.py`, `player_storage.py`) — each store call now issues one
       `executemany` batch instead of per-row `execute`, matching the
       `record_many` pattern (#78)
-- [ ] Widen mypy CI target to cover `cs2_analytics` ingestion core, not just the API layer
+- [x] Widen mypy CI target to cover `cs2_analytics` ingestion core, not just
+      the API layer — CI now type-checks `cs2_analytics`; the errors that
+      surfaced were fixed with real annotations (generic
+      `BaseIngestionState[IdT]`, a `_MatchMetadata` TypedDict, typed locals)
+      rather than suppressions (#79)
 - [x] Break up overlong controller and utility functions
       (`match_controller.py`, `map_controller.py`, `results_controller.py`,
       `retry_utils.py`) — controller run loops now delegate to cohesive


### PR DESCRIPTION
## Summary

Closes #79. **Contains a CI change - flagging for human review per the repo policy.**

Extends the CI mypy target from the API layer and entrypoints to also cover the `cs2_analytics` ingestion core (48 additional source files, 58 total). The 17 errors that surfaced were all fixed with real annotations - zero suppressions were needed.

## Fixes for what surfaced

- **`BaseIngestionState` is now generic over the source-id type** (`BaseIngestionState[IdT: (int, str)]`): `MatchIngestionState`/`MapIngestionState` bind `int`, `DemoIngestionState` binds `str`. `fetch()`, `queue()`, and `record_many()` get precise per-table types, which also resolves the match-controller arg-type error at its root. Typing only - generics are erased at runtime.
- **Real LSP fix in `MapIngestionState.queue`**: `cur` stays in the base class's positional slot and `match_id`/`map_order` become keyword-only. Previously a base-typed call passing `cur` as the 5th positional argument would have bound it to `match_id`. The only call site (`match_stage_service.py`) already passes these as keywords.
- **`_MatchMetadata` TypedDict** for `MatchParser._extract_match_metadata`, so the `**metadata` spread into `_build_match` type-checks instead of collapsing to `str | int | bool`.
- **Typed locals at untyped-library boundaries** (bs4, psycopg2, sqlalchemy under `--follow-imports=skip`): parsers, results scraper, ingestion-state fetches, alembic `env.py`.
- **`Database.__init__`** narrows the pool to non-None before assigning the attribute.
- **`_connection_kwargs`** declares `dict[str, str | int]` (`DB_PORT` is an int); the adjacent pre-existing SIM117 nested-`with` lint finding is folded into one `with` statement.
- **`cs2_analytics/pipeline/__init__.py`** drops its `ImportError`-to-`None` fallback for a plain re-export. The fallback (a) assigned `None` to a type, (b) used `print` instead of logging, and (c) only deferred failure to a confusing `'NoneType' is not callable` - counter to the fail-loud direction from #103. `main.py` imports the submodule directly and is unaffected.

## Verification

- `mypy cs2_analytics api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip` — no issues in 58 files (the exact widened CI command)
- `python -m pytest` — 150 passed
- `ruff check` clean under both the CI E,F target and the full project ruleset; `ruff format --check` clean
- `import cs2_analytics.pipeline` smoke-checked

## Documentation check

`docs/backlog.md` updated: the v1.0 Polish checklist item for widening the mypy CI target is checked off with a completion note. CI behavior change is the subject of this PR itself; no other doc surfaces (setup, API, schema, architecture boundaries) are affected.
