### PR TITLE
Add cs2a db commands wrapping Alembic migrations (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ environments should run the equivalent Alembic command during release startup:
 alembic -c cs2_analytics/alembic.ini upgrade head
 ```
 
+Day-to-day migration operations are also exposed through the CLI. Each
+command first prints the target database (name, host, and port) so it is
+obvious whether the environment points at a local or production database:
+
+```sh
+cs2a db current                  # show the database's current revision
+cs2a db upgrade                  # apply migrations up to head; confirms first
+cs2a db downgrade <revision>     # revert to a revision; confirms first
+```
+
+These wrap the same `alembic -c cs2_analytics/alembic.ini ...` commands with
+the same environment-driven connection settings.
+
 For an existing database that was already initialized from the current
 `schema.sql`, first confirm the live schema matches the initial Alembic
 migration, then mark it as migration-managed without recreating tables:

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -76,12 +76,22 @@ def process(
 
 
 def _alembic_config():
-    """Load the project's Alembic configuration for programmatic commands."""
+    """Load the project's Alembic configuration for programmatic commands.
+
+    alembic.ini declares script_location and prepend_sys_path relative to
+    the repository root, so both are overridden with absolute paths (as
+    initialize_db.run_migrations does) to keep `cs2a db` working from any
+    working directory.
+    """
     from pathlib import Path
 
     from alembic.config import Config
 
-    return Config(str(Path(__file__).resolve().parent / "alembic.ini"))
+    package_root = Path(__file__).resolve().parent
+    config = Config(str(package_root / "alembic.ini"))
+    config.set_main_option("script_location", str(package_root / "alembic"))
+    config.set_main_option("prepend_sys_path", str(package_root.parent))
+    return config
 
 
 def _echo_target_database() -> None:

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -22,6 +22,11 @@ ingest_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(ingest_app, name="ingest")
+db_app = typer.Typer(
+    help="Schema migration commands wrapping Alembic.",
+    no_args_is_help=True,
+)
+app.add_typer(db_app, name="db")
 
 
 class DiscoverMode(StrEnum):
@@ -68,6 +73,61 @@ def process(
 
     MatchController().run(batch_size=batch)
     MapController().run(batch_size=batch)
+
+
+def _alembic_config():
+    """Load the project's Alembic configuration for programmatic commands."""
+    from pathlib import Path
+
+    from alembic.config import Config
+
+    return Config(str(Path(__file__).resolve().parent / "alembic.ini"))
+
+
+def _echo_target_database() -> None:
+    """Print the migration target so the operator sees local versus production."""
+    from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PORT
+
+    typer.echo(f"Target database: {DB_NAME} on {DB_HOST}:{DB_PORT}")
+
+
+@db_app.command("upgrade")
+def db_upgrade(
+    revision: Annotated[
+        str,
+        typer.Argument(help="Target revision to migrate up to."),
+    ] = "head",
+) -> None:
+    """Apply schema migrations up to the given revision, after confirming."""
+    from alembic import command
+
+    _echo_target_database()
+    typer.confirm(f"Upgrade the database to revision '{revision}'?", abort=True)
+    command.upgrade(_alembic_config(), revision)
+
+
+@db_app.command("downgrade")
+def db_downgrade(
+    revision: Annotated[
+        str,
+        typer.Argument(help="Revision to revert the schema down to."),
+    ],
+) -> None:
+    """Revert schema migrations down to the given revision, after confirming."""
+    from alembic import command
+
+    _echo_target_database()
+    typer.confirm(f"Downgrade the database to revision '{revision}'?", abort=True)
+    command.downgrade(_alembic_config(), revision)
+
+
+@db_app.command("current")
+def db_current() -> None:
+    """Show the revision the database is currently at."""
+    from alembic import command
+
+    _echo_target_database()
+    command.current(_alembic_config())
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,11 +31,25 @@ def _patch_controller(monkeypatch, module_path, class_name, name, calls):
     monkeypatch.setattr(module, class_name, lambda: _RecordingController(name, calls))
 
 
+def _patch_alembic_command(monkeypatch, calls):
+    """Replace alembic.command functions with recorders capturing revisions."""
+    import alembic.command
+
+    def _recorder(name):
+        def _record(config, *args):
+            calls.append((name, args))
+
+        return _record
+
+    for command_name in ("upgrade", "downgrade", "current"):
+        monkeypatch.setattr(alembic.command, command_name, _recorder(command_name))
+
+
 def test_help_lists_all_commands() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    for command in ("ingest", "process", "status"):
+    for command in ("ingest", "process", "status", "db"):
         assert command in result.stdout
 
 
@@ -182,3 +196,77 @@ def test_status_exits_nonzero_when_database_is_unavailable(monkeypatch) -> None:
     result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 1
+
+
+def test_db_upgrade_defaults_to_head_and_prints_target(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "upgrade"], input="y\n")
+
+    assert result.exit_code == 0
+    assert calls == [("upgrade", ("head",))]
+    assert "Target database:" in result.stdout
+
+
+def test_db_upgrade_accepts_explicit_revision(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "upgrade", "20260521_0001"], input="y\n")
+
+    assert result.exit_code == 0
+    assert calls == [("upgrade", ("20260521_0001",))]
+
+
+def test_db_upgrade_aborts_without_confirmation(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "upgrade"], input="n\n")
+
+    assert result.exit_code != 0
+    assert calls == []
+    assert "Target database:" in result.stdout
+
+
+def test_db_downgrade_requires_a_revision(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "downgrade"])
+
+    assert result.exit_code != 0
+    assert calls == []
+
+
+def test_db_downgrade_aborts_without_confirmation(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "downgrade", "20260521_0001"], input="n\n")
+
+    assert result.exit_code != 0
+    assert calls == []
+    assert "Target database:" in result.stdout
+
+
+def test_db_downgrade_runs_after_confirmation(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "downgrade", "20260521_0001"], input="y\n")
+
+    assert result.exit_code == 0
+    assert calls == [("downgrade", ("20260521_0001",))]
+
+
+def test_db_current_reports_revision_and_prints_target(monkeypatch) -> None:
+    calls: list[tuple[str, tuple]] = []
+    _patch_alembic_command(monkeypatch, calls)
+
+    result = runner.invoke(app, ["db", "current"])
+
+    assert result.exit_code == 0
+    assert calls == [("current", ())]
+    assert "Target database:" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def _patch_alembic_command(monkeypatch, calls):
     import alembic.command
 
     def _recorder(name):
-        def _record(config, *args):
+        def _record(config, *args, **kwargs):
             calls.append((name, args))
 
         return _record


### PR DESCRIPTION
## Summary

Adds `cs2a db upgrade [REVISION]` (default `head`), `cs2a db downgrade REVISION`, and `cs2a db current`, wrapping Alembic programmatically with the existing `cs2_analytics/alembic.ini`. Both `upgrade` and `downgrade` ask for y/n confirmation and abort unless answered yes. Every `db` command first prints `Target database: <name> on <host>:<port>` so the operator sees whether the environment points at local or production before anything runs.

## Related Issue

Closes #120

## Scope

- `cs2_analytics/cli.py` - new `db` Typer sub-app with the three commands plus two small private helpers (`_alembic_config`, `_echo_target_database`); imports stay inside command bodies per the CLI convention
- `tests/test_cli.py` - tests with `alembic.command` stubbed: default revision, explicit revision, required downgrade argument, abort and confirm paths for both upgrade and downgrade, and the target line
- `README.md` - database setup section documents the new commands

## Out of Scope

- Migration files, schema content, `manage_db.py` / `initialize_db` behavior - all unchanged
- A `--yes` flag for non-interactive use; deployed environments keep running raw Alembic per the README, so nothing automated needs to bypass the prompt yet

## Risk Level

Risk level: Medium

Reason: The commands will be run against the production database and downgrade is destructive. Mitigations: y/n confirmation on both upgrade and downgrade, the printed target line before any action, and no password in any output. Per the issue's review notes, please look at the prompt and target-line behavior carefully.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase. (None.)

## Documentation Check

Documentation: Updated

Reason: README's database setup section documents the new commands and their confirmation/target-line behavior - a setup-command surface change.

Backlog: Update not needed

Reason: No roadmap checklist item covers #120; it supports the ingestion-baseline priority already described in the backlog without changing phase status or sequencing.

## Verification

Commands run:

- `uv run pytest --cov`
- Manual, against a throwaway local Postgres 16 container (not the Render database): `cs2a db current` on an empty database, `cs2a db upgrade`, `cs2a db current` again, `cs2a db downgrade 20260521_0001` answering both `n` and `y`

Results:

- 159 passed; total coverage 80.31% (75% floor)
- Target line printed by every command; upgrade migrated to head; `current` reported `20260716_0002 (head)`; downgrade aborted with exit 1 on `n` and ran on `y`

## Review Notes

- Deviation from the issue's letter: it suggested reusing `_redacted_database_url` from `alembic/env.py`, but `env.py` is an Alembic script that executes migrations at import time and cannot be imported by the CLI. Rather than duplicating URL machinery or extracting a shared module, the target line prints `DB_NAME`/`DB_HOST`/`DB_PORT` from the already-loaded config - same operator question answered, no password anywhere near the output, and `env.py` stays untouched.
- The confirmation prompt on `upgrade` goes beyond the issue (which only required it for downgrade), added at the user's request since these commands target production.