### PR TITLE
Add SCD2 player-roster-history snapshot (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,12 @@ uv run dbt debug --project-dir dbt --profiles-dir dbt
 uv run dbt build --project-dir dbt --profiles-dir dbt
 ```
 
-`dbt build` runs the models and their data tests together; use `dbt run` or
-`dbt test` for either half on its own.
+`dbt build` runs the models, snapshots, and their data tests together; use
+`dbt run`, `dbt snapshot`, or `dbt test` for any part on its own. The
+`player_roster_history_snapshot` snapshot records SCD2 player-to-team roster
+history: each run compares every player's current team against the recorded
+history and effective-dates any changes, so history accrues across runs
+(and resets with the local database).
 
 To browse the model/column documentation and the lineage graph, generate and
 serve the dbt docs site locally (after a `dbt run` or `dbt build` so the

--- a/README.md
+++ b/README.md
@@ -313,7 +313,10 @@ uv run dbt build --project-dir dbt --profiles-dir dbt
 `player_roster_history_snapshot` snapshot records SCD2 player-to-team roster
 history: each run compares every player's current team against the recorded
 history and effective-dates any changes, so history accrues across runs
-(and resets with the local database).
+(and resets with the local database). On a fresh database, run `dbt build`
+(or `dbt snapshot`) before a standalone `dbt run`: `dbt run` does not
+execute snapshots, and `dim_player_roster_history` reads the snapshot
+table.
 
 To browse the model/column documentation and the lineage graph, generate and
 serve the dbt docs site locally (after a `dbt run` or `dbt build` so the

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -94,3 +94,32 @@ models:
         description: Round-swing metric on this map.
       - name: rating
         description: Performance rating from the source on this map.
+
+  - name: int_player_current_team
+    description: >
+      Each player's current team as observed in match data. Grain: one row
+      per player, keyed by player_id. The ingestion pipeline does not
+      populate a roster table, so current membership is derived as the
+      team_name from the player's most recent map that recorded a team
+      (map_date desc, map_id desc as the deterministic tie-break). Rows with
+      a null player_id or null team_name are excluded. This is the source
+      relation for the player_roster_history_snapshot SCD2 snapshot, so its
+      output must stay deterministic across runs.
+    columns:
+      - name: player_id
+        description: Player identifier. Primary key; grain of this model.
+        data_tests:
+          - unique
+          - not_null
+      - name: team_name
+        description: >
+          Team the player represented on their most recent team-recording
+          map.
+        data_tests:
+          - not_null
+      - name: observed_map_date
+        description: >
+          Map date of the most recent map that recorded a team for this
+          player.
+        data_tests:
+          - not_null

--- a/dbt/models/intermediate/int_player_current_team.sql
+++ b/dbt/models/intermediate/int_player_current_team.sql
@@ -1,0 +1,53 @@
+-- Intermediate model: each player's current team as observed in match data.
+--
+-- Grain: one row per player, keyed by player_id. The ingestion pipeline does
+-- not populate a roster table; the only roster signal is the team a player
+-- represented on each map. This model derives "current team" as the team_name
+-- from the player's most recent map that recorded a team, so it is the
+-- deterministic source relation for the player_roster_history_snapshot SCD2
+-- snapshot.
+--
+-- Determinism: rows persisted in the same batch can share a map_date, so
+-- map_id breaks ties. The output depends only on ingested rows, never on
+-- run order, so re-running against unchanged sources yields identical rows
+-- and cannot corrupt recorded snapshot history.
+--
+-- Rows with a null player_id or null team_name are excluded: a membership
+-- observation needs both sides of the player-team pair.
+
+with player_maps as (
+
+    select * from {{ ref('int_match_player_stats') }}
+
+),
+
+ranked as (
+
+    select
+        player_id,
+        team_name,
+        map_date,
+        row_number() over (
+            partition by player_id
+            order by map_date desc, map_id desc
+        ) as recency_rank
+
+    from player_maps
+    where player_id is not null
+      and team_name is not null
+
+),
+
+final as (
+
+    select
+        player_id,
+        team_name,
+        map_date as observed_map_date
+
+    from ranked
+    where recency_rank = 1
+
+)
+
+select * from final

--- a/dbt/models/intermediate/int_player_current_team.sql
+++ b/dbt/models/intermediate/int_player_current_team.sql
@@ -29,7 +29,7 @@ ranked as (
         map_date,
         row_number() over (
             partition by player_id
-            order by map_date desc, map_id desc
+            order by map_date desc nulls last, map_id desc
         ) as recency_rank
 
     from player_maps

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -176,3 +176,59 @@ models:
         data_tests:
           - unique
           - not_null
+
+  - name: dim_player_roster_history
+    description: >
+      SCD2 player-to-team roster membership history. Grain: one row per
+      player-team membership interval, keyed by (player_id, valid_from), with
+      roster_history_key as the surrogate key for downstream joins.
+      Presentation shaping over player_roster_history_snapshot: validity
+      columns renamed, surrogate key added, current interval flagged. Player
+      identity fields stay in dim_players; join on player_id. Intended
+      consumers: roster timelines and point-in-time roster lookups
+      (valid_from <= :as_of and (valid_to > :as_of or valid_to is null)).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - player_id
+              - valid_from
+    columns:
+      - name: roster_history_key
+        description: >
+          Surrogate key for this membership interval, generated from
+          (player_id, valid_from).
+        data_tests:
+          - unique
+          - not_null
+      - name: player_id
+        description: >
+          Player identifier; part of the interval natural key. Joins to
+          dim_players.player_id.
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_players')
+                field: player_id
+      - name: team_name
+        description: Team the player belonged to during this interval.
+        data_tests:
+          - not_null
+      - name: observed_map_date
+        description: >
+          Map date of the player's most recent team-recording map when this
+          interval was opened. Context only.
+      - name: valid_from
+        description: >
+          UTC timestamp when this interval was opened; part of the interval
+          natural key.
+        data_tests:
+          - not_null
+      - name: valid_to
+        description: >
+          UTC timestamp when this interval was closed; null while current.
+      - name: is_current
+        description: Whether this is the player's open (current) interval.
+        data_tests:
+          - not_null

--- a/dbt/models/marts/dim_player_roster_history.sql
+++ b/dbt/models/marts/dim_player_roster_history.sql
@@ -1,0 +1,36 @@
+-- Dimension: SCD2 player-to-team roster membership history.
+--
+-- Grain: one row per player-team membership interval, keyed by
+-- (player_id, valid_from) with roster_history_key as the surrogate key for
+-- downstream joins. Presentation shaping over the
+-- player_roster_history_snapshot SCD2 snapshot only: rename the dbt-managed
+-- validity columns, add the surrogate key, and flag the current interval.
+-- Player identity fields stay in dim_players; consumers join on player_id
+-- rather than duplicating them here.
+--
+-- Point-in-time usage (roster as-of a date): filter
+-- valid_from <= :as_of and (valid_to > :as_of or valid_to is null).
+
+with roster_history as (
+
+    select * from {{ ref('player_roster_history_snapshot') }}
+
+),
+
+final as (
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['player_id', 'dbt_valid_from']) }}
+            as roster_history_key,
+        player_id,
+        team_name,
+        observed_map_date,
+        dbt_valid_from as valid_from,
+        dbt_valid_to as valid_to,
+        dbt_valid_to is null as is_current
+
+    from roster_history
+
+)
+
+select * from final

--- a/dbt/snapshots/_snapshots.yml
+++ b/dbt/snapshots/_snapshots.yml
@@ -1,0 +1,67 @@
+version: 2
+
+snapshots:
+  - name: player_roster_history_snapshot
+    relation: ref('int_player_current_team')
+    description: >
+      SCD2 history of player-to-team roster membership. Grain: one row per
+      player-team membership interval, keyed by (player_id, dbt_valid_from).
+      Each dbt snapshot run compares the current team per player (from
+      int_player_current_team) against the latest recorded row; when the team
+      changes, the open interval is closed (dbt_valid_to is set) and a new
+      interval is opened. Intervals are effective-dated from when the change
+      was observed by a snapshot run, not backdated to the underlying map
+      date; observed_map_date carries the match-data context. The check
+      strategy is used because the source has no reliable roster-change
+      timestamp: a timestamp strategy keyed on map recency would open a new
+      interval every time a player simply played another map. History is
+      additive only; this snapshot never mutates ingestion outputs or
+      existing marts.
+    config:
+      unique_key: player_id
+      strategy: check
+      check_cols: [team_name]
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - player_id
+              - dbt_valid_from
+    columns:
+      - name: player_id
+        description: >
+          Player identifier; the snapshot unique key and part of the interval
+          natural key. Joins to dim_players.player_id.
+        data_tests:
+          - not_null
+      - name: team_name
+        description: >
+          Team the player belonged to during this interval; the tracked
+          (check strategy) column.
+        data_tests:
+          - not_null
+      - name: observed_map_date
+        description: >
+          Map date of the player's most recent team-recording map at the time
+          this interval was opened. Context only; not part of change
+          detection, so it is frozen when the interval is opened rather than
+          updated on every new map.
+      - name: dbt_scd_id
+        description: >
+          dbt-managed surrogate key for this interval row, unique across the
+          snapshot.
+        data_tests:
+          - not_null
+          - unique
+      - name: dbt_valid_from
+        description: >
+          UTC timestamp when this interval was opened; part of the interval
+          natural key.
+        data_tests:
+          - not_null
+      - name: dbt_valid_to
+        description: >
+          UTC timestamp when this interval was closed by a newer observation;
+          null while the interval is current.
+      - name: dbt_updated_at
+        description: dbt-managed timestamp of the run that last wrote this row.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,7 +22,7 @@ Current priorities:
   dbt: the project is initialized (#109), staging models exist (#110),
   the first intermediate model exists (#111), the initial marts exist (#112),
   data tests cover every layer (#113), lineage/docs generation is done
-  (#114), and the SCD2 player-roster-history snapshot (#130) is next;
+  (#114), and the SCD2 player-roster-history snapshot exists (#130);
   Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
   (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
@@ -727,6 +727,15 @@ writes into.
   mart layering; generation/viewing documented in the README and
   `docs/dbt_models.md`; generated output stays gitignored in `dbt/target/`
   rather than committed or published
+- [x] Add SCD2 player-roster-history snapshot (#130):
+  `player_roster_history_snapshot` (check strategy on team_name, keyed on
+  player_id) records player-to-team membership intervals with dbt-managed
+  `dbt_valid_from`/`dbt_valid_to`; sourced from the new deterministic
+  `int_player_current_team` view (latest team-recording map per player);
+  `dim_player_roster_history` shapes it for consumers with a
+  `roster_history_key` surrogate key and `is_current` flag; grain,
+  strategy rationale, and a point-in-time query documented in
+  `docs/dbt_models.md`
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic
 
 ---

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -82,6 +82,9 @@ The dbt project should be organized into three main layers:
 - intermediate
 - marts
 
+Snapshots (SCD2 change tracking) sit alongside the model layers under
+`snapshots/`; see the Snapshot Layer section.
+
 This keeps transformations readable, modular, and maintainable.
 
 ---
@@ -594,6 +597,67 @@ Use cases:
 
 ---
 
+# 4. Snapshot Layer (SCD2)
+
+Status: implemented (#130). One snapshot records player-to-team roster
+membership history as a Slowly Changing Dimension Type 2, with a mart
+dimension shaped on top of it for consumers.
+
+## player_roster_history_snapshot
+
+- Grain: one row per player-team membership interval, keyed by
+  (player_id, dbt_valid_from).
+- Source: `int_player_current_team`, which derives each player's current
+  team as the team_name from their most recent map that recorded a team
+  (the ingestion pipeline does not populate a roster table). The derivation
+  is deterministic (map_date desc, map_id desc tie-break) so re-runs against
+  unchanged sources cannot corrupt recorded history.
+- Strategy: `check` on `team_name`, keyed on `player_id`. The source has no
+  reliable roster-change timestamp, and a `timestamp` strategy keyed on map
+  recency would open a new interval every time a player simply played
+  another map.
+- dbt manages `dbt_valid_from`, `dbt_valid_to`, and `dbt_scd_id`. Intervals
+  are effective-dated from when a snapshot run observed the change, not
+  backdated to the underlying map date; `observed_map_date` carries the
+  match-data context. The first snapshot run seeds each player's current
+  membership with `dbt_valid_from` equal to that run's timestamp.
+- History is additive only. The snapshot never mutates ingestion outputs or
+  existing marts, and it builds in the same database/schema as the models,
+  so resetting the local database also resets locally recorded history.
+
+Run it with `dbt snapshot`, or as part of `dbt build`, which orders it after
+its source model automatically.
+
+## dim_player_roster_history
+
+- Grain: one row per player-team membership interval, keyed by
+  (player_id, valid_from), with `roster_history_key` as the surrogate key
+  for downstream joins.
+- Presentation shaping over the snapshot only: renames `dbt_valid_from` /
+  `dbt_valid_to` to `valid_from` / `valid_to`, adds the surrogate key, and
+  flags the open interval with `is_current`.
+- Player identity fields stay in `dim_players`; consumers join on
+  `player_id` rather than duplicating them here.
+
+Point-in-time query example (roster of a team as of a given date):
+
+```sql
+select
+    roster.player_id,
+    players.player_name
+from dim_player_roster_history as roster
+join dim_players as players
+    on players.player_id = roster.player_id
+where roster.team_name = 'Some Team'
+  and roster.valid_from <= timestamp '2026-06-01'
+  and (
+      roster.valid_to > timestamp '2026-06-01'
+      or roster.valid_to is null
+  )
+```
+
+---
+
 ## Planned Directory Structure
 
 The dbt project should follow a clear folder structure:
@@ -604,6 +668,7 @@ dbt/
     staging/
     intermediate/
     marts/
+  snapshots/
   tests/
   macros/
   seeds/
@@ -621,6 +686,7 @@ Use these prefixes consistently:
 - `int_` for intermediate models
 - `fact_` for fact tables
 - `dim_` for dimension tables
+- `_snapshot` suffix for snapshots
 
 Rules:
 


### PR DESCRIPTION
## Summary

Add the Phase 4 SCD2 roster-history layer: a dbt snapshot recording
player-to-team roster membership intervals with dbt-managed effective
dating, plus a mart dimension shaped on top of it for consumers.

## Related Issue

Closes #130

## Scope

- `dbt/models/intermediate/int_player_current_team.sql` (+ yml entry):
  deterministic view deriving each player's current team as the team_name
  from their most recent team-recording map (map_date desc, map_id desc
  tie-break; null player_id/team_name rows excluded). This is the snapshot
  source relation.
- `dbt/snapshots/_snapshots.yml`: `player_roster_history_snapshot`,
  YAML-defined, `check` strategy on `team_name` keyed on `player_id`.
  Check was chosen over timestamp because the source has no reliable
  roster-change timestamp: keying on map recency would open a new interval
  every time a player simply played another map.
- `dbt/models/marts/dim_player_roster_history.sql` (+ yml entry):
  presentation shaping only - `valid_from`/`valid_to` renames, a
  `roster_history_key` surrogate (dbt_utils, player_id + valid_from), and
  an `is_current` flag. Player identity stays in `dim_players` per the
  issue's no-duplication guardrail.
- Tests: natural key (`player_id`, `valid_from`) unique combination on
  both snapshot and dim; `not_null` on player_id/team_name/valid_from;
  surrogate keys (`dbt_scd_id`, `roster_history_key`) unique + not_null;
  `relationships` from the dim to `dim_players`.
- `docs/dbt_models.md`: new Snapshot Layer section - grain, strategy
  rationale, observation-time effective-dating semantics, and a
  point-in-time roster query example; directory/naming sections updated.
- `README.md`: dbt build now includes the snapshot; history accrues
  across runs and resets with the local database.
- `docs/backlog.md`: Phase 4 SCD2 item added and checked off (#130);
  priorities line updated.

## Out of Scope

- Per-match lineup history or eco-derived history (deferred per issue).
- Backdating intervals to underlying map dates: dbt snapshots
  effective-date from observation time; `observed_map_date` carries the
  match-data context and the semantics are documented.
- The legacy `player_team_history`/`player_transfers` ingestion tables:
  never populated by the pipeline, so the snapshot derives membership
  from observed match data instead.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Additive dbt-layer change only. No ingestion, Python, Alembic
schema, or existing-model changes; the snapshot writes a new table in the
dbt-owned analytics schema and never mutates ingestion outputs or
existing marts.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

Note: this is the explicitly requested SCD2 snapshot work of issue #130
(Phase 4). The snapshot table lives in the dbt-owned analytics schema;
the Alembic-owned ingestion schema is untouched.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: `docs/dbt_models.md` gains the Snapshot Layer section (grain,
strategy rationale, effective-dating semantics, point-in-time query);
README documents the snapshot in the dbt workflow.

Backlog: Updated

Reason: Phase 4 checklist gains the checked SCD2 item (#130) and the
priorities line now marks it done.

## Verification

Commands run (against an isolated Postgres 17 container, port 55432, so
the local dev database was untouched):

- `docker run ... postgres:17` + `alembic upgrade head`
- seeded two matches/maps with player 101 on Team Alpha and player 201
  on Team Bravo
- `uv run dbt deps` / `uv run dbt build --project-dir dbt --profiles-dir dbt`
- seeded a third, newer match with player 101 now on Team Bravo; re-ran
  `dbt build`
- `uv run dbt snapshot` a third time with no source changes
- `uv run dbt docs generate` smoke test
- `uv run pytest --cov`

Results:

- First build: 74 of 74 resources pass (1 snapshot, 10 models, 63 data
  tests), snapshot seeds one open interval per player.
- After the team change: player 101's Team Alpha interval is closed
  (valid_to set) and a Team Bravo interval opened with `is_current`;
  player 201 played a new map on an unchanged team and gained no
  spurious row (the check-vs-timestamp rationale in action). All 74
  resources still pass.
- Third snapshot run with no source change is a no-op (row count
  unchanged) - re-runs cannot corrupt recorded history.
- `dbt docs generate` succeeds with the new nodes.
- Python suite: 171 passed, coverage 80.36% (floor is 80%).

## Review Notes

- Key semantic to review: intervals are effective-dated from when a
  snapshot run observed the change, not backdated to the underlying map
  date. `observed_map_date` carries the match-data context and the
  behavior is documented in `docs/dbt_models.md`.
- The one dependency-adjacent detail: no new packages;
  `dbt_utils.generate_surrogate_key` comes from the existing dbt_utils
  dependency added in #135.