### PR TITLE
Document dbt lineage/docs generation workflow (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,18 @@ uv run dbt build --project-dir dbt --profiles-dir dbt
 `dbt build` runs the models and their data tests together; use `dbt run` or
 `dbt test` for either half on its own.
 
+To browse the model/column documentation and the lineage graph, generate and
+serve the dbt docs site locally (after a `dbt run` or `dbt build` so the
+catalog reflects the built tables):
+
+```sh
+uv run dbt docs generate --project-dir dbt --profiles-dir dbt
+uv run dbt docs serve --project-dir dbt --profiles-dir dbt
+```
+
+The generated site lives in `dbt/target/`, which is gitignored; docs are
+generated on demand, not committed or published.
+
 To run against a deployed database on purpose, export its `DB_*` values and
 name the `prod` target explicitly:
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -21,7 +21,8 @@ Current priorities:
 - continue Phase 4 (dbt) without moving ingestion responsibilities into
   dbt: the project is initialized (#109), staging models exist (#110),
   the first intermediate model exists (#111), the initial marts exist (#112),
-  data tests cover every layer (#113), and lineage/docs generation is next;
+  data tests cover every layer (#113), lineage/docs generation is done
+  (#114), and the SCD2 player-roster-history snapshot (#130) is next;
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -720,7 +721,12 @@ writes into.
   model; `relationships` tests on the key joins; multi-column grains tested via
   `dbt_utils.unique_combination_of_columns` (new `dbt/packages.yml`
   dependency). CI integration deferred to its own review.
-- [ ] Generate lineage/docs
+- [x] Generate lineage/docs (#114): every source, model, and physical model
+  column carries a yml description; `dbt docs generate` builds the site and
+  the lineage graph shows the intended source -> staging -> intermediate ->
+  mart layering; generation/viewing documented in the README and
+  `docs/dbt_models.md`; generated output stays gitignored in `dbt/target/`
+  rather than committed or published
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic
 
 ---

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -701,6 +701,23 @@ dbt tests should be added to ensure trust in transformed models.
 
 ## Documentation Goals
 
+Status: implemented (#114). Every source table, model, and physical model
+column has a description in the model yml, and the generated lineage graph
+shows the intended layering: sources feed only the staging views, staging
+feeds the intermediate model and the marts, and `fact_player_map_stats` is
+built from `int_match_player_stats`. Generate and view the docs site with:
+
+```sh
+uv run dbt docs generate --project-dir dbt --profiles-dir dbt
+uv run dbt docs serve --project-dir dbt --profiles-dir dbt
+```
+
+Run `dbt run` or `dbt build` first so the catalog reflects the built tables.
+Generated output goes to `dbt/target/`, which is gitignored: docs are
+generated on demand rather than committed or published, and project
+documentation under `docs/architecture/` remains the source of truth for
+architecture boundaries. dbt docs cover the transformation layer only.
+
 dbt documentation should help explain:
 
 - model purpose
@@ -708,13 +725,13 @@ dbt documentation should help explain:
 - important columns
 - lineage between models
 
-Each model should eventually have:
+Each model should have:
 
 - a short description
 - important column descriptions
 - tests defined where appropriate
 
-This will make the project stronger both for maintainability and portfolio presentation.
+This makes the project stronger both for maintainability and portfolio presentation.
 
 ---
 


### PR DESCRIPTION
## Summary

Document the dbt lineage/docs generation workflow and verify the lineage
graph. The model yml already carries descriptions for every source table,
model, and physical model column (built up across #110-#113), so this
branch verifies the docs site end to end and documents how to generate and
view it; no model SQL or yml changes were needed.

## Related Issue

Closes #114

## Scope

- `README.md`: the dbt workflow section now documents
  `dbt docs generate` and `dbt docs serve`, and records the decision that
  generated output stays gitignored in `dbt/target/` (generated on demand,
  not committed or published).
- `docs/dbt_models.md`: the Documentation Goals section is marked
  implemented (#114) with the verified lineage layering, the
  generate/serve commands, and the boundary note that
  `docs/architecture/*` remains the source of truth for architecture
  boundaries; dbt docs cover the transformation layer only.
- `docs/backlog.md`: Phase 4 lineage/docs item checked off; the "next"
  pointer moves to the SCD2 player-roster-history snapshot (#130).

## Out of Scope

- Publishing the docs site (GitHub Pages already serves the frontend;
  the issue calls for generated output not to be committed).
- New descriptions or yml changes - a catalog-vs-manifest audit found
  zero undocumented physical columns, so none were needed.
- `persist_docs` (pushing descriptions into database comments) - not
  requested; can be its own decision later.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Docs-only branch - README and two docs files. No model SQL, yml,
schema, dependency, or Python changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: this is the explicitly requested lineage/docs work of issue #114
(Phase 4).

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: This branch is the documentation - README dbt workflow and
`docs/dbt_models.md` now cover docs generation/viewing and the
not-committed decision.

Backlog: Updated

Reason: Checked off the Phase 4 lineage/docs item (#114) and moved the
"next" pointer to the SCD2 snapshot (#130).

## Verification

Commands run:

- `docker compose --env-file .env.example up -d db`
- `env DB_HOST=localhost ... uv run alembic -c cs2_analytics/alembic.ini upgrade head`
- seeded three matches, three maps, and three player rows
- `uv run dbt deps` / `uv run dbt build --project-dir dbt --profiles-dir dbt`
- `uv run dbt docs generate --project-dir dbt --profiles-dir dbt`
- `uv run dbt docs serve --project-dir dbt --profiles-dir dbt --port 8123`
  plus a curl smoke test against the served site
- audited `target/manifest.json` parent_map and compared
  `target/catalog.json` columns against yml-documented columns

Results:

- `dbt build` passes 53 of 53 resources (8 models, 45 data tests).
- `dbt docs generate` succeeds; `index.html`, `manifest.json`, and
  `catalog.json` are produced and the served site responds 200.
- The lineage graph matches the intended layering: sources feed only the
  staging views; staging feeds `int_match_player_stats`, `fact_matches`,
  `dim_players`, and `dim_maps`; `fact_player_map_stats` is built from
  `int_match_player_stats`. No mart reads a source directly.
- The catalog audit reports zero physical model columns without a yml
  description.

## Review Notes

- The one decision embedded here: dbt docs are generated on demand and
  never committed or published (`dbt/target/` was already gitignored).
  Publishing (for example to GitHub Pages) can be revisited later if the
  portfolio wants a public lineage view.
- Immediate follow-up per the backlog: the SCD2 player-roster-history
  snapshot (#130).
