### PR TITLE
Raise the coverage floor to 80% and publish a README coverage badge (#128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,44 @@ jobs:
 
       - name: Run tests with coverage gate
         run: uv run pytest --cov
+
+      - name: Generate coverage badge data
+        run: uv run python scripts/generate_coverage_badge.py coverage-badge.json
+
+      - name: Upload coverage badge data
+        # actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: coverage-badge
+          path: coverage-badge.json
+
+  publish-coverage-badge:
+    name: Publish Coverage Badge
+    needs: lint-type-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download coverage badge data
+        # actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: coverage-badge
+
+      - name: Publish to the badges branch
+        # The badges branch holds only generated output, so it is
+        # recreated as a single-commit orphan branch on every publish.
+        run: |
+          git init -b badges badge-publish
+          cd badge-publish
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          cp ../coverage-badge.json coverage.json
+          git add coverage.json
+          git commit -m "Update coverage badge for ${GITHUB_SHA}"
+          git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 # Test coverage
 .coverage
 .coverage.*
+coverage-badge.json
 .pytest_cache/
 htmlcov/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Counter-Strike 2 Pro Match Analytics Tool
 
 [![CI](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dardenkyle/CS2-analytics/badges/coverage.json)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/ci.yml)
 [![Frontend CI](https://github.com/dardenkyle/CS2-analytics/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/frontend-ci.yml)
 [![Deploy Frontend](https://github.com/dardenkyle/CS2-analytics/actions/workflows/deploy-frontend.yml/badge.svg)](https://github.com/dardenkyle/CS2-analytics/actions/workflows/deploy-frontend.yml)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -759,7 +759,8 @@ should be addressed before the repo is considered v1.0.
 
 - [x] Add a coverage `fail-under` threshold and wire it into CI so the floor
       is enforced — `fail_under = 75` in `pyproject.toml`, CI runs
-      `pytest --cov` (#76)
+      `pytest --cov` (#76); floor raised to 80 with a README coverage badge
+      published from CI (#128)
 - [x] Stop silently coercing parse failures to `0` — required stats now raise
       `MapParseError` into the failed ingestion state, secondary stats log a
       warning before defaulting (#75)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,8 +163,9 @@ omit = [
 ]
 
 [tool.coverage.report]
-# Honest floor measured at 75.09% total coverage; raise as coverage improves.
-fail_under = 75
+# Honest floor; raised from 75 at a measured 80.36% (#128). Raise as
+# coverage improves.
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/scripts/generate_coverage_badge.py
+++ b/scripts/generate_coverage_badge.py
@@ -1,0 +1,62 @@
+"""Generate a shields.io endpoint JSON badge from measured coverage.
+
+Reads the .coverage data file produced by `pytest --cov` and writes the
+small JSON document that shields.io's endpoint badge consumes. CI runs
+this after the test step and publishes the output to the `badges`
+branch, which the README coverage badge points at.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+from coverage import Coverage
+
+COLOR_THRESHOLDS = (
+    (90.0, "brightgreen"),
+    (80.0, "green"),
+    (70.0, "yellowgreen"),
+    (60.0, "yellow"),
+    (50.0, "orange"),
+)
+DEFAULT_OUTPUT_PATH = "coverage-badge.json"
+
+
+def badge_color(percent: float) -> str:
+    """Map a coverage percentage to a shields.io color name."""
+    for floor, color in COLOR_THRESHOLDS:
+        if percent >= floor:
+            return color
+    return "red"
+
+
+def build_badge(percent: float) -> dict[str, object]:
+    """Build the shields.io endpoint schema document for a percentage."""
+    return {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": f"{percent:.1f}%",
+        "color": badge_color(percent),
+    }
+
+
+def measured_total_percent() -> float:
+    """Load the .coverage data file and return the total percentage."""
+    cov = Coverage()
+    cov.load()
+    return cov.report(file=io.StringIO())
+
+
+def main() -> None:
+    output_arg = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT_PATH
+    output_path = Path(output_arg)
+    percent = measured_total_percent()
+    output_path.write_text(
+        json.dumps(build_badge(percent)) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote {output_path} at {percent:.1f}% coverage")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_coverage_badge.py
+++ b/tests/test_generate_coverage_badge.py
@@ -1,0 +1,52 @@
+"""Tests for the coverage badge generator script (issue #128)."""
+
+import json
+import sys
+
+import pytest
+
+import scripts.generate_coverage_badge as badge_module
+from scripts.generate_coverage_badge import badge_color, build_badge
+
+
+@pytest.mark.parametrize(
+    ("percent", "expected_color"),
+    [
+        (95.0, "brightgreen"),
+        (90.0, "brightgreen"),
+        (80.4, "green"),
+        (80.0, "green"),
+        (79.9, "yellowgreen"),
+        (70.0, "yellowgreen"),
+        (65.0, "yellow"),
+        (55.0, "orange"),
+        (49.9, "red"),
+        (0.0, "red"),
+    ],
+)
+def test_badge_color_thresholds(percent: float, expected_color: str) -> None:
+    assert badge_color(percent) == expected_color
+
+
+def test_build_badge_uses_shields_endpoint_schema() -> None:
+    badge = build_badge(80.36)
+
+    assert badge == {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": "80.4%",
+        "color": "green",
+    }
+
+
+def test_main_writes_endpoint_json_to_given_path(tmp_path, monkeypatch) -> None:
+    output_path = tmp_path / "coverage.json"
+    monkeypatch.setattr(badge_module, "measured_total_percent", lambda: 81.25)
+    monkeypatch.setattr(sys, "argv", ["generate_coverage_badge.py", str(output_path)])
+
+    badge_module.main()
+
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written["schemaVersion"] == 1
+    assert written["message"] == "81.2%"
+    assert written["color"] == "green"


### PR DESCRIPTION
## Summary

Raises the enforced coverage floor from 75% to 80% (`fail_under` in `pyproject.toml`) and adds a self-updating coverage badge to the README badge row. The suite measures 80.36%, so the old floor left five points of silent-erosion room; the new floor locks in the level actually achieved.

The badge needs no external service account: CI generates a shields.io endpoint JSON from the measured coverage and publishes it to a `badges` branch; the README badge reads it via raw.githubusercontent.com.

## Related Issue

Closes #128

## Scope

- `pyproject.toml` - `fail_under = 80` with an updated comment
- `scripts/generate_coverage_badge.py` - reads the `.coverage` file left by `pytest --cov`, writes the shields.io endpoint JSON (percentage message, fixed color thresholds)
- `tests/test_generate_coverage_badge.py` - unit tests for the color mapping, endpoint schema, and file output
- `.github/workflows/ci.yml` - the test job generates and uploads the badge JSON as an artifact; a new `publish-coverage-badge` job (main pushes only) downloads it and publishes it as a single-commit orphan `badges` branch
- `README.md` - coverage badge added next to the CI badge, linked to the CI workflow
- `.gitignore` - ignores locally generated `coverage-badge.json`
- `docs/backlog.md` - the v1.0 polish line recording the 75% floor is annotated with the raise

## Out of Scope

- New tests to push coverage higher - this locks in the current level
- Per-module thresholds or PR coverage-diff gates
- Changes to what `--cov` measures

## Risk Level

Risk level: Medium

Reason: CI workflow change (human review required regardless), including a job with `contents: write`. Mitigations: the write permission is scoped to the new publish job only (the test job keeps `contents: read`), the job runs only on pushes to main, it can only write the generated `badges` branch content, and both artifact actions are pinned by commit SHA with version comments matching the workflow's existing style.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase. (None.)

## Documentation Check

Documentation: Updated

Reason: README gains the badge (user-facing), and the stale `fail_under = 75` mention in `docs/backlog.md` is annotated. `docs/workflow.md` describes the coverage gate without naming a number, so it needed no change.

Backlog: Updated

Reason: The v1.0 polish checklist line that recorded the 75% floor now notes the raise to 80 and the badge (#128). No phase status or sequencing changed.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run python scripts/generate_coverage_badge.py coverage-badge.json` against the real `.coverage` file
- `uv run ruff check` on the new files; YAML parse check on the workflow

Results:

- 171 passed; total coverage 80.36% against the new 80% floor
- Badge JSON: `{"schemaVersion": 1, "label": "coverage", "message": "80.4%", "color": "green"}`
- Lint and YAML both clean

## Review Notes

- The `badges` branch is force-pushed as a single-commit orphan on every main build - it holds only regenerated output, so history there is deliberately not kept. Flagging since force-push is normally off-limits; here it never touches main.
- The badge will render 404/`invalid` until the first main build after merge creates the `badges` branch; it self-heals on that first push.
- shields.io caches endpoint responses briefly, so the badge can lag a merge by a few minutes.