### PR TITLE
Stamp last_processed_at when marking a match as partial

### DIFF
--- a/cs2_analytics/ingestion_state/match_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/match_ingestion_state.py
@@ -27,12 +27,12 @@ class MatchIngestionState(BaseIngestionState[int]):
         now = dt.datetime.now()
         query = """
         UPDATE match_ingestion_state
-        SET status = 'partial', last_updated_at = %s
+        SET status = 'partial', last_processed_at = %s, last_updated_at = %s
         WHERE match_id = %s;
         """
         try:
             with self.db.get_cursor() as cur:
-                cur.execute(query, (now, id_value))
+                cur.execute(query, (now, now, id_value))
         except Exception as e:
             raise self.error_cls(
                 "Failed to mark item as partial in match_ingestion_state."

--- a/tests/ingestion_state/test_ingestion_state_exceptions.py
+++ b/tests/ingestion_state/test_ingestion_state_exceptions.py
@@ -158,9 +158,10 @@ def test_match_ingestion_state_marks_partial(
 
     assert cursor.execute_query is not None
     assert "status = 'partial'" in cursor.execute_query
+    assert "last_processed_at" in cursor.execute_query
     assert "last_updated_at" in cursor.execute_query
     assert cursor.execute_values is not None
-    assert cursor.execute_values[1:] == (1,)
+    assert cursor.execute_values[2:] == (1,)
 
 
 def test_map_ingestion_state_records_parent_match_context(


### PR DESCRIPTION
## Summary

Follow-up to #117 (merged before human review). Post-merge review of the Copilot comments concluded one fix should be applied: `mark_as_partial()` now stamps `last_processed_at` alongside `last_updated_at`, mirroring `mark_as_processed()`. Since `partial` means the match itself was processed while some maps never reached a terminal state, leaving `last_processed_at` NULL would make lifecycle data claim the match was never processed.

The companion suggestion to stamp `last_failed_at` in `mark_as_dead()` was reviewed and deliberately not applied: `mark_as_failed()` already stamps `last_failed_at` on every failure, and `dead` is a classification applied after the final failure, not a failure event itself, so the field is already populated in the real flow.

## Related Issue

Follow-up to #117 / #85 (no standalone issue; addresses post-merge review comments).

## Scope

- `cs2_analytics/ingestion_state/match_ingestion_state.py` - `mark_as_partial()` sets `last_processed_at`
- `tests/ingestion_state/test_ingestion_state_exceptions.py` - test asserts `last_processed_at` and accounts for the extra timestamp parameter

## Out of Scope

- Changing `mark_as_dead()` (declined, see Summary)
- Any schema or migration changes - none needed; `last_processed_at` already exists on all ingestion-state tables

## Risk Level

Risk level: Low

Reason: One-line behavior change to a method nothing calls yet (callers land with the match-complete processing unit). No schema, controller, or stage-service changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Documentation: Update not needed

Reason: Internal refinement of an unused method's timestamp behavior; `docs/ingestion_lifecycle.md` already defines `last_processed_at` as "most recent successful processing completion", which this change now honors. No architecture, setup, schema, API, or workflow surface changed.

Backlog: Update not needed

Reason: No roadmap work completed, no phase or checklist status changed, no branch sequencing altered.

## Verification

Commands run:

- `python -m pytest` (full suite)

Results:

- 152 passed

## Review Notes

- This is the fix-forward remediation for #117 being merged before human review; the other three Copilot comments on #117 are answered inline there.