### PR TITLE
Pin worker image Python deps to uv.lock and log browser stack versions (#91)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,19 @@ RUN apt-get update \
         fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml uv.lock README.md ./
 COPY api ./api
 COPY cs2_analytics ./cs2_analytics
 COPY scripts ./scripts
 
-RUN python -m pip install --upgrade pip \
-    && python -m pip install .
+# Install dependencies pinned by uv.lock so image builds are reproducible
+# instead of drifting to whatever pip resolves at build time.
+RUN python -m pip install --upgrade pip uv \
+    && uv export --frozen --no-default-groups --no-emit-project \
+        --format requirements-txt -o /tmp/requirements.txt \
+    && python -m pip install -r /tmp/requirements.txt \
+    && python -m pip install --no-deps . \
+    && rm /tmp/requirements.txt
 
 COPY main.py manage_db.py run_api.py ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,24 @@ RUN apt-get update \
         fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies pinned by uv.lock so image builds are reproducible
+# instead of drifting to whatever pip resolves at build time. uv itself is
+# pinned so the export step cannot change behavior between builds. Runs
+# before the source COPY so this layer stays cached across code changes.
+RUN python -m pip install --upgrade pip "uv==0.11.23" \
+    && uv export --frozen --no-default-groups --no-emit-project \
+        --format requirements-txt -o /tmp/requirements.txt \
+    && python -m pip install -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+
+COPY README.md ./
 COPY api ./api
 COPY cs2_analytics ./cs2_analytics
 COPY scripts ./scripts
 
-# Install dependencies pinned by uv.lock so image builds are reproducible
-# instead of drifting to whatever pip resolves at build time.
-RUN python -m pip install --upgrade pip uv \
-    && uv export --frozen --no-default-groups --no-emit-project \
-        --format requirements-txt -o /tmp/requirements.txt \
-    && python -m pip install -r /tmp/requirements.txt \
-    && python -m pip install --no-deps . \
-    && rm /tmp/requirements.txt
+RUN python -m pip install --no-deps .
 
 COPY main.py manage_db.py run_api.py ./
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -164,10 +164,21 @@ Validated production checks:
   failure with diagnostics before parser handling. This confirms the deployment
   worker path while keeping recurring worker runs paused until broader live
   ingestion behavior and operations are intentionally resumed.
-- As of 2026-07, the worker's in-container browser validation fails on current
-  Debian Chromium (#91): the unpinned browser stack drifted past what the
-  installed SeleniumBase can drive. The image itself builds (Python 3.12 base
-  since #90), and the worker path stays paused pending #91 and #66.
+- The 2026-07-06 in-container browser validation failures (#91) were caused by
+  Debian trixie's initial Chromium 150 package (`150.0.7871.46-1~deb13u1`),
+  which SeleniumBase undetected mode could not connect to. The follow-up distro
+  point release (`150.0.7871.124-1~deb13u1`) resolved the failure with no
+  repository change: validation passes with it on both the then-current and
+  current SeleniumBase releases. The worker path stays paused pending #66.
+- To keep worker builds reproducible instead of drifting with `pip` resolution,
+  the Docker image installs Python dependencies pinned by `uv.lock` (via
+  `uv export --frozen`). Upgrading the browser automation stack now happens
+  through a reviewed `uv.lock` update rather than silently at build time.
+  Chromium and its driver still come from the Debian package archive, which
+  only serves current point releases, so the browser itself can still drift;
+  `scripts/validate_worker_browser.py` logs the Chromium, ChromeDriver,
+  SeleniumBase, and Selenium versions on every run so any future failure is
+  immediately attributable to a specific stack.
 
 Local worker validation commands:
 

--- a/scripts/validate_worker_browser.py
+++ b/scripts/validate_worker_browser.py
@@ -1,6 +1,9 @@
 """Validate that the container worker can start Selenium/Chromium."""
 
+import shutil
+import subprocess
 import sys
+from importlib import metadata
 
 from seleniumbase import Driver
 
@@ -14,10 +17,47 @@ CHECK_URL = (
     "<html><head><title>CS2 Analytics Worker Browser Check</title></head>"
     "<body>ok</body></html>"
 )
+BROWSER_BINARIES = ("chromium", "chromedriver")
+BROWSER_PACKAGES = ("seleniumbase", "selenium")
+VERSION_COMMAND_TIMEOUT_SECONDS = 30
+
+
+def get_binary_version(binary: str) -> str:
+    """Return the ``--version`` output for a browser binary on PATH."""
+    path = shutil.which(binary)
+    if path is None:
+        return "not found"
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=VERSION_COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"version check failed: {exc}"
+    return result.stdout.strip() or result.stderr.strip() or "unknown"
+
+
+def get_package_version(package: str) -> str:
+    """Return the installed version of a Python package."""
+    try:
+        return metadata.version(package)
+    except metadata.PackageNotFoundError:
+        return "not installed"
+
+
+def log_browser_stack_versions() -> None:
+    """Log browser stack versions so failures are attributable to drift."""
+    for binary in BROWSER_BINARIES:
+        logger.info("Browser stack: %s %s", binary, get_binary_version(binary))
+    for package in BROWSER_PACKAGES:
+        logger.info("Browser stack: %s %s", package, get_package_version(package))
 
 
 def main() -> int:
     """Start Chromium through SeleniumBase and load a deterministic page."""
+    log_browser_stack_versions()
     driver = None
     try:
         driver = Driver(uc=True, headless=True)

--- a/tests/test_validate_worker_browser.py
+++ b/tests/test_validate_worker_browser.py
@@ -1,0 +1,89 @@
+"""Tests for the worker browser validation script diagnostics (issue #91)."""
+
+import subprocess
+
+import pytest
+
+import scripts.validate_worker_browser as validate_module
+from scripts.validate_worker_browser import (
+    get_binary_version,
+    get_package_version,
+    log_browser_stack_versions,
+)
+
+
+class FakeCompletedProcess:
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_get_binary_version_reports_missing_binary(monkeypatch) -> None:
+    monkeypatch.setattr(validate_module.shutil, "which", lambda _binary: None)
+
+    assert get_binary_version("chromium") == "not found"
+
+
+def test_get_binary_version_prefers_stdout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        validate_module.shutil, "which", lambda _binary: "/usr/bin/chromium"
+    )
+    monkeypatch.setattr(
+        validate_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: FakeCompletedProcess(stdout="Chromium 150.0\n"),
+    )
+
+    assert get_binary_version("chromium") == "Chromium 150.0"
+
+
+def test_get_binary_version_falls_back_to_stderr(monkeypatch) -> None:
+    monkeypatch.setattr(
+        validate_module.shutil, "which", lambda _binary: "/usr/bin/chromedriver"
+    )
+    monkeypatch.setattr(
+        validate_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: FakeCompletedProcess(stderr="ChromeDriver 150.0\n"),
+    )
+
+    assert get_binary_version("chromedriver") == "ChromeDriver 150.0"
+
+
+def test_get_binary_version_reports_command_failure(monkeypatch) -> None:
+    def raise_timeout(*args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=30)
+
+    monkeypatch.setattr(
+        validate_module.shutil, "which", lambda _binary: "/usr/bin/chromium"
+    )
+    monkeypatch.setattr(validate_module.subprocess, "run", raise_timeout)
+
+    assert get_binary_version("chromium").startswith("version check failed:")
+
+
+def test_get_package_version_reports_installed_package() -> None:
+    assert get_package_version("pytest") == pytest.__version__
+
+
+def test_get_package_version_reports_missing_package() -> None:
+    assert get_package_version("definitely-not-a-real-package") == "not installed"
+
+
+def test_log_browser_stack_versions_logs_all_components(monkeypatch, caplog) -> None:
+    monkeypatch.setattr(validate_module, "get_binary_version", lambda _binary: "1.2.3")
+    monkeypatch.setattr(
+        validate_module, "get_package_version", lambda _package: "4.5.6"
+    )
+
+    logger = validate_module.logger
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("INFO", logger=logger.name):
+            log_browser_stack_versions()
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    for component in ("chromium", "chromedriver", "seleniumbase", "selenium"):
+        assert component in logged


### PR DESCRIPTION
## Summary

Closes #91.

Root-cause finding: the 2026-07-06 worker browser validation failures were caused by Debian trixie's initial Chromium 150 package (`150.0.7871.46-1~deb13u1`), which SeleniumBase undetected mode could not connect to. Debian's follow-up point release (`150.0.7871.124-1~deb13u1`) fixed it upstream. Reproduced locally per the issue's suggested investigation: a fresh `docker build` + `scripts/validate_worker_browser.py` now passes, and it also passes with seleniumbase 4.50.5 (the release current at the time of the failing runs) against the new Chromium, isolating the regression to the distro package rather than the Python stack.

What this PR fixes is the reproducibility gap the incident exposed: the image installed the Python stack unpinned at build time and no run logged browser versions, so builds drifted and failures were hard to attribute.

## Changes

- `Dockerfile`: install Python dependencies pinned by `uv.lock` (`uv export --frozen` -> `pip install -r`), then install the project with `--no-deps`. Browser automation upgrades now go through reviewed lockfile updates instead of drifting with pip resolution at build time. Chromium stays on the distro package: Debian only serves current point releases, so a hard apt pin would break builds whenever the archive moves.
- `scripts/validate_worker_browser.py`: log Chromium, ChromeDriver, seleniumbase, and selenium versions before starting the driver, so any future validation failure log shows the exact stack that broke.
- `tests/test_validate_worker_browser.py`: focused tests for the new version-diagnostic helpers.
- `docs/deployment.md`: record the root cause, the pinning strategy, and the remaining Chromium drift caveat.

## Verification

- Local `docker build` from this branch installs exactly the lockfile versions (selenium 4.45.0, seleniumbase 4.50.1); in-container browser validation passes and logs the full stack:
  ```
  Browser stack: chromium Chromium 150.0.7871.124 built on Debian GNU/Linux 13 (trixie)
  Browser stack: chromedriver ChromeDriver 150.0.7871.124
  Browser stack: seleniumbase 4.50.1
  Browser stack: selenium 4.45.0
  Worker browser validation passed.
  ```
- Runtime smoke in the pinned image: API/runtime imports and `cs2a --help` succeed, so the Render image path is unaffected in shape (same entrypoints, now pinned deps).
- `uv run pytest --cov`: 178 passed, coverage 80.36% (floor 80%).
- `ruff check` and `ruff format --check` clean on changed files; `mypy` clean on the changed script.
- Suggest a manual run of the Manual Pipeline Worker workflow (with `run_pipeline` disabled) from this branch to confirm the validation step passes on a GitHub-hosted runner.

## Documentation check

`docs/deployment.md` updated: the #91 status bullet now records the root cause and resolution, and a new bullet documents the lockfile-pinned image build and version diagnostics. `docs/backlog.md` not updated because #91 is not tracked as a roadmap/phase item there; the worker path status lives in `docs/deployment.md`.

## Risk

Medium (dependency/build change): the Dockerfile change affects how both the worker image and the Render API image install Python dependencies. Versions installed are the same ones already in `uv.lock` used everywhere else (CI runs `uv sync --frozen`), but this PR should get human review before merge per the change policy.
