### PR TITLE
Add int_match_player_stats intermediate model (#111)

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -27,3 +27,6 @@ models:
     staging:
       # Staging models are thin views over the Alembic-owned sources.
       +materialized: view
+    intermediate:
+      # Intermediate models are reusable-join views over staging models.
+      +materialized: view

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -1,0 +1,80 @@
+version: 2
+
+models:
+  - name: int_match_player_stats
+    description: >
+      Per-map player performance enriched with map and match context. Grain:
+      one row per player per map, keyed by (map_id, player_id) - the same grain
+      as stg_players. Factors the reusable stg_players -> stg_maps ->
+      stg_matches join into one place so downstream marts do not repeat it.
+      Joins and context attachment only; no aggregation. The canonical map_name
+      comes from stg_maps.
+    columns:
+      - name: map_id
+        description: Map identifier; part of the grain. Joins to stg_maps.map_id.
+      - name: player_id
+        description: Player identifier; part of the grain.
+      - name: match_id
+        description: Parent match identifier, carried from stg_maps.match_id.
+      - name: team1
+        description: First team name for the parent match.
+      - name: team2
+        description: Second team name for the parent match.
+      - name: match_winner
+        description: Winning team name for the parent match.
+      - name: event
+        description: Event or tournament name for the parent match.
+      - name: match_type
+        description: Match format label for the parent match.
+      - name: match_date
+        description: Parent match date/time (stg_matches.date).
+      - name: map_order
+        description: Position of this map within the match, from 1 to 5.
+      - name: map_name
+        description: Canonical map name from stg_maps.
+      - name: map_winner
+        description: Winning team name for this map.
+      - name: map_team1_score
+        description: Round score for team1 on this map (stg_maps.team1_score).
+      - name: map_team2_score
+        description: Round score for team2 on this map (stg_maps.team2_score).
+      - name: map_date
+        description: Map date/time (stg_maps.date).
+      - name: player_name
+        description: Player name as parsed for this map.
+      - name: player_url
+        description: Canonical source URL for the player, when available.
+      - name: team_name
+        description: Team the player represented on this map.
+      - name: kills
+        description: Total kills on this map.
+      - name: headshots
+        description: Total headshot kills on this map.
+      - name: assists
+        description: Total assists on this map.
+      - name: flash_assists
+        description: Total flash assists on this map.
+      - name: deaths
+        description: Total deaths on this map.
+      - name: traded_deaths
+        description: Total traded deaths on this map.
+      - name: opening_kills
+        description: Total opening (entry) kills on this map.
+      - name: opening_deaths
+        description: Total opening (entry) deaths on this map.
+      - name: multi_kills
+        description: Total multi-kill rounds on this map.
+      - name: clutches_won
+        description: Total clutches won on this map.
+      - name: kast
+        description: KAST percentage on this map.
+      - name: kd_diff
+        description: Kill/death differential on this map.
+      - name: adr
+        description: Average damage per round on this map.
+      - name: fk_diff
+        description: First-kill differential on this map.
+      - name: round_swing
+        description: Round-swing metric on this map.
+      - name: rating
+        description: Performance rating from the source on this map.

--- a/dbt/models/intermediate/int_match_player_stats.sql
+++ b/dbt/models/intermediate/int_match_player_stats.sql
@@ -1,0 +1,85 @@
+-- Intermediate model: per-map player stats enriched with map and match context.
+--
+-- Grain: one row per player per map, keyed by (map_id, player_id) - the same
+-- grain as stg_players. This factors the players -> maps -> matches join into
+-- one reusable place so downstream marts do not repeat it. Joins and context
+-- attachment only; no aggregation and no presentation-shaping.
+--
+-- The canonical map_name comes from stg_maps; the parsed stg_players.map_name
+-- context column is intentionally not carried through (see
+-- docs/schema_target_pre_dbt.md).
+
+with players as (
+
+    select * from {{ ref('stg_players') }}
+
+),
+
+maps as (
+
+    select * from {{ ref('stg_maps') }}
+
+),
+
+matches as (
+
+    select * from {{ ref('stg_matches') }}
+
+),
+
+joined as (
+
+    select
+        -- keys / grain
+        players.map_id,
+        players.player_id,
+        maps.match_id,
+
+        -- match context
+        matches.team1,
+        matches.team2,
+        matches.match_winner,
+        matches.event,
+        matches.match_type,
+        matches.date as match_date,
+
+        -- map context
+        maps.map_order,
+        maps.map_name,
+        maps.map_winner,
+        maps.team1_score as map_team1_score,
+        maps.team2_score as map_team2_score,
+        maps.date as map_date,
+
+        -- player identity
+        players.player_name,
+        players.player_url,
+        players.team_name,
+
+        -- player performance
+        players.kills,
+        players.headshots,
+        players.assists,
+        players.flash_assists,
+        players.deaths,
+        players.traded_deaths,
+        players.opening_kills,
+        players.opening_deaths,
+        players.multi_kills,
+        players.clutches_won,
+        players.kast,
+        players.kd_diff,
+        players.adr,
+        players.fk_diff,
+        players.round_swing,
+        players.rating
+
+    from players
+    inner join maps
+        on players.map_id = maps.map_id
+    inner join matches
+        on maps.match_id = matches.match_id
+
+)
+
+select * from joined

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -19,8 +19,8 @@ Current priorities:
   the Render database, with controllable quantity (`cs2a` caps and batch
   sizes) and a schedulable entry point
 - continue Phase 4 (dbt) without moving ingestion responsibilities into
-  dbt: the project is initialized (#109), staging models exist (#110), and
-  intermediate models are next;
+  dbt: the project is initialized (#109), staging models exist (#110),
+  the first intermediate model exists (#111), and marts are next;
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -705,8 +705,12 @@ writes into.
   Postgres profile, sources declared for `matches`, `maps`, `players`
 - [x] Create staging models (`stg_matches`, `stg_maps`, `stg_players`) (#110):
   thin views over the declared sources with documented grains
-- [ ] Create intermediate models for reusable joins
-- [ ] Create marts (`fact_*`, `dim_*`)
+- [x] Create intermediate models for reusable joins (#111):
+  `int_match_player_stats` factors the reusable stg_players -> stg_maps ->
+  stg_matches join (grain: one row per player per map). The issue's
+  "used by a downstream mart" check is satisfied when the marts land (#112).
+- [ ] Create marts (`fact_*`, `dim_*`) - includes wiring at least one mart onto
+  `int_match_player_stats` to close the #111 downstream-usage criterion
 - [ ] Add dbt tests (`not_null`, `unique`, `relationships`)
 - [ ] Generate lineage/docs
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -705,12 +705,13 @@ writes into.
   Postgres profile, sources declared for `matches`, `maps`, `players`
 - [x] Create staging models (`stg_matches`, `stg_maps`, `stg_players`) (#110):
   thin views over the declared sources with documented grains
-- [x] Create intermediate models for reusable joins (#111):
-  `int_match_player_stats` factors the reusable stg_players -> stg_maps ->
-  stg_matches join (grain: one row per player per map). The issue's
-  "used by a downstream mart" check is satisfied when the marts land (#112).
-- [ ] Create marts (`fact_*`, `dim_*`) - includes wiring at least one mart onto
-  `int_match_player_stats` to close the #111 downstream-usage criterion
+- [ ] Create intermediate models for reusable joins (#111):
+  - [x] `int_match_player_stats` built - factors the reusable stg_players ->
+    stg_maps -> stg_matches join (grain: one row per player per map)
+  - [ ] at least one downstream mart consumes it - closes the #111
+    "used by a downstream mart" criterion; lands with the marts (#112)
+- [ ] Create marts (`fact_*`, `dim_*`) - the first mart consumes
+  `int_match_player_stats`, closing the #111 downstream-usage criterion
 - [ ] Add dbt tests (`not_null`, `unique`, `relationships`)
 - [ ] Generate lineage/docs
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -270,6 +270,12 @@ Possible responsibilities:
 
 # 2. Intermediate Layer
 
+Status: `int_match_player_stats` is implemented (#111) under
+`dbt/models/intermediate/` as a reusable-join view over the staging models
+(grain: one row per player per map), documented in
+`dbt/models/intermediate/_intermediate__models.yml`. The other `int_*` models
+below remain planning-only until a mart needs them.
+
 The intermediate layer handles reusable joins and logic that should not be repeated in marts.
 
 These models are not always exposed directly to end users or the API.


### PR DESCRIPTION
## Summary

Add the first dbt intermediate model for Phase 4: `int_match_player_stats`,
which factors the reusable `stg_players -> stg_maps -> stg_matches` join into
one place so the mart layer does not repeat it.

## Related Issue

Contributes to #111 (does not auto-close). #111 is fully complete once at least
one mart consumes `int_match_player_stats`, which lands with the marts (#112).
This PR delivers the intermediate model itself.

## Scope

- `dbt/models/intermediate/int_match_player_stats.sql`: per-map player stats
  enriched with map and match context. Grain: one row per player per map,
  keyed by `(map_id, player_id)` - the same grain as `stg_players`. Joins and
  context attachment only; no aggregation and no presentation shaping. Canonical
  `map_name` comes from `stg_maps`; the parsed `stg_players.map_name` context is
  dropped.
- `dbt/models/intermediate/_intermediate__models.yml`: grain and column docs.
- `dbt/dbt_project.yml`: materialize `intermediate/` models as views.
- `docs/backlog.md`, `docs/dbt_models.md`: status updates.

## Out of Scope

- The other planned `int_*` models (`int_team_match_results`,
  `int_player_match_aggregates`, `int_event_matches`) remain planning-only until
  a mart needs them.
- Mart (`fact_*`, `dim_*`) models and dbt tests.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Additive dbt-only change. The model is a read-only view over existing
staging models; it adds no schema, no ingestion behavior, and no new
dependencies. The default dbt target is local, so nothing runs against a
deployed database implicitly.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: the intermediate model is the explicitly requested work of issue #111
(Phase 4). It reads only staging models (`ref`), never raw sources, and no
application/source schema changed.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: Added `_intermediate__models.yml` grain/column docs and an
implementation-status note to the intermediate section of `docs/dbt_models.md`.

Backlog: Updated

Reason: Checked off the Phase 4 "Create intermediate models" item, moved the
"next" pointer to marts, and recorded that #111's downstream-mart-usage
criterion is closed by the marts item (#112).

## Verification

Commands run:

- `docker compose --env-file .env.example up -d db`
- `env DB_HOST=localhost ... uv run alembic -c cs2_analytics/alembic.ini upgrade head`
- seeded one match, one map, and two players
- `uv run dbt run --project-dir dbt --profiles-dir dbt`
- `uv run dbt parse --project-dir dbt --profiles-dir dbt`
- row/grain checks against `analytics.int_match_player_stats`

Results:

- `dbt run` builds all four models (PASS=4), including
  `int_match_player_stats`.
- The model returns two rows with distinct `(map_id, player_id)` grain,
  correctly enriched with match context (`event`, `match_winner`) and map
  context (`map_name`).
- `dbt parse` succeeds.

## Review Notes

- The joins are `inner join`. Given the FK constraints
  (`maps.match_id -> matches`, `players.map_id -> maps`), inner and left are
  equivalent here; inner is used to state the intent that a player row requires
  its map and match. Say the word if you prefer defensive left joins.
- Immediate follow-up: marts (#112) will consume this model, which closes the
  "used by a downstream mart" criterion from #111.