### PR TITLE
Migrate ingestion-state status enums to domain-oriented values (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,14 +319,17 @@ hard to reason about.
 ### Ingestion state over work queues
 
 Discovered matches, maps, and demos live in PostgreSQL-backed
-ingestion-state tables (`pending`, `processing`, `processed`, `failed`,
-`skipped`) rather than a disposable work queue. Rows are keyed by source ID,
-so rediscovery refreshes existing rows instead of duplicating work, and a
-rerun after a crash resumes from state instead of starting over. The
-`skipped` versus `failed` distinction is deliberate: `skipped` records an
-intentional decision not to process (for example a forfeited match with no
-stats), while `failed` means processing was attempted and exhausted its
-retries. Collapsing the two would make failure metrics lie. The tradeoff is
+ingestion-state tables (`discovered`, `processing`, `processed`, `failed`,
+`skipped`, `dead`, `partial`) rather than a disposable work queue. Rows are
+keyed by source ID, so rediscovery refreshes existing rows instead of
+duplicating work, and a rerun after a crash resumes from state instead of
+starting over. The `skipped` versus `failed` distinction is deliberate:
+`skipped` records an intentional decision not to process (for example a
+forfeited match with no stats), while `failed` means a processing attempt
+went wrong, and `dead` marks rows whose retries are exhausted so claim
+queries can exclude them without counting failures. `partial` is reserved
+for matches processed while some of their maps never reached a terminal
+state. Collapsing these would make failure metrics lie. The tradeoff is
 more lifecycle discipline than a queue requires — every outcome must be
 recorded explicitly — in exchange for an ingestion run that is resumable,
 idempotent, and observable.

--- a/cs2_analytics/alembic/versions/20260716_0002_migrate_ingestion_status_enums.py
+++ b/cs2_analytics/alembic/versions/20260716_0002_migrate_ingestion_status_enums.py
@@ -1,0 +1,77 @@
+"""Migrate ingestion-state status enums.
+
+Rename `pending` to `discovered` and add `dead` and `partial` as terminal
+states across all three ingestion-state tables (issue #85).
+
+Revision ID: 20260716_0002
+Revises: 20260521_0001
+Create Date: 2026-07-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260716_0002"
+down_revision: str | None = "20260521_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INGESTION_STATE_TABLES = (
+    "match_ingestion_state",
+    "map_ingestion_state",
+    "demo_ingestion_state",
+)
+
+OLD_STATUS_CHECK = (
+    "status IN ('pending', 'processing', 'processed', 'failed', 'skipped')"
+)
+NEW_STATUS_CHECK = (
+    "status IN ('discovered', 'processing', 'processed', 'failed', "
+    "'skipped', 'dead', 'partial')"
+)
+
+
+def upgrade() -> None:
+    for table_name in INGESTION_STATE_TABLES:
+        # Drop the old constraint before rewriting rows: the old value set
+        # does not include 'discovered', so the UPDATE must run unconstrained.
+        op.drop_constraint(f"{table_name}_status_check", table_name, type_="check")
+        op.execute(
+            f"UPDATE {table_name} SET status = 'discovered' "
+            "WHERE status = 'pending'"
+        )
+        op.create_check_constraint(
+            f"{table_name}_status_check", table_name, NEW_STATUS_CHECK
+        )
+        op.alter_column(
+            table_name,
+            "status",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+            server_default=sa.text("'discovered'"),
+        )
+
+
+def downgrade() -> None:
+    for table_name in INGESTION_STATE_TABLES:
+        op.drop_constraint(f"{table_name}_status_check", table_name, type_="check")
+        op.execute(
+            f"UPDATE {table_name} SET status = 'failed' "
+            "WHERE status IN ('dead', 'partial')"
+        )
+        op.execute(
+            f"UPDATE {table_name} SET status = 'pending' "
+            "WHERE status = 'discovered'"
+        )
+        op.create_check_constraint(
+            f"{table_name}_status_check", table_name, OLD_STATUS_CHECK
+        )
+        op.alter_column(
+            table_name,
+            "status",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+            server_default=sa.text("'pending'"),
+        )

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -37,11 +37,11 @@ class BaseIngestionState[IdT: (int, str)]:
         return get_db()
 
     def fetch(self, limit: int = 25) -> list[tuple[IdT, str]]:
-        """Fetches pending items from the ingestion state table."""
+        """Fetches discovered items from the ingestion state table."""
         query = f"""
         SELECT {self.id_field}, {self.url_field}
         FROM {self.table_name}
-        WHERE status = 'pending'
+        WHERE status = 'discovered'
         ORDER BY priority DESC, first_seen_at ASC
         LIMIT %s;
         """
@@ -52,7 +52,7 @@ class BaseIngestionState[IdT: (int, str)]:
                 return rows
         except Exception as e:
             raise self.error_cls(
-                f"Failed to fetch pending items from {self.table_name}."
+                f"Failed to fetch discovered items from {self.table_name}."
             ) from e
 
     def queue(
@@ -75,7 +75,7 @@ class BaseIngestionState[IdT: (int, str)]:
             {self.id_field}, {self.url_field}, status, source, priority,
             first_seen_at, last_seen_at, last_updated_at
         )
-        VALUES (%s, %s, 'pending', %s, %s, %s, %s, %s)
+        VALUES (%s, %s, 'discovered', %s, %s, %s, %s, %s)
         ON CONFLICT ({self.id_field}) DO UPDATE
         SET {self.url_field} = EXCLUDED.{self.url_field},
             source = EXCLUDED.source,
@@ -113,7 +113,7 @@ class BaseIngestionState[IdT: (int, str)]:
             {self.id_field}, {self.url_field}, status, source, priority,
             first_seen_at, last_seen_at, last_updated_at
         )
-        VALUES (%s, %s, 'pending', %s, %s, %s, %s, %s)
+        VALUES (%s, %s, 'discovered', %s, %s, %s, %s, %s)
         ON CONFLICT ({self.id_field}) DO UPDATE
         SET {self.url_field} = EXCLUDED.{self.url_field},
             source = EXCLUDED.source,
@@ -204,6 +204,28 @@ class BaseIngestionState[IdT: (int, str)]:
         except Exception as e:
             raise self.error_cls(
                 f"Failed to mark item as failed in {self.table_name}."
+            ) from e
+
+    def mark_as_dead(self, id_value: int | str, reason: str = "unknown") -> None:
+        """Marks the item as dead after retry attempts are exhausted.
+
+        Dead rows are terminal and excluded from the work queue without
+        requiring claim queries to filter on failure_count.
+        """
+        now = dt.datetime.now()
+        query = f"""
+        UPDATE {self.table_name}
+        SET status = 'dead',
+            last_updated_at = %s,
+            last_error_message = %s
+        WHERE {self.id_field} = %s;
+        """
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(query, (now, reason, id_value))
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to mark item as dead in {self.table_name}."
             ) from e
 
     def mark_as_skipped(self, id_value: int | str, reason: str = "unknown") -> None:

--- a/cs2_analytics/ingestion_state/map_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/map_ingestion_state.py
@@ -20,11 +20,11 @@ class MapIngestionState(BaseIngestionState[int]):
     def fetch_with_match_context(
         self, limit: int = 25
     ) -> list[tuple[int, str, int | None, int | None]]:
-        """Fetch pending map rows with parent match and map-order context."""
+        """Fetch discovered map rows with parent match and map-order context."""
         query = """
         SELECT map_id, map_url, match_id, map_order
         FROM map_ingestion_state
-        WHERE status = 'pending'
+        WHERE status = 'discovered'
         ORDER BY priority DESC, first_seen_at ASC
         LIMIT %s;
         """
@@ -35,7 +35,7 @@ class MapIngestionState(BaseIngestionState[int]):
                 return rows
         except Exception as e:
             raise self.error_cls(
-                "Failed to fetch pending map items with match context."
+                "Failed to fetch discovered map items with match context."
             ) from e
 
     def queue(
@@ -61,7 +61,7 @@ class MapIngestionState(BaseIngestionState[int]):
             map_id, map_url, match_id, map_order, status, source, priority,
             first_seen_at, last_seen_at, last_updated_at
         )
-        VALUES (%s, %s, %s, %s, 'pending', %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, 'discovered', %s, %s, %s, %s, %s)
         ON CONFLICT (map_id) DO UPDATE
         SET map_url = EXCLUDED.map_url,
             match_id = COALESCE(EXCLUDED.match_id, map_ingestion_state.match_id),

--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -1,5 +1,7 @@
 """Match ingestion state manager."""
 
+import datetime as dt
+
 from cs2_analytics.exceptions import MatchIngestionStateError
 from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
@@ -14,3 +16,24 @@ class MatchIngestionState(BaseIngestionState[int]):
             url_field="match_url",
             error_cls=MatchIngestionStateError,
         )
+
+    def mark_as_partial(self, id_value: int) -> None:
+        """Marks the match as processed with maps still in non-terminal states.
+
+        Reserved for the match-complete processing unit: a match is partial
+        when it was processed but not all of its maps reached a terminal
+        state.
+        """
+        now = dt.datetime.now()
+        query = """
+        UPDATE match_ingestion_state
+        SET status = 'partial', last_updated_at = %s
+        WHERE match_id = %s;
+        """
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(query, (now, id_value))
+        except Exception as e:
+            raise self.error_cls(
+                "Failed to mark item as partial in match_ingestion_state."
+            ) from e

--- a/cs2_analytics/storage/schema.sql
+++ b/cs2_analytics/storage/schema.sql
@@ -138,8 +138,11 @@ CREATE TABLE IF NOT EXISTS match_ingestion_state (
     match_id INT PRIMARY KEY,
     match_url TEXT NOT NULL,
     status TEXT CHECK (
-        status IN ('pending', 'processing', 'processed', 'failed', 'skipped')
-    ) NOT NULL DEFAULT 'pending',
+        status IN (
+            'discovered', 'processing', 'processed', 'failed', 'skipped',
+            'dead', 'partial'
+        )
+    ) NOT NULL DEFAULT 'discovered',
     first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_attempted_at TIMESTAMP,
@@ -163,8 +166,11 @@ CREATE TABLE IF NOT EXISTS map_ingestion_state (
         AND 5
     ),
     status TEXT CHECK (
-        status IN ('pending', 'processing', 'processed', 'failed', 'skipped')
-    ) NOT NULL DEFAULT 'pending',
+        status IN (
+            'discovered', 'processing', 'processed', 'failed', 'skipped',
+            'dead', 'partial'
+        )
+    ) NOT NULL DEFAULT 'discovered',
     first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_attempted_at TIMESTAMP,
@@ -182,8 +188,11 @@ CREATE TABLE IF NOT EXISTS demo_ingestion_state (
     demo_id TEXT PRIMARY KEY,
     demo_url TEXT NOT NULL,
     status TEXT CHECK (
-        status IN ('pending', 'processing', 'processed', 'failed', 'skipped')
-    ) NOT NULL DEFAULT 'pending',
+        status IN (
+            'discovered', 'processing', 'processed', 'failed', 'skipped',
+            'dead', 'partial'
+        )
+    ) NOT NULL DEFAULT 'discovered',
     first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_attempted_at TIMESTAMP,

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -206,7 +206,7 @@ stage-service and dbt-readiness cleanup.
 
 ### Completed lifecycle-state cleanup
 
-- Status values are based on lifecycle semantics: `pending`, `processing`, `processed`, `failed`, and `skipped`
+- Status values are based on lifecycle semantics: `discovered`, `processing`, `processed`, `failed`, `skipped`, `dead`, and `partial`
 - Ingestion-state tables use distinct lifecycle fields such as `first_seen_at`, `last_seen_at`, `last_attempted_at`, `last_processed_at`, and `last_failed_at`
 - Current table names are `match_ingestion_state`, `map_ingestion_state`, and `demo_ingestion_state`
 - Redundant fields such as `retry_count`, `run_id`, and `worker_id` are intentionally absent from these lifecycle tables

--- a/docs/ingestion_lifecycle.md
+++ b/docs/ingestion_lifecycle.md
@@ -57,15 +57,23 @@ pages:
 
 The same status model is used across match, map, and demo ingestion state:
 
-- `pending`: discovered and ready to be processed
+- `discovered`: discovered and ready to be processed
 - `processing`: actively being worked on
 - `processed`: fetched, parsed, and persisted successfully
 - `failed`: terminal failure under the current retry policy
 - `skipped`: intentionally not processed
+- `dead`: exceeded max retry attempts; excluded from the work queue without
+  filtering on `failure_count` in claim queries
+- `partial`: reserved for the match-complete processing unit; a match is
+  partial when it was processed but not all its maps reached a terminal state
 
-`pending` replaces queue-oriented language like `queued`.
+`discovered` replaces the earlier `pending`, which did not reflect the domain:
+rows are discovered matches/maps waiting to be processed, not generic pending
+work.
 `processed` replaces parser-specific language like `parsed`, because a
 successful stage includes fetch, parse, and persistence.
+Nothing writes `dead` or `partial` yet; that logic lands with the
+match-complete processing unit and retry exhaustion work.
 
 ## Shared Fields
 

--- a/tests/ingestion_state/test_ingestion_state_exceptions.py
+++ b/tests/ingestion_state/test_ingestion_state_exceptions.py
@@ -98,7 +98,7 @@ def test_match_ingestion_state_refreshes_existing_rows_on_rediscovery(
 
     assert cursor.execute_query is not None
     assert "match_ingestion_state" in cursor.execute_query
-    assert "'pending'" in cursor.execute_query
+    assert "'discovered'" in cursor.execute_query
     assert "first_seen_at" in cursor.execute_query
     assert "last_seen_at" in cursor.execute_query
     assert "ON CONFLICT (match_id) DO UPDATE" in cursor.execute_query
@@ -128,6 +128,39 @@ def test_match_ingestion_state_marks_failures_with_lifecycle_fields(
     assert "failure_count = COALESCE(failure_count, 0) + 1" in cursor.execute_query
     assert cursor.execute_values is not None
     assert cursor.execute_values[2:] == ("boom", 1)
+
+
+def test_match_ingestion_state_marks_dead_with_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+    state = MatchIngestionState()
+
+    state.mark_as_dead(1, "retries exhausted")
+
+    assert cursor.execute_query is not None
+    assert "status = 'dead'" in cursor.execute_query
+    assert "last_updated_at" in cursor.execute_query
+    assert "last_error_message" in cursor.execute_query
+    assert cursor.execute_values is not None
+    assert cursor.execute_values[1:] == ("retries exhausted", 1)
+
+
+def test_match_ingestion_state_marks_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+    state = MatchIngestionState()
+
+    state.mark_as_partial(1)
+
+    assert cursor.execute_query is not None
+    assert "status = 'partial'" in cursor.execute_query
+    assert "last_updated_at" in cursor.execute_query
+    assert cursor.execute_values is not None
+    assert cursor.execute_values[1:] == (1,)
 
 
 def test_map_ingestion_state_records_parent_match_context(

--- a/tests/storage/test_initialize_db.py
+++ b/tests/storage/test_initialize_db.py
@@ -333,11 +333,13 @@ def test_schema_defines_ingestion_state_tables() -> None:
         "last_updated_at",
     )
     required_status_values = (
-        "'pending'",
+        "'discovered'",
         "'processing'",
         "'processed'",
         "'failed'",
         "'skipped'",
+        "'dead'",
+        "'partial'",
     )
 
     for table_name in (


### PR DESCRIPTION
## Summary

Renames `pending` to `discovered` and adds `dead` and `partial` as new terminal states across all three ingestion-state tables, so match, map, and demo ingestion share one seven-value status vocabulary: `discovered`, `processing`, `processed`, `failed`, `skipped`, `dead`, `partial`.

`pending` did not reflect the domain (rows are discovered matches/maps waiting for processing), `dead` lets claim queries exclude retry-exhausted rows without filtering on `failure_count`, and `partial` is reserved for the upcoming match-complete processing unit.

## Related Issue

Closes #85

## Scope

- `cs2_analytics/alembic/versions/20260716_0002_migrate_ingestion_status_enums.py` - new migration: drop old status CHECK constraints, rewrite `pending` rows to `discovered`, add the new CHECK constraints, move `server_default` to `'discovered'`; downgrade reverses the data migration (`dead`/`partial` to `failed`, `discovered` to `pending`) and restores the old constraints and default
- `cs2_analytics/storage/schema.sql` - aligned CHECK constraints and defaults
- `cs2_analytics/ingestion_state/base_ingestion_state.py` - `pending` to `discovered` in fetch WHERE, queue VALUES, record_many VALUES; new `mark_as_dead()`
- `cs2_analytics/ingestion_state/map_ingestion_state.py` - `pending` to `discovered` in `fetch_with_match_context` and the map `queue` override
- `cs2_analytics/ingestion_state/match_ingestion_state.py` - new `mark_as_partial()`
- `tests/storage/test_initialize_db.py` - `required_status_values` updated to the new set
- `tests/ingestion_state/test_ingestion_state_exceptions.py` - `'pending'` assertion updated; new focused tests for `mark_as_dead()` and `mark_as_partial()`
- `docs/ingestion_lifecycle.md`, `docs/database_schema.md`, `README.md` - status vocabulary updated

## Out of Scope

- Changing the other status values (`processing`, `processed`, `failed`, `skipped`)
- The logic that writes `dead` or `partial` - comes with the match-complete processing unit and retry-exhaustion work
- Controller or stage-service changes
- Renaming the `idx_*_ingestion_state_pending` indexes (name only, semantics unchanged)

## Risk Level

Risk level: Medium

Reason: Schema change with a data migration. Ordering matters at deploy time: code currently running against the database still writes `status = 'pending'`, which the new CHECK constraint rejects. Apply the migration to the Render database together with rolling out this code, while no old-code scraper run is active.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Documentation: Updated

Reason: `docs/ingestion_lifecycle.md`, `docs/database_schema.md`, and the README's "Ingestion state over work queues" section documented the old status vocabulary; all now describe the new seven-value set, and the docs note that nothing writes `dead` or `partial` yet.

Backlog: Update not needed

Reason: The backlog has no checklist item for #85 and this change does not complete a roadmap phase, change phase status, or alter planned branch sequencing; it is part of the ongoing ingestion-baseline priority already described there.

## Verification

Commands run:

- `python -m pytest` (full suite)
- Against a throwaway local Postgres 16 Docker container (not the Render database): `alembic upgrade 20260521_0001`, seeded rows with `pending`/`failed` statuses, `alembic upgrade head`, constraint/default probes, `alembic downgrade -1`, re-`upgrade head`

Results:

- 152 passed
- Upgrade rewrote seeded `pending` rows to `discovered` in all three tables and left `failed` untouched; `dead` and `partial` inserts accepted; new rows default to `discovered`; `pending` insert rejected by `<table>_status_check`. Downgrade mapped `dead`/`partial` to `failed` and `discovered` to `pending`, restored the `pending` default, and rejected `discovered`. Re-upgrade to head ran cleanly.

## Review Notes

- The issue's migration sketch ran the UPDATE before dropping the constraint; the migration drops the constraint first because the old value set does not allow `discovered`, so the UPDATE would violate it.
- Constraint names rely on the Postgres auto-generated `<table>_status_check` naming (the initial migration created them unnamed); the container run confirmed the names resolve.
- Deploy ordering caveat under Risk Level: migrate the Render database at the same time this code ships.