### PR TITLE
Add dbt data tests across sources, staging, intermediate, and marts (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,16 +296,20 @@ python -m pytest
 dbt is installed with the dev dependencies (`uv sync`). Its default target is a
 **local** Postgres, so `dbt run` never touches a deployed database by accident.
 dbt uses its own `DBT_DB_*` variables (with local defaults, see `.env.example`)
-and does not read `.env` itself. Start a local Postgres, load the schema, then
-run dbt:
+and does not read `.env` itself. Start a local Postgres, load the schema,
+install dbt packages, then build (models plus data tests):
 
 ```sh
 docker compose --env-file .env.example up -d db
 env DB_HOST=localhost DB_USER=postgres DB_PASS=change_me DB_NAME=cs2_db \
   uv run alembic -c cs2_analytics/alembic.ini upgrade head
+uv run dbt deps --project-dir dbt --profiles-dir dbt
 uv run dbt debug --project-dir dbt --profiles-dir dbt
-uv run dbt run --project-dir dbt --profiles-dir dbt
+uv run dbt build --project-dir dbt --profiles-dir dbt
 ```
+
+`dbt build` runs the models and their data tests together; use `dbt run` or
+`dbt test` for either half on its own.
 
 To run against a deployed database on purpose, export its `DB_*` values and
 name the `prod` target explicitly:

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -8,6 +8,10 @@
 name: "cs2_analytics"
 version: "1.0.0"
 
+# The generic-test `arguments:` nesting used in the model yml requires
+# dbt 1.10+; fail fast on older installs instead of misparsing tests.
+require-dbt-version: [">=1.10.0", "<2.0.0"]
+
 profile: "cs2_analytics"
 
 model-paths: ["models"]

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -9,13 +9,29 @@ models:
       stg_matches join into one place so downstream marts do not repeat it.
       Joins and context attachment only; no aggregation. The canonical map_name
       comes from stg_maps.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - map_id
+              - player_id
     columns:
       - name: map_id
         description: Map identifier; part of the grain. Joins to stg_maps.map_id.
+        data_tests:
+          - not_null
       - name: player_id
         description: Player identifier; part of the grain.
+        data_tests:
+          - not_null
       - name: match_id
         description: Parent match identifier, carried from stg_maps.match_id.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_matches')
+                field: match_id
       - name: team1
         description: First team name for the parent match.
       - name: team2

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -119,15 +119,18 @@ models:
         description: Series score for team2.
       - name: winning_team
         description: >
-          Winning team name (equals team1 or team2). Null when the source has
-          not recorded a winner; the current source schema enforces a non-null
-          winner, which the not_null test asserts at this layer.
+          Winning team name (equals team1 or team2). Non-null; the source
+          schema enforces a recorded winner and the not_null test asserts it
+          at this layer.
         data_tests:
           - not_null
       - name: losing_team
         description: >
-          Losing team name, derived as the team that is not the winner. Null
-          when the winner is null or does not match either team name.
+          Losing team name, derived as the team that is not the winner.
+          Non-null in practice: the source schema requires the winner to equal
+          team1 or team2, so the derivation always resolves.
+        data_tests:
+          - not_null
       - name: match_type
         description: Match format label, such as best-of series type.
       - name: match_date

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -7,13 +7,33 @@ models:
       player per map, keyed by (map_id, player_id). Projected from
       int_match_player_stats. Intended consumers: player performance lookups,
       player map splits, and rating/ADR trend analysis.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - map_id
+              - player_id
     columns:
       - name: match_id
         description: Parent match identifier.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('fact_matches')
+                field: match_id
       - name: map_id
         description: Map identifier; part of the grain.
+        data_tests:
+          - not_null
       - name: player_id
         description: Player identifier; part of the grain.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_players')
+                field: player_id
       - name: player_name
         description: Player name as parsed for this map.
       - name: team_name
@@ -26,6 +46,12 @@ models:
         description: Winning team name for the parent match.
       - name: map_name
         description: Canonical map name.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_maps')
+                field: map_name
       - name: map_order
         description: Position of this map within the match, from 1 to 5.
       - name: map_date
@@ -78,6 +104,9 @@ models:
     columns:
       - name: match_id
         description: Match identifier. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null
       - name: event
         description: Event or tournament name, when available.
       - name: team1
@@ -91,7 +120,10 @@ models:
       - name: winning_team
         description: >
           Winning team name (equals team1 or team2). Null when the source has
-          not recorded a winner.
+          not recorded a winner; the current source schema enforces a non-null
+          winner, which the not_null test asserts at this layer.
+        data_tests:
+          - not_null
       - name: losing_team
         description: >
           Losing team name, derived as the team that is not the winner. Null
@@ -100,10 +132,14 @@ models:
         description: Match format label, such as best-of series type.
       - name: match_date
         description: Match date/time.
+        data_tests:
+          - not_null
       - name: forfeit
         description: Whether the match was recorded as a forfeit.
       - name: map_count
         description: Number of maps recorded for this match in stg_maps.
+        data_tests:
+          - not_null
       - name: data_complete
         description: >
           Whether the source match row satisfies its required-field contract.
@@ -117,8 +153,13 @@ models:
     columns:
       - name: player_id
         description: Player identifier. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null
       - name: player_name
         description: Most recently persisted player name for this player.
+        data_tests:
+          - not_null
       - name: player_url
         description: Most recently persisted source URL for this player.
 
@@ -129,3 +170,6 @@ models:
     columns:
       - name: map_name
         description: Distinct map name. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null

--- a/dbt/models/staging/_ingestion__sources.yml
+++ b/dbt/models/staging/_ingestion__sources.yml
@@ -5,18 +5,47 @@ sources:
     description: >
       Parsed application tables written by the ingestion pipeline and owned
       by Alembic migrations. dbt reads these as sources and never manages
-      their schema.
+      their schema. Grain tests here catch ingestion-side grain drift at the
+      boundary; relationship tests live on the staging models, which are thin
+      views over these tables.
     schema: public
     tables:
       - name: matches
         description: >
           One row per professional match: teams, series score, winner,
           event, match type, and match date.
+        columns:
+          - name: match_id
+            description: Primary key; grain of this table.
+            data_tests:
+              - unique
+              - not_null
       - name: maps
         description: >
           One row per map played within a match, keyed by map_id with a
           foreign key to matches and a per-match map_order.
+        columns:
+          - name: map_id
+            description: Primary key; grain of this table.
+            data_tests:
+              - unique
+              - not_null
       - name: players
         description: >
           Per-player per-map performance statistics (kills, deaths, ADR,
           KAST, rating, and related fields), keyed by (map_id, player_id).
+        data_tests:
+          - dbt_utils.unique_combination_of_columns:
+              arguments:
+                combination_of_columns:
+                  - map_id
+                  - player_id
+        columns:
+          - name: map_id
+            description: Part of the grain.
+            data_tests:
+              - not_null
+          - name: player_id
+            description: Part of the grain.
+            data_tests:
+              - not_null

--- a/dbt/models/staging/_staging__models.yml
+++ b/dbt/models/staging/_staging__models.yml
@@ -14,6 +14,9 @@ models:
     columns:
       - name: match_id
         description: Source match identifier. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null
       - name: match_url
         description: Canonical source URL for the match.
       - name: team1
@@ -28,6 +31,8 @@ models:
         description: >
           Winning team name (source column winner). Equals either team1 or
           team2.
+        data_tests:
+          - not_null
       - name: event
         description: Event or tournament name, when available.
       - name: match_type
@@ -36,6 +41,8 @@ models:
         description: Whether the match was recorded as a forfeit.
       - name: date
         description: Match date/time as parsed from the source.
+        data_tests:
+          - not_null
       - name: inserted_at
         description: >
           First persistence timestamp for the source row (source column
@@ -59,14 +66,25 @@ models:
     columns:
       - name: map_id
         description: Source map-stats identifier. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null
       - name: match_id
         description: Parent match identifier; foreign key to stg_matches.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_matches')
+                field: match_id
       - name: map_url
         description: Canonical source URL for the map stats page.
       - name: map_order
         description: Position of this map within the match, from 1 to 5.
       - name: map_name
         description: Map name, such as Mirage or Inferno.
+        data_tests:
+          - not_null
       - name: team1_score
         description: Round score for team1 on this map.
       - name: team2_score
@@ -96,13 +114,29 @@ models:
       timezone-aware (TIMESTAMPTZ); downstream models should not assume UTC-aware
       semantics. Audit-field timezone normalization is deferred (see
       docs/schema_target_pre_dbt.md).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - map_id
+              - player_id
     columns:
       - name: map_id
         description: Map identifier; foreign key to stg_maps. Part of the grain.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_maps')
+                field: map_id
       - name: player_id
         description: Player identifier. Part of the grain.
+        data_tests:
+          - not_null
       - name: player_name
         description: Player name as parsed for this map.
+        data_tests:
+          - not_null
       - name: player_url
         description: Canonical source URL for the player, when available.
       - name: map_name

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -1,0 +1,5 @@
+packages:
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+sha1_hash: a4da77dcded39caf20bd661f0098cbffd9735800

--- a/dbt/packages.yml
+++ b/dbt/packages.yml
@@ -1,0 +1,10 @@
+# dbt package dependencies. Install with:
+#
+#   uv run dbt deps --project-dir dbt --profiles-dir dbt
+#
+# dbt_utils provides unique_combination_of_columns, used to test the
+# (map_id, player_id) grain of the player models, which spans two columns
+# and cannot be expressed with the built-in single-column unique test.
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.3.0", "<2.0.0"]

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,7 +21,7 @@ Current priorities:
 - continue Phase 4 (dbt) without moving ingestion responsibilities into
   dbt: the project is initialized (#109), staging models exist (#110),
   the first intermediate model exists (#111), the initial marts exist (#112),
-  and dbt tests are next;
+  data tests cover every layer (#113), and lineage/docs generation is next;
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -715,7 +715,11 @@ writes into.
   `fact_matches`, `dim_players`, and `dim_maps` as tables, each with a
   documented grain. `fact_player_map_stats` is built on
   `int_match_player_stats`.
-- [ ] Add dbt tests (`not_null`, `unique`, `relationships`)
+- [x] Add dbt tests (`not_null`, `unique`, `relationships`) (#113): grain
+  `unique`/`not_null` tests on every source, staging, intermediate, and mart
+  model; `relationships` tests on the key joins; multi-column grains tested via
+  `dbt_utils.unique_combination_of_columns` (new `dbt/packages.yml`
+  dependency). CI integration deferred to its own review.
 - [ ] Generate lineage/docs
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -652,6 +652,13 @@ This should be decided after actual query patterns and table sizes are understoo
 
 ## Testing Strategy
 
+Status: implemented (#113). Grain `unique`/`not_null` tests cover every
+source table, staging model, intermediate model, and mart; `relationships`
+tests cover the key joins (maps -> matches, player rows -> maps/matches, and
+fact -> dim joins). Multi-column `(map_id, player_id)` grains use
+`dbt_utils.unique_combination_of_columns` (see `dbt/packages.yml`; install
+with `dbt deps`). Run everything with `dbt build`.
+
 dbt tests should be added to ensure trust in transformed models.
 
 ### Core test types


### PR DESCRIPTION
## Summary

Add dbt data tests (`not_null`, `unique`, `relationships`) across the source
declarations, staging models, the intermediate model, and the marts, so the
grain and relationship guarantees from Phase 3.5 are enforced in the
transformation layer instead of assumed by consumers.

## Related Issue

Closes #113

## Scope

- Grain tests on every layer: `unique` + `not_null` on `match_id` (source
  `matches`, `stg_matches`, `fact_matches`), `map_id` (source `maps`,
  `stg_maps`), `player_id` (`dim_players`), and `map_name` (`dim_maps`).
- The two-column `(map_id, player_id)` grain of source `players`,
  `stg_players`, `int_match_player_stats`, and `fact_player_map_stats` is
  tested with `dbt_utils.unique_combination_of_columns`.
- `relationships` tests on the key joins: `stg_maps.match_id -> stg_matches`,
  `stg_players.map_id -> stg_maps`, `int_match_player_stats.match_id ->
  stg_matches`, and `fact_player_map_stats -> fact_matches / dim_players /
  dim_maps`.
- `not_null` on load-bearing non-key columns the marts depend on
  (`match_winner`, match date, `map_name`, `player_name`, `winning_team`,
  `losing_team`, `map_count`). `losing_team` is guaranteed by the source
  CHECK constraint (winner equals team1 or team2), so the test asserts it.
- New `dbt/packages.yml` pinning `dbt-labs/dbt_utils` `>=1.3.0,<2.0.0`
  (resolved 1.4.1 in the committed `package-lock.yml`); `dbt_packages/` was
  already gitignored. **This is a dependency addition.**
- Generic tests with arguments use the dbt 1.11 `arguments:` nesting, so the
  build is deprecation-warning free. `dbt_project.yml` now sets
  `require-dbt-version: [">=1.10.0", "<2.0.0"]` so older dbt installs fail
  fast instead of misparsing the nested arguments.
- `README.md`: the dbt workflow now includes `dbt deps` and `dbt build`.
- `docs/dbt_models.md`, `docs/backlog.md`: status updates.

## Out of Scope

- CI integration of `dbt build`/`dbt test` - deferred to its own review per
  the issue, since CI changes need separate human review.
- `accepted_values` tests and source freshness - nothing in the current
  models has a stable enumerated domain yet.
- Lineage/docs generation - the next Phase 4 item.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Additive test definitions in yml plus one dev-time dbt package. No
model SQL, schema, ingestion behavior, or Python dependencies change. The
dependency addition (`dbt_utils`) is called out explicitly for review.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: the tests are the explicitly requested work of issue #113 (Phase 4).
They are analytics-layer checks only and do not replace pytest coverage of
ingestion behavior.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README dbt workflow now documents `dbt deps` and `dbt build`;
`docs/dbt_models.md` testing strategy is marked implemented with what is
covered.

Backlog: Updated

Reason: Checked off the Phase 4 dbt-tests item (#113) and moved the "next"
pointer to lineage/docs generation.

## Verification

Commands run:

- `docker compose --env-file .env.example up -d db`
- `env DB_HOST=localhost ... uv run alembic -c cs2_analytics/alembic.ini upgrade head`
- seeded three matches, three maps, and three player rows (including a
  repeated player)
- `uv run dbt deps --project-dir dbt --profiles-dir dbt`
- `uv run dbt build --project-dir dbt --profiles-dir dbt`
- negative check: deleted a `dim_players` row, re-ran
  `dbt test --select fact_player_map_stats`, then rebuilt

Results:

- `dbt build` passes 53 of 53 resources (8 models, 45 data tests) with zero
  warnings and zero deprecation notices.
- The negative check fails exactly as intended: the
  `fact_player_map_stats.player_id -> dim_players` relationships test reports
  the two orphaned fact rows; a full rebuild returns to 53/53 green.

## Review Notes

- The dependency addition (`dbt/packages.yml` + `package-lock.yml`) is the one
  item that needs explicit reviewer sign-off under the dependency-change
  policy. `dbt_utils` is only needed for `unique_combination_of_columns` on
  the two-column player grain; the alternative was hand-written singular
  tests, which are more code to maintain for a weaker guarantee.
- Source-level tests cover grain only; relationship tests live on the staging
  models (thin views over the same tables) to avoid duplicating every check
  at two layers.
- Immediate follow-up per the backlog: dbt lineage/docs generation.

