### PR TITLE
Add dbt staging models (stg_matches, stg_maps, stg_players) (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,19 @@ DB_PASS=change_me
 DB_HOST=localhost
 DB_PORT=5432
 
+# dbt connection (default `dev` target).
+# dbt uses its own DBT_DB_* variables so it stays decoupled from the DB_*
+# variables above, which may point at a deployed database. These default to a
+# local Postgres (matching docker-compose's `db` service), so a bare
+# `dbt run` never touches a deployed database. Override to point elsewhere.
+# The committed `prod` target reads the DB_* variables above and is only used
+# with an explicit `dbt run --target prod`.
+DBT_DB_NAME=cs2_db
+DBT_DB_USER=postgres
+DBT_DB_PASS=change_me
+DBT_DB_HOST=localhost
+DBT_DB_PORT=5432
+
 # Optional: override the results discovery URL used by the results scraper.
 # Defaults to the built-in results source when unset.
 # SOURCE_URL=

--- a/README.md
+++ b/README.md
@@ -292,20 +292,33 @@ python -m pytest
 
 ### 10. Run dbt (analytics transformations)
 
-dbt is installed with the dev dependencies (`uv sync`). It connects with the
-same `DB_*` variables the application uses, but does not read `.env` itself,
-so export them first:
+dbt is installed with the dev dependencies (`uv sync`). Its default target is a
+**local** Postgres, so `dbt run` never touches a deployed database by accident.
+dbt uses its own `DBT_DB_*` variables (with local defaults, see `.env.example`)
+and does not read `.env` itself. Start a local Postgres, load the schema, then
+run dbt:
+
+```sh
+docker compose --env-file .env.example up -d db
+env DB_HOST=localhost DB_USER=postgres DB_PASS=change_me DB_NAME=cs2_db \
+  uv run alembic -c cs2_analytics/alembic.ini upgrade head
+uv run dbt debug --project-dir dbt --profiles-dir dbt
+uv run dbt run --project-dir dbt --profiles-dir dbt
+```
+
+To run against a deployed database on purpose, export its `DB_*` values and
+name the `prod` target explicitly:
 
 ```sh
 set -a; source .env; set +a
-uv run dbt debug --project-dir dbt --profiles-dir dbt
-uv run dbt compile --project-dir dbt --profiles-dir dbt
+uv run dbt run --project-dir dbt --profiles-dir dbt --target prod
 ```
 
 dbt owns analytics transformations only; the ingestion schema stays owned by
 Alembic migrations. Sources are declared for the `matches`, `maps`, and
-`players` tables, and models arrive with the Phase 4 staging work. See
-`docs/dbt_models.md` for the planned model layers.
+`players` tables. The staging layer (`stg_matches`, `stg_maps`, `stg_players`)
+is thin views over those sources. See `docs/dbt_models.md` for the planned
+model layers.
 
 Note: Demo processing is still deferred and intentionally remains outside the active ingestion pipeline; its implementation lives on the `feature/demo-parsing` branch.
 

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -21,3 +21,9 @@ target-path: "target"
 clean-targets:
   - "target"
   - "dbt_packages"
+
+models:
+  cs2_analytics:
+    staging:
+      # Staging models are thin views over the Alembic-owned sources.
+      +materialized: view

--- a/dbt/models/staging/_staging__models.yml
+++ b/dbt/models/staging/_staging__models.yml
@@ -6,7 +6,11 @@ models:
       Staging model over the matches source table. Grain: one row per
       professional match, keyed by match_id. Thin rename/cast/select over the
       source; the stringified trace/debug columns map_links and demo_links are
-      intentionally dropped.
+      intentionally dropped. All audit timestamps (inserted_at, last_scraped_at,
+      last_updated_at) are timezone-naive TIMESTAMP in the current source,
+      unlike stg_maps where they are timezone-aware (TIMESTAMPTZ); downstream
+      models should not assume UTC-aware semantics. Audit-field timezone
+      normalization is deferred (see docs/schema_target_pre_dbt.md).
     columns:
       - name: match_id
         description: Source match identifier. Primary key; grain of this model.
@@ -35,7 +39,8 @@ models:
       - name: inserted_at
         description: >
           First persistence timestamp for the source row (source column
-          last_inserted_at).
+          last_inserted_at). Timezone-naive TIMESTAMP in the current source,
+          unlike stg_maps.inserted_at which is timezone-aware (TIMESTAMPTZ).
       - name: last_scraped_at
         description: Most recent time the source row was scraped.
       - name: last_updated_at
@@ -85,7 +90,12 @@ models:
     description: >
       Staging model over the players source table. Grain: one row per player per
       map, keyed by (map_id, player_id). Thin rename/cast/select over the
-      source; carries per-map total stats only.
+      source; carries per-map total stats only. All audit timestamps
+      (inserted_at, last_scraped_at, last_updated_at) are timezone-naive
+      TIMESTAMP in the current source, unlike stg_maps where they are
+      timezone-aware (TIMESTAMPTZ); downstream models should not assume UTC-aware
+      semantics. Audit-field timezone normalization is deferred (see
+      docs/schema_target_pre_dbt.md).
     columns:
       - name: map_id
         description: Map identifier; foreign key to stg_maps. Part of the grain.
@@ -136,7 +146,8 @@ models:
       - name: inserted_at
         description: >
           First persistence timestamp for the source row (source column
-          last_inserted_at).
+          last_inserted_at). Timezone-naive TIMESTAMP in the current source,
+          unlike stg_maps.inserted_at which is timezone-aware (TIMESTAMPTZ).
       - name: last_scraped_at
         description: Most recent time the source row was scraped.
       - name: last_updated_at

--- a/dbt/models/staging/_staging__models.yml
+++ b/dbt/models/staging/_staging__models.yml
@@ -1,0 +1,147 @@
+version: 2
+
+models:
+  - name: stg_matches
+    description: >
+      Staging model over the matches source table. Grain: one row per
+      professional match, keyed by match_id. Thin rename/cast/select over the
+      source; the stringified trace/debug columns map_links and demo_links are
+      intentionally dropped.
+    columns:
+      - name: match_id
+        description: Source match identifier. Primary key; grain of this model.
+      - name: match_url
+        description: Canonical source URL for the match.
+      - name: team1
+        description: First team name as parsed from the match page.
+      - name: team2
+        description: Second team name as parsed from the match page.
+      - name: score1
+        description: Series score for team1.
+      - name: score2
+        description: Series score for team2.
+      - name: match_winner
+        description: >
+          Winning team name (source column winner). Equals either team1 or
+          team2.
+      - name: event
+        description: Event or tournament name, when available.
+      - name: match_type
+        description: Match format label, such as best-of series type.
+      - name: forfeit
+        description: Whether the match was recorded as a forfeit.
+      - name: date
+        description: Match date/time as parsed from the source.
+      - name: inserted_at
+        description: >
+          First persistence timestamp for the source row (source column
+          last_inserted_at).
+      - name: last_scraped_at
+        description: Most recent time the source row was scraped.
+      - name: last_updated_at
+        description: Most recent meaningful update to the source row.
+      - name: data_complete
+        description: >
+          Whether the source row satisfies its required-field contract for
+          downstream use.
+
+  - name: stg_maps
+    description: >
+      Staging model over the maps source table. Grain: one row per map played
+      within a match, keyed by map_id, with match_id as a foreign key to
+      stg_matches and a per-match map_order. Thin rename/cast/select over the
+      source.
+    columns:
+      - name: map_id
+        description: Source map-stats identifier. Primary key; grain of this model.
+      - name: match_id
+        description: Parent match identifier; foreign key to stg_matches.
+      - name: map_url
+        description: Canonical source URL for the map stats page.
+      - name: map_order
+        description: Position of this map within the match, from 1 to 5.
+      - name: map_name
+        description: Map name, such as Mirage or Inferno.
+      - name: team1_score
+        description: Round score for team1 on this map.
+      - name: team2_score
+        description: Round score for team2 on this map.
+      - name: map_winner
+        description: Winning team name for this map.
+      - name: date
+        description: Map date/time as parsed from the source.
+      - name: inserted_at
+        description: First persistence timestamp for the source row.
+      - name: last_scraped_at
+        description: Most recent time the source row was scraped.
+      - name: last_updated_at
+        description: Most recent meaningful update to the source row.
+      - name: data_complete
+        description: >
+          Whether the source row satisfies its required-field contract for
+          downstream use.
+
+  - name: stg_players
+    description: >
+      Staging model over the players source table. Grain: one row per player per
+      map, keyed by (map_id, player_id). Thin rename/cast/select over the
+      source; carries per-map total stats only.
+    columns:
+      - name: map_id
+        description: Map identifier; foreign key to stg_maps. Part of the grain.
+      - name: player_id
+        description: Player identifier. Part of the grain.
+      - name: player_name
+        description: Player name as parsed for this map.
+      - name: player_url
+        description: Canonical source URL for the player, when available.
+      - name: map_name
+        description: >
+          Parsed map-name context for this player row. Downstream models should
+          prefer stg_maps.map_name for a canonical map name.
+      - name: team_name
+        description: Team the player represented on this map.
+      - name: kills
+        description: Total kills on this map.
+      - name: headshots
+        description: Total headshot kills on this map.
+      - name: assists
+        description: Total assists on this map.
+      - name: flash_assists
+        description: Total flash assists on this map.
+      - name: deaths
+        description: Total deaths on this map.
+      - name: traded_deaths
+        description: Total traded deaths on this map.
+      - name: opening_kills
+        description: Total opening (entry) kills on this map.
+      - name: opening_deaths
+        description: Total opening (entry) deaths on this map.
+      - name: multi_kills
+        description: Total multi-kill rounds on this map.
+      - name: clutches_won
+        description: Total clutches won on this map.
+      - name: kast
+        description: KAST percentage on this map.
+      - name: kd_diff
+        description: Kill/death differential on this map.
+      - name: adr
+        description: Average damage per round on this map.
+      - name: fk_diff
+        description: First-kill differential on this map.
+      - name: round_swing
+        description: Round-swing metric on this map.
+      - name: rating
+        description: Performance rating from the source on this map.
+      - name: inserted_at
+        description: >
+          First persistence timestamp for the source row (source column
+          last_inserted_at).
+      - name: last_scraped_at
+        description: Most recent time the source row was scraped.
+      - name: last_updated_at
+        description: Most recent meaningful update to the source row.
+      - name: data_complete
+        description: >
+          Whether the source row satisfies its required-field contract for
+          downstream use.

--- a/dbt/models/staging/stg_maps.sql
+++ b/dbt/models/staging/stg_maps.sql
@@ -1,0 +1,34 @@
+-- Staging model for the parsed maps source table.
+--
+-- Grain: one row per map played within a match, keyed by map_id, with a
+-- foreign key to matches and a per-match map_order. Thin by design: select,
+-- rename, and light casting only. No joins and no business logic.
+
+with source as (
+
+    select * from {{ source('ingestion', 'maps') }}
+
+),
+
+renamed as (
+
+    select
+        map_id,
+        match_id,
+        map_url,
+        map_order,
+        map_name,
+        team1_score,
+        team2_score,
+        map_winner,
+        date,
+        inserted_at,
+        last_scraped_at,
+        last_updated_at,
+        data_complete
+
+    from source
+
+)
+
+select * from renamed

--- a/dbt/models/staging/stg_matches.sql
+++ b/dbt/models/staging/stg_matches.sql
@@ -1,0 +1,38 @@
+-- Staging model for the parsed matches source table.
+--
+-- Grain: one row per professional match, keyed by match_id.
+-- Thin by design: select, rename, and light casting only. No joins and no
+-- business logic. The stringified trace/debug columns map_links and demo_links
+-- are intentionally dropped; relationship-ready downstream models use
+-- stg_maps.match_id rather than parsing those source fields.
+
+with source as (
+
+    select * from {{ source('ingestion', 'matches') }}
+
+),
+
+renamed as (
+
+    select
+        match_id,
+        match_url,
+        team1,
+        team2,
+        score1,
+        score2,
+        winner as match_winner,
+        event,
+        match_type,
+        forfeit,
+        date,
+        last_inserted_at as inserted_at,
+        last_scraped_at,
+        last_updated_at,
+        data_complete
+
+    from source
+
+)
+
+select * from renamed

--- a/dbt/models/staging/stg_players.sql
+++ b/dbt/models/staging/stg_players.sql
@@ -1,0 +1,48 @@
+-- Staging model for the parsed players source table.
+--
+-- Grain: one row per player per map, keyed by (map_id, player_id). Thin by
+-- design: select, rename, and light casting only. No joins and no business
+-- logic. The parsed map_name context column is passed through as-is; downstream
+-- models should prefer stg_maps.map_name when a canonical map name is needed.
+
+with source as (
+
+    select * from {{ source('ingestion', 'players') }}
+
+),
+
+renamed as (
+
+    select
+        map_id,
+        player_id,
+        player_name,
+        player_url,
+        map_name,
+        team_name,
+        kills,
+        headshots,
+        assists,
+        flash_assists,
+        deaths,
+        traded_deaths,
+        opening_kills,
+        opening_deaths,
+        multi_kills,
+        clutches_won,
+        kast,
+        kd_diff,
+        adr,
+        fk_diff,
+        round_swing,
+        rating,
+        last_inserted_at as inserted_at,
+        last_scraped_at,
+        last_updated_at,
+        data_complete
+
+    from source
+
+)
+
+select * from renamed

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,16 +1,39 @@
 # Connection profile for the CS2 Analytics dbt project.
 #
-# Credentials are environment-driven via the same DB_* variables the
-# application uses (see .env.example); nothing secret is committed here.
-# dbt does not read .env itself, so export the variables first:
+# The default target is a LOCAL Postgres, so `dbt run` never touches a
+# deployed database by accident. dbt uses its own DBT_DB_* variables (with
+# local defaults) and is deliberately decoupled from the application's DB_*
+# variables, which may point at a deployed database.
+#
+# Local (default target `dev`): start a local Postgres, then run dbt. The
+# defaults below match docker-compose's `db` service and .env.example:
+#
+#   docker compose --env-file .env.example up -d db
+#   uv run dbt run --project-dir dbt --profiles-dir dbt
+#
+# Override any DBT_DB_* variable to point the default target elsewhere.
+#
+# Deployed database (explicit opt-in only): the `prod` target reads the
+# application's DB_* variables and is only used when named on the command line:
 #
 #   set -a; source .env; set +a
-#   uv run dbt debug --project-dir dbt --profiles-dir dbt
+#   uv run dbt run --project-dir dbt --profiles-dir dbt --target prod
+#
+# Nothing secret is committed here.
 
 cs2_analytics:
   target: dev
   outputs:
     dev:
+      type: postgres
+      host: "{{ env_var('DBT_DB_HOST', 'localhost') }}"
+      port: "{{ env_var('DBT_DB_PORT', '5432') | as_number }}"
+      user: "{{ env_var('DBT_DB_USER', 'postgres') }}"
+      password: "{{ env_var('DBT_DB_PASS', 'change_me') }}"
+      dbname: "{{ env_var('DBT_DB_NAME', 'cs2_db') }}"
+      schema: analytics
+      threads: 4
+    prod:
       type: postgres
       host: "{{ env_var('DB_HOST') }}"
       port: "{{ env_var('DB_PORT', '5432') | as_number }}"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,7 +19,8 @@ Current priorities:
   the Render database, with controllable quantity (`cs2a` caps and batch
   sizes) and a schedulable entry point
 - continue Phase 4 (dbt) without moving ingestion responsibilities into
-  dbt: the project is initialized (#109) and staging models are next;
+  dbt: the project is initialized (#109), staging models exist (#110), and
+  intermediate models are next;
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -702,7 +703,8 @@ writes into.
 
 - [x] Initialize dbt project (#109): skeleton under `dbt/`, env-driven
   Postgres profile, sources declared for `matches`, `maps`, `players`
-- [ ] Create staging models (`stg_matches`, `stg_maps`, `stg_players`)
+- [x] Create staging models (`stg_matches`, `stg_maps`, `stg_players`) (#110):
+  thin views over the declared sources with documented grains
 - [ ] Create intermediate models for reusable joins
 - [ ] Create marts (`fact_*`, `dim_*`)
 - [ ] Add dbt tests (`not_null`, `unique`, `relationships`)

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -88,6 +88,13 @@ This keeps transformations readable, modular, and maintainable.
 
 # 1. Staging Layer
 
+Status: the parsed-source staging models `stg_matches`, `stg_maps`, and
+`stg_players` are implemented (#110) as thin views under
+`dbt/models/staging/`, with grains and columns documented in
+`dbt/models/staging/_staging__models.yml`. The `stg_raw_*` snapshot models
+below remain planning-only; the pipeline does not persist raw HTML snapshots,
+so those are not built.
+
 The staging layer standardizes raw inputs and structured source tables.
 
 These models should do light cleanup only.


### PR DESCRIPTION
## Summary

Add the initial dbt staging layer for Phase 4: one thin model per parsed source
table (`stg_matches`, `stg_maps`, `stg_players`) with documented grains. Also
decouple the dbt profile from the application's `DB_*` variables so dbt defaults
to a local Postgres and only reaches a deployed database through an explicit
`--target prod`.

## Related Issue

Closes #110

## Scope

- `dbt/models/staging/stg_matches.sql`, `stg_maps.sql`, `stg_players.sql`: thin
  `source -> renamed` views over the declared sources. Renames follow the
  pre-dbt schema target (`winner` -> `match_winner`; `last_inserted_at` ->
  `inserted_at`). Stringified trace/debug columns `map_links`/`demo_links` are
  intentionally dropped.
- `dbt/models/staging/_staging__models.yml`: documents each model's grain and
  columns.
- `dbt/dbt_project.yml`: materialize the `staging/` folder as views.
- `dbt/profiles.yml`: default `dev` target now uses `DBT_DB_*` variables with
  local defaults; new explicit `prod` target reads the application `DB_*`
  variables.
- `.env.example`: documents the new `DBT_DB_*` variables.
- `README.md`: dbt section rewritten for the local-first workflow.
- `docs/backlog.md`, `docs/dbt_models.md`: status updates.

## Out of Scope

- dbt tests (`not_null`, `unique`, `relationships`) - separate Phase 4 item.
- Intermediate and mart models.
- Parsed-source schema normalization deferred in
  `docs/schema_target_pre_dbt.md` (JSONB link fields, `data_complete`
  contracts, `team_side`, etc.).

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: The staging models themselves are additive and low risk (read-only
views over Alembic-owned sources). The Medium rating is for the `profiles.yml`
change: it alters how dbt resolves its database connection. It is included
because the previous profile reused the application `DB_*` variables, which
currently point at the deployed database, so a plain `dbt run` materialized
against production. The new default is local-only, with the deployed database
reachable solely via an explicit `--target prod`.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: the dbt staging models are the explicitly requested work of issue #110
(Phase 4). No application/source schema changed; dbt reads the Alembic-owned
`matches`, `maps`, and `players` tables as sources only.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: Added `_staging__models.yml` grain/column docs, documented `DBT_DB_*`
in `.env.example`, rewrote the README dbt section for the local-first workflow,
and added an implementation-status note to `docs/dbt_models.md`.

Backlog: Updated

Reason: Checked off the Phase 4 "Create staging models" item and moved the
"next" pointer to intermediate models.

## Verification

Commands run:

- `uv run dbt debug --project-dir dbt --profiles-dir dbt`
- `docker compose --env-file .env.example up -d db`
- `env DB_HOST=localhost ... uv run alembic -c cs2_analytics/alembic.ini upgrade head`
- `uv run dbt run --select staging --project-dir dbt --profiles-dir dbt`
- `uv run dbt show --select stg_matches --limit 2 ...`

Results:

- `dbt debug` reports `host: localhost` by default; connection OK.
- Alembic brought a fresh local Postgres to head (`20260716_0002`); source
  tables present.
- `dbt run --select staging` created all three views (PASS=3).
- `dbt show` returns rows through `stg_matches`.

## Review Notes

- Primary reviewer focus: `dbt/profiles.yml`. Confirm the local default and the
  explicit `prod` opt-in match how the deployed database should be targeted.
- The three views created during earlier verification against the deployed
  database were dropped; only an empty dbt-owned `analytics` schema remains
  there.
- dbt tests over these models are the intended immediate follow-up.
