### PR TITLE
Add initial dbt mart layer (fact_* and dim_* models) (#112)

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -30,3 +30,6 @@ models:
     intermediate:
       # Intermediate models are reusable-join views over staging models.
       +materialized: view
+    marts:
+      # Marts are business-ready fact/dim tables for analytics and API reads.
+      +materialized: table

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -30,18 +30,32 @@ models:
         description: Position of this map within the match, from 1 to 5.
       - name: map_date
         description: Map date/time.
+      - name: map_winner
+        description: Winning team name for this map.
+      - name: map_team1_score
+        description: Rounds won by team1 on this map.
+      - name: map_team2_score
+        description: Rounds won by team2 on this map.
       - name: kills
         description: Total kills on this map.
       - name: deaths
         description: Total deaths on this map.
       - name: assists
         description: Total assists on this map.
+      - name: flash_assists
+        description: Total flash assists on this map.
       - name: headshots
         description: Total headshot kills on this map.
       - name: opening_kills
         description: Total opening (entry) kills on this map.
       - name: opening_deaths
         description: Total opening (entry) deaths on this map.
+      - name: traded_deaths
+        description: Deaths traded by a teammate on this map.
+      - name: multi_kills
+        description: Rounds with multiple kills on this map.
+      - name: clutches_won
+        description: Clutch rounds won on this map.
       - name: kast
         description: KAST percentage on this map.
       - name: adr
@@ -52,6 +66,8 @@ models:
         description: Kill/death differential on this map.
       - name: fk_diff
         description: First-kill differential on this map.
+      - name: round_swing
+        description: Round swing contribution from the source on this map.
 
   - name: fact_matches
     description: >
@@ -73,9 +89,13 @@ models:
       - name: score2
         description: Series score for team2.
       - name: winning_team
-        description: Winning team name (equals team1 or team2).
+        description: >
+          Winning team name (equals team1 or team2). Null when the source has
+          not recorded a winner.
       - name: losing_team
-        description: Losing team name, derived as the team that is not the winner.
+        description: >
+          Losing team name, derived as the team that is not the winner. Null
+          when the winner is null or does not match either team name.
       - name: match_type
         description: Match format label, such as best-of series type.
       - name: match_date

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -1,0 +1,111 @@
+version: 2
+
+models:
+  - name: fact_player_map_stats
+    description: >
+      Player performance facts at the player-map grain. Grain: one row per
+      player per map, keyed by (map_id, player_id). Projected from
+      int_match_player_stats. Intended consumers: player performance lookups,
+      player map splits, and rating/ADR trend analysis.
+    columns:
+      - name: match_id
+        description: Parent match identifier.
+      - name: map_id
+        description: Map identifier; part of the grain.
+      - name: player_id
+        description: Player identifier; part of the grain.
+      - name: player_name
+        description: Player name as parsed for this map.
+      - name: team_name
+        description: Team the player represented on this map.
+      - name: event
+        description: Event or tournament name for the parent match.
+      - name: match_date
+        description: Parent match date/time.
+      - name: match_winner
+        description: Winning team name for the parent match.
+      - name: map_name
+        description: Canonical map name.
+      - name: map_order
+        description: Position of this map within the match, from 1 to 5.
+      - name: map_date
+        description: Map date/time.
+      - name: kills
+        description: Total kills on this map.
+      - name: deaths
+        description: Total deaths on this map.
+      - name: assists
+        description: Total assists on this map.
+      - name: headshots
+        description: Total headshot kills on this map.
+      - name: opening_kills
+        description: Total opening (entry) kills on this map.
+      - name: opening_deaths
+        description: Total opening (entry) deaths on this map.
+      - name: kast
+        description: KAST percentage on this map.
+      - name: adr
+        description: Average damage per round on this map.
+      - name: rating
+        description: Performance rating from the source on this map.
+      - name: kd_diff
+        description: Kill/death differential on this map.
+      - name: fk_diff
+        description: First-kill differential on this map.
+
+  - name: fact_matches
+    description: >
+      Clean match-level facts. Grain: one row per match, keyed by match_id.
+      Built from stg_matches, with map_count derived from stg_maps and
+      losing_team derived from the winner. Intended consumers: recent match
+      listings, event-level match analysis, and team performance analysis.
+    columns:
+      - name: match_id
+        description: Match identifier. Primary key; grain of this model.
+      - name: event
+        description: Event or tournament name, when available.
+      - name: team1
+        description: First team name.
+      - name: team2
+        description: Second team name.
+      - name: score1
+        description: Series score for team1.
+      - name: score2
+        description: Series score for team2.
+      - name: winning_team
+        description: Winning team name (equals team1 or team2).
+      - name: losing_team
+        description: Losing team name, derived as the team that is not the winner.
+      - name: match_type
+        description: Match format label, such as best-of series type.
+      - name: match_date
+        description: Match date/time.
+      - name: forfeit
+        description: Whether the match was recorded as a forfeit.
+      - name: map_count
+        description: Number of maps recorded for this match in stg_maps.
+      - name: data_complete
+        description: >
+          Whether the source match row satisfies its required-field contract.
+
+  - name: dim_players
+    description: >
+      Stable player identity dimension. Grain: one row per player, keyed by
+      player_id, holding the most recently persisted identity per player.
+      Intended consumers: filtering by player and joining player metadata onto
+      the fact tables.
+    columns:
+      - name: player_id
+        description: Player identifier. Primary key; grain of this model.
+      - name: player_name
+        description: Most recently persisted player name for this player.
+      - name: player_url
+        description: Most recently persisted source URL for this player.
+
+  - name: dim_maps
+    description: >
+      Unique map catalog. Grain: one row per distinct map name present in
+      stg_maps. Intended consumers: map-based filtering and analytics.
+    columns:
+      - name: map_name
+        description: Distinct map name. Primary key; grain of this model.

--- a/dbt/models/marts/dim_maps.sql
+++ b/dbt/models/marts/dim_maps.sql
@@ -1,0 +1,25 @@
+-- Dimension: unique map catalog.
+--
+-- Grain: one row per distinct map name. Sourced from the map names present in
+-- stg_maps. Additional map attributes (active-pool flag, map group) are
+-- deferred until they are derivable.
+--
+-- Intended consumers: map-based filtering and analytics.
+
+with maps as (
+
+    select * from {{ ref('stg_maps') }}
+
+),
+
+final as (
+
+    select distinct
+        map_name
+
+    from maps
+    where map_name is not null
+
+)
+
+select * from final

--- a/dbt/models/marts/dim_players.sql
+++ b/dbt/models/marts/dim_players.sql
@@ -3,7 +3,9 @@
 -- Grain: one row per player, keyed by player_id. The parsed player rows repeat
 -- identity fields across every map a player appears on, and a player_name can
 -- change over time, so this dimension keeps the most recently persisted
--- identity per player_id (by inserted_at).
+-- identity per player_id (by inserted_at). Rows persisted in the same batch
+-- share an inserted_at, so map_id breaks ties to keep the pick deterministic
+-- across rebuilds.
 --
 -- Intended consumers: filtering by player and joining player metadata onto the
 -- fact tables.
@@ -22,7 +24,7 @@ ranked as (
         player_url,
         row_number() over (
             partition by player_id
-            order by inserted_at desc nulls last
+            order by inserted_at desc nulls last, map_id desc
         ) as identity_rank
 
     from players

--- a/dbt/models/marts/dim_players.sql
+++ b/dbt/models/marts/dim_players.sql
@@ -1,0 +1,45 @@
+-- Dimension: stable player identity.
+--
+-- Grain: one row per player, keyed by player_id. The parsed player rows repeat
+-- identity fields across every map a player appears on, and a player_name can
+-- change over time, so this dimension keeps the most recently persisted
+-- identity per player_id (by inserted_at).
+--
+-- Intended consumers: filtering by player and joining player metadata onto the
+-- fact tables.
+
+with players as (
+
+    select * from {{ ref('stg_players') }}
+
+),
+
+ranked as (
+
+    select
+        player_id,
+        player_name,
+        player_url,
+        row_number() over (
+            partition by player_id
+            order by inserted_at desc nulls last
+        ) as identity_rank
+
+    from players
+    where player_id is not null
+
+),
+
+final as (
+
+    select
+        player_id,
+        player_name,
+        player_url
+
+    from ranked
+    where identity_rank = 1
+
+)
+
+select * from final

--- a/dbt/models/marts/fact_matches.sql
+++ b/dbt/models/marts/fact_matches.sql
@@ -1,0 +1,53 @@
+-- Fact: clean match-level facts.
+--
+-- Grain: one row per match, keyed by match_id. Built from stg_matches, with
+-- map_count derived from stg_maps and losing_team derived from the winner and
+-- the two team names.
+--
+-- Intended consumers: recent match listings, event-level match analysis, and
+-- team performance analysis.
+
+with matches as (
+
+    select * from {{ ref('stg_matches') }}
+
+),
+
+map_counts as (
+
+    select
+        match_id,
+        count(*) as map_count
+
+    from {{ ref('stg_maps') }}
+    group by match_id
+
+),
+
+final as (
+
+    select
+        matches.match_id,
+        matches.event,
+        matches.team1,
+        matches.team2,
+        matches.score1,
+        matches.score2,
+        matches.match_winner as winning_team,
+        case
+            when matches.match_winner = matches.team1 then matches.team2
+            else matches.team1
+        end as losing_team,
+        matches.match_type,
+        matches.date as match_date,
+        matches.forfeit,
+        coalesce(map_counts.map_count, 0) as map_count,
+        matches.data_complete
+
+    from matches
+    left join map_counts
+        on matches.match_id = map_counts.match_id
+
+)
+
+select * from final

--- a/dbt/models/marts/fact_matches.sql
+++ b/dbt/models/marts/fact_matches.sql
@@ -2,7 +2,8 @@
 --
 -- Grain: one row per match, keyed by match_id. Built from stg_matches, with
 -- map_count derived from stg_maps and losing_team derived from the winner and
--- the two team names.
+-- the two team names. losing_team is null when the winner is null or does not
+-- match either team name, rather than guessing a loser.
 --
 -- Intended consumers: recent match listings, event-level match analysis, and
 -- team performance analysis.
@@ -36,7 +37,7 @@ final as (
         matches.match_winner as winning_team,
         case
             when matches.match_winner = matches.team1 then matches.team2
-            else matches.team1
+            when matches.match_winner = matches.team2 then matches.team1
         end as losing_team,
         matches.match_type,
         matches.date as match_date,

--- a/dbt/models/marts/fact_player_map_stats.sql
+++ b/dbt/models/marts/fact_player_map_stats.sql
@@ -1,0 +1,52 @@
+-- Fact: player performance at the player-map grain.
+--
+-- Grain: one row per player per map, keyed by (map_id, player_id).
+-- Built directly on the int_match_player_stats intermediate model, which
+-- already carries the reusable staging join, so this mart is a clean
+-- analytics-facing projection of that enriched player-map dataset.
+--
+-- Intended consumers: player performance lookups, player map splits, and
+-- rating/ADR trend analysis (including the API read paths).
+
+with enriched as (
+
+    select * from {{ ref('int_match_player_stats') }}
+
+),
+
+final as (
+
+    select
+        -- keys
+        match_id,
+        map_id,
+        player_id,
+
+        -- identity / context
+        player_name,
+        team_name,
+        event,
+        match_date,
+        match_winner,
+        map_name,
+        map_order,
+        map_date,
+
+        -- performance
+        kills,
+        deaths,
+        assists,
+        headshots,
+        opening_kills,
+        opening_deaths,
+        kast,
+        adr,
+        rating,
+        kd_diff,
+        fk_diff
+
+    from enriched
+
+)
+
+select * from final

--- a/dbt/models/marts/fact_player_map_stats.sql
+++ b/dbt/models/marts/fact_player_map_stats.sql
@@ -31,19 +31,27 @@ final as (
         map_name,
         map_order,
         map_date,
+        map_winner,
+        map_team1_score,
+        map_team2_score,
 
         -- performance
         kills,
         deaths,
         assists,
+        flash_assists,
         headshots,
         opening_kills,
         opening_deaths,
+        traded_deaths,
+        multi_kills,
+        clutches_won,
         kast,
         adr,
         rating,
         kd_diff,
-        fk_diff
+        fk_diff,
+        round_swing
 
     from enriched
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -20,7 +20,8 @@ Current priorities:
   sizes) and a schedulable entry point
 - continue Phase 4 (dbt) without moving ingestion responsibilities into
   dbt: the project is initialized (#109), staging models exist (#110),
-  the first intermediate model exists (#111), and marts are next;
+  the first intermediate model exists (#111), the initial marts exist (#112),
+  and dbt tests are next;
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -705,13 +706,15 @@ writes into.
   Postgres profile, sources declared for `matches`, `maps`, `players`
 - [x] Create staging models (`stg_matches`, `stg_maps`, `stg_players`) (#110):
   thin views over the declared sources with documented grains
-- [ ] Create intermediate models for reusable joins (#111):
+- [x] Create intermediate models for reusable joins (#111):
   - [x] `int_match_player_stats` built - factors the reusable stg_players ->
     stg_maps -> stg_matches join (grain: one row per player per map)
-  - [ ] at least one downstream mart consumes it - closes the #111
-    "used by a downstream mart" criterion; lands with the marts (#112)
-- [ ] Create marts (`fact_*`, `dim_*`) - the first mart consumes
-  `int_match_player_stats`, closing the #111 downstream-usage criterion
+  - [x] `fact_player_map_stats` (#112) consumes it - closes the #111
+    "used by a downstream mart" criterion
+- [x] Create marts (`fact_*`, `dim_*`) (#112): `fact_player_map_stats`,
+  `fact_matches`, `dim_players`, and `dim_maps` as tables, each with a
+  documented grain. `fact_player_map_stats` is built on
+  `int_match_player_stats`.
 - [ ] Add dbt tests (`not_null`, `unique`, `relationships`)
 - [ ] Generate lineage/docs
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -391,6 +391,12 @@ Possible responsibilities:
 
 # 3. Mart Layer
 
+Status: an initial mart set is implemented (#112) under `dbt/models/marts/` as
+tables, documented in `dbt/models/marts/_marts__models.yml`:
+`fact_player_map_stats` (player-per-map, built on `int_match_player_stats`),
+`fact_matches` (per match), `dim_players` (per player), and `dim_maps` (per map
+name). The other fact/dim models below remain planning-only.
+
 The mart layer contains business-ready models intended for analytics, reporting, and API use.
 
 These should be the cleanest and most trusted representations of the data.


### PR DESCRIPTION
## Summary

Add the initial dbt mart layer for Phase 4: an analytics-facing set of fact and
dimension tables built from the staging and intermediate layers.
`fact_player_map_stats` consumes `int_match_player_stats`, which also closes the
last open acceptance criterion of #111.

## Related Issue

Closes #112
Closes #111

## Scope

- `dbt/models/marts/fact_player_map_stats.sql`: player performance at the
  player-map grain `(map_id, player_id)`, projected from
  `int_match_player_stats`.
- `dbt/models/marts/fact_matches.sql`: match-level facts (grain: one row per
  match) from `stg_matches`, with `map_count` derived from `stg_maps` and
  `losing_team` derived from the winner.
- `dbt/models/marts/dim_players.sql`: stable player identity (grain: one row per
  `player_id`), most recent name/url per player.
- `dbt/models/marts/dim_maps.sql`: unique map-name catalog (grain: one row per
  map name).
- `dbt/models/marts/_marts__models.yml`: grain and column docs.
- `dbt/dbt_project.yml`: materialize `marts/` models as tables.
- `docs/backlog.md`, `docs/dbt_models.md`: status updates.

## Out of Scope

- `dim_teams` and `dim_events` - deferred until clean team/event keys exist;
  staging currently exposes them only as strings.
- The other planned fact models (`fact_player_match_stats`) and `int_*` models.
- dbt tests (`not_null`, `unique`, `relationships`) - the next Phase 4 item.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Additive dbt-only change. The marts are read-only tables built from
existing staging/intermediate models; no schema, ingestion behavior, or
dependencies change. The default dbt target is local, so nothing runs against a
deployed database implicitly.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: the mart models are the explicitly requested work of issue #112 (Phase 4).
They read only staging and intermediate models (`ref`), never raw sources, and
no application/source schema changed.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: Added `_marts__models.yml` grain/column docs and a mart-layer
implementation-status note to `docs/dbt_models.md`.

Backlog: Updated

Reason: Checked off the Phase 4 "Create marts" item and both #111 sub-items
(the mart now consumes the intermediate model), and moved the "next" pointer to
dbt tests.

## Verification

Commands run:

- `docker compose --env-file .env.example up -d db`
- `env DB_HOST=localhost ... uv run alembic -c cs2_analytics/alembic.ini upgrade head`
- seeded two matches, three maps, and three player rows (including a repeated
  player)
- `uv run dbt run --project-dir dbt --profiles-dir dbt`
- `uv run dbt parse --project-dir dbt --profiles-dir dbt`
- grain and derived-field checks against the mart tables

Results:

- `dbt run` builds all eight models (PASS=8): four staging/intermediate views
  and four mart tables.
- `fact_matches` derives `losing_team` correctly and reports `map_count` of 2
  and 1 for the two matches.
- `fact_player_map_stats` returns three rows with distinct `(map_id, player_id)`
  grain, enriched with match/map context.
- `dim_players` collapses the repeated player to a single identity row.
- `dim_maps` lists the three distinct map names.
- `dbt parse` succeeds.

## Review Notes

- `fact_player_map_stats` is the mart that consumes `int_match_player_stats`,
  closing the "used by a downstream mart" criterion from #111; this PR therefore
  closes both #112 and #111.
- Immediate follow-up: dbt tests (`not_null`, `unique`, `relationships`) over
  the staging, intermediate, and mart models.
