### PR TITLE
Add cs2a retry command to requeue failed ingestion work (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,19 @@ cs2a ingest discover            # scrape results pages, queue new matches
 cs2a ingest discover --mode backfill
 cs2a process --batch 50         # process pending matches, then maps
 cs2a status                     # ingestion-state row counts by status
+cs2a retry --stage match        # requeue failed matches for reprocessing
+cs2a retry --stage map --dry-run
 ```
+
+`cs2a retry` resets `failed` ingestion-state rows back to `discovered` so
+the next `cs2a process` run picks them up. `dead` and `partial` rows are
+only requeued when named explicitly via `--status`, including when
+targeting a single row with `--id`. `--limit` bounds how much work is
+requeued and `--dry-run` previews the affected rows without writing.
+Before writing, the command shows the affected row count and the target
+database and asks for confirmation. Requeueing preserves `failure_count`
+and `last_error_message` as history; the requeue itself is visible via
+`last_updated_at`.
 
 ### 8. Run the API
 

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -7,11 +7,14 @@ do not pay the scraper-stack import cost.
 """
 
 from enum import StrEnum
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 
 from cs2_analytics.exceptions import DatabaseConnectionError, IngestionStateError
+
+if TYPE_CHECKING:
+    from cs2_analytics.ingestion_state.base_ingestion_state import BaseIngestionState
 
 app = typer.Typer(
     help="CS2 analytics ingestion pipeline.",
@@ -93,7 +96,7 @@ class RetryStatus(StrEnum):
 RETRY_ERROR_PREVIEW_LENGTH = 60
 
 
-def _retry_state_for(stage: RetryStage):
+def _retry_state_for(stage: RetryStage) -> "BaseIngestionState[int]":
     """Return the ingestion-state manager for the requested retry stage."""
     from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
     from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
@@ -151,7 +154,9 @@ def retry(
         return
 
     for row_id, failure_count, last_error in candidates:
-        error_preview = (last_error or "")[:RETRY_ERROR_PREVIEW_LENGTH]
+        error_preview = last_error or ""
+        if len(error_preview) > RETRY_ERROR_PREVIEW_LENGTH:
+            error_preview = error_preview[:RETRY_ERROR_PREVIEW_LENGTH] + "..."
         typer.echo(f"  {row_id}  failures={failure_count or 0}  {error_preview}")
     typer.echo(f"{len(candidates)} {stage.value} row(s) in status '{status.value}'.")
 
@@ -167,6 +172,11 @@ def retry(
         typer.echo(f"Failed to requeue rows: {e}", err=True)
         raise typer.Exit(code=1) from e
     typer.echo(f"Requeued {requeued} row(s); failure_count preserved as history.")
+    skipped = len(candidates) - requeued
+    if skipped > 0:
+        typer.echo(
+            f"{skipped} row(s) changed status since the preview and were left alone."
+        )
 
 
 def _alembic_config():

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 import typer
 
-from cs2_analytics.exceptions import DatabaseConnectionError
+from cs2_analytics.exceptions import DatabaseConnectionError, IngestionStateError
 
 app = typer.Typer(
     help="CS2 analytics ingestion pipeline.",
@@ -75,6 +75,100 @@ def process(
     MapController().run(batch_size=batch)
 
 
+class RetryStage(StrEnum):
+    """Ingestion stage whose state table a requeue targets."""
+
+    MATCH = "match"
+    MAP = "map"
+
+
+class RetryStatus(StrEnum):
+    """Lifecycle statuses eligible for requeueing."""
+
+    FAILED = "failed"
+    DEAD = "dead"
+    PARTIAL = "partial"
+
+
+RETRY_ERROR_PREVIEW_LENGTH = 60
+
+
+def _retry_state_for(stage: RetryStage):
+    """Return the ingestion-state manager for the requested retry stage."""
+    from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
+    from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
+
+    if stage is RetryStage.MATCH:
+        return MatchIngestionState()
+    return MapIngestionState()
+
+
+@app.command()
+def retry(
+    stage: Annotated[
+        RetryStage,
+        typer.Option(help="Ingestion stage whose state rows to requeue."),
+    ],
+    status: Annotated[
+        RetryStatus,
+        typer.Option(
+            help=(
+                "Status to requeue. dead and partial rows are only requeued "
+                "when named here explicitly, including with --id."
+            ),
+        ),
+    ] = RetryStatus.FAILED,
+    limit: Annotated[
+        int | None,
+        typer.Option(min=1, help="Requeue at most this many rows."),
+    ] = None,
+    item_id: Annotated[
+        int | None,
+        typer.Option("--id", help="Requeue a single match/map by ID."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Print what would be requeued without writing."),
+    ] = False,
+) -> None:
+    """Requeue failed ingestion work by resetting rows to 'discovered'.
+
+    failure_count and last_error_message are preserved as history; the
+    requeue itself is visible via last_updated_at. The next `cs2a process`
+    run picks the requeued rows up.
+    """
+    state = _retry_state_for(stage)
+    try:
+        candidates = state.fetch_requeue_candidates(
+            status.value, limit=limit, id_value=item_id
+        )
+    except IngestionStateError as e:
+        typer.echo(f"Failed to fetch requeue candidates: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    if not candidates:
+        typer.echo(f"No {status.value} rows to requeue in {state.table_name}.")
+        return
+
+    for row_id, failure_count, last_error in candidates:
+        error_preview = (last_error or "")[:RETRY_ERROR_PREVIEW_LENGTH]
+        typer.echo(f"  {row_id}  failures={failure_count or 0}  {error_preview}")
+    typer.echo(f"{len(candidates)} {stage.value} row(s) in status '{status.value}'.")
+
+    if dry_run:
+        typer.echo("Dry run: no rows were changed.")
+        return
+
+    _echo_target_database()
+    typer.confirm(f"Requeue {len(candidates)} row(s) to 'discovered'?", abort=True)
+    try:
+        requeued = state.requeue([row[0] for row in candidates], status.value)
+    except IngestionStateError as e:
+        typer.echo(f"Failed to requeue rows: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    typer.echo(f"Requeued {requeued} row(s); failure_count preserved as history.")
+
+
 def _alembic_config():
     """Load the project's Alembic configuration for programmatic commands.
 
@@ -95,7 +189,7 @@ def _alembic_config():
 
 
 def _echo_target_database() -> None:
-    """Print the migration target so the operator sees local versus production."""
+    """Print the target database so the operator sees local versus production."""
     from cs2_analytics.config.config import DB_HOST, DB_NAME, DB_PORT
 
     typer.echo(f"Target database: {DB_NAME} on {DB_HOST}:{DB_PORT}")

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -245,3 +245,65 @@ class BaseIngestionState[IdT: (int, str)]:
             raise self.error_cls(
                 f"Failed to mark item as skipped in {self.table_name}."
             ) from e
+
+    def fetch_requeue_candidates(
+        self,
+        status: str,
+        limit: int | None = None,
+        id_value: IdT | None = None,
+    ) -> list[tuple[IdT, int | None, str | None]]:
+        """Fetches rows in the given status that are eligible for requeueing.
+
+        Returns (id, failure_count, last_error_message) tuples so callers
+        can preview exactly what a requeue would touch. Ordering matches
+        fetch(): priority first, then oldest discovery.
+        """
+        query = f"""
+        SELECT {self.id_field}, failure_count, last_error_message
+        FROM {self.table_name}
+        WHERE status = %s
+        """
+        params: list[object] = [status]
+        if id_value is not None:
+            query += f"AND {self.id_field} = %s\n        "
+            params.append(id_value)
+        query += "ORDER BY priority DESC, first_seen_at ASC\n        "
+        if limit is not None:
+            query += "LIMIT %s\n        "
+            params.append(limit)
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(query, tuple(params))
+                rows: list[tuple[IdT, int | None, str | None]] = cur.fetchall()
+                return rows
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to fetch requeue candidates from {self.table_name}."
+            ) from e
+
+    def requeue(self, ids: list[IdT], expected_status: str) -> int:
+        """Resets rows back to 'discovered' so processing picks them up again.
+
+        Only rows still in expected_status are reset, so an item that
+        changed state between preview and confirmation is left alone.
+        failure_count and last_error_message are preserved as history
+        (the requeue itself is visible via last_updated_at); the next
+        mark_as_failed keeps incrementing from the preserved count.
+        Returns the number of rows actually reset.
+        """
+        if not ids:
+            return 0
+        now = dt.datetime.now()
+        query = f"""
+        UPDATE {self.table_name}
+        SET status = 'discovered', last_updated_at = %s
+        WHERE {self.id_field} = ANY(%s) AND status = %s;
+        """
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(query, (now, list(ids), expected_status))
+                return cur.rowcount
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to requeue items in {self.table_name}."
+            ) from e

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -302,7 +302,7 @@ class BaseIngestionState[IdT: (int, str)]:
         try:
             with self.db.get_cursor() as cur:
                 cur.execute(query, (now, list(ids), expected_status))
-                return cur.rowcount
+                return int(cur.rowcount)
         except Exception as e:
             raise self.error_cls(
                 f"Failed to requeue items in {self.table_name}."

--- a/tests/ingestion_state/test_requeue.py
+++ b/tests/ingestion_state/test_requeue.py
@@ -1,0 +1,140 @@
+"""Tests for the ingestion-state requeue path used by `cs2a retry` (#122).
+
+Covers the storage-layer query building for candidate lookup and the
+status reset, including the decision that failure_count is preserved as
+history rather than reset on requeue.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+
+from cs2_analytics.exceptions import MatchIngestionStateError
+from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
+from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
+
+
+class _RecordingCursor:
+    def __init__(
+        self,
+        rows: list[tuple] | None = None,
+        rowcount: int = 0,
+    ) -> None:
+        self.execute_query: str | None = None
+        self.execute_values: tuple[object, ...] | None = None
+        self.rows = rows if rows is not None else []
+        self.rowcount = rowcount
+
+    def execute(self, query: str, values: tuple[object, ...]) -> None:
+        self.execute_query = query
+        self.execute_values = values
+
+    def fetchall(self) -> list[tuple]:
+        return self.rows
+
+
+class _RecordingStateDb:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+        self.cursor_uses = 0
+
+    @contextmanager
+    def get_cursor(self):
+        self.cursor_uses += 1
+        yield self.cursor
+
+
+class _FailingStateDb:
+    @contextmanager
+    def get_cursor(self):
+        raise RuntimeError("db down")
+        yield
+
+
+def test_fetch_requeue_candidates_filters_on_status_only_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(rows=[(1, 3, "boom"), (2, None, None)])
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+    state = MatchIngestionState()
+
+    rows = state.fetch_requeue_candidates("failed")
+
+    assert rows == [(1, 3, "boom"), (2, None, None)]
+    assert cursor.execute_query is not None
+    assert "SELECT match_id, failure_count, last_error_message" in cursor.execute_query
+    assert "FROM match_ingestion_state" in cursor.execute_query
+    assert "WHERE status = %s" in cursor.execute_query
+    assert "ORDER BY priority DESC, first_seen_at ASC" in cursor.execute_query
+    assert "LIMIT" not in cursor.execute_query
+    assert "match_id = %s" not in cursor.execute_query
+    assert cursor.execute_values == ("failed",)
+
+
+def test_fetch_requeue_candidates_applies_id_and_limit_filters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(rows=[(42, 1, "boom")])
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+    state = MatchIngestionState()
+
+    rows = state.fetch_requeue_candidates("dead", limit=5, id_value=42)
+
+    assert rows == [(42, 1, "boom")]
+    assert cursor.execute_query is not None
+    assert "AND match_id = %s" in cursor.execute_query
+    assert "LIMIT %s" in cursor.execute_query
+    assert cursor.execute_values == ("dead", 42, 5)
+
+
+def test_fetch_requeue_candidates_wraps_db_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingStateDb())
+    state = MatchIngestionState()
+
+    with pytest.raises(
+        MatchIngestionStateError,
+        match="Failed to fetch requeue candidates from match_ingestion_state.",
+    ):
+        state.fetch_requeue_candidates("failed")
+
+
+def test_requeue_resets_status_and_preserves_failure_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(rowcount=2)
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+    state = MatchIngestionState()
+
+    requeued = state.requeue([1, 2], "failed")
+
+    assert requeued == 2
+    assert cursor.execute_query is not None
+    assert "SET status = 'discovered', last_updated_at = %s" in cursor.execute_query
+    assert "WHERE match_id = ANY(%s) AND status = %s" in cursor.execute_query
+    assert "failure_count" not in cursor.execute_query
+    assert "last_error_message" not in cursor.execute_query
+    assert cursor.execute_values is not None
+    assert cursor.execute_values[1:] == ([1, 2], "failed")
+
+
+def test_requeue_with_no_ids_is_a_no_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _RecordingCursor()
+    db = _RecordingStateDb(cursor)
+    monkeypatch.setattr(base_state_module, "get_db", lambda: db)
+    state = MatchIngestionState()
+
+    assert state.requeue([], "failed") == 0
+    assert db.cursor_uses == 0
+
+
+def test_requeue_wraps_db_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingStateDb())
+    state = MatchIngestionState()
+
+    with pytest.raises(
+        MatchIngestionStateError,
+        match="Failed to requeue items in match_ingestion_state.",
+    ):
+        state.requeue([1], "failed")

--- a/tests/storage/test_database_setup.py
+++ b/tests/storage/test_database_setup.py
@@ -48,7 +48,19 @@ class _RecordingPool:
 
 
 def _clear_import_safety_modules(monkeypatch) -> None:
+    """Drop the modules from sys.modules so the test can re-import them.
+
+    Re-importing a submodule also rebinds it as an attribute on its parent
+    package, and monkeypatch only restores sys.modules. Pin the parent
+    attribute too so teardown leaves sys.modules and the package attribute
+    pointing at the same module object; otherwise later tests that patch
+    one lookup path silently miss consumers using the other.
+    """
     for module_name in IMPORT_SAFETY_MODULES:
+        parent_name, _, child_name = module_name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, child_name):
+            monkeypatch.setattr(parent, child_name, getattr(parent, child_name))
         monkeypatch.delitem(sys.modules, module_name, raising=False)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_help_lists_all_commands() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    for command in ("ingest", "process", "status", "db"):
+    for command in ("ingest", "process", "retry", "status", "db"):
         assert command in result.stdout
 
 
@@ -159,6 +159,176 @@ def test_process_runs_matches_then_maps_with_batch(monkeypatch) -> None:
         ("match", {"batch_size": 10}),
         ("map", {"batch_size": 10}),
     ]
+
+
+class _FakeRetryState:
+    """Ingestion-state stand-in recording fetch/requeue calls per stage."""
+
+    def __init__(
+        self,
+        name: str,
+        table_name: str,
+        candidates: list[tuple],
+        calls: list[tuple[str, str, dict]],
+    ) -> None:
+        self.table_name = table_name
+        self._name = name
+        self._candidates = candidates
+        self._calls = calls
+
+    def fetch_requeue_candidates(self, status, limit=None, id_value=None):
+        self._calls.append(
+            ("fetch", self._name, {"status": status, "limit": limit, "id": id_value})
+        )
+        return self._candidates
+
+    def requeue(self, ids, expected_status):
+        self._calls.append(
+            ("requeue", self._name, {"ids": ids, "expected_status": expected_status})
+        )
+        return len(ids)
+
+
+def _patch_retry_states(monkeypatch, candidates, calls):
+    """Replace both lazily imported state classes with recording fakes."""
+    import importlib
+
+    match_module = importlib.import_module(
+        "cs2_analytics.ingestion_state.match_ingestion_state"
+    )
+    map_module = importlib.import_module(
+        "cs2_analytics.ingestion_state.map_ingestion_state"
+    )
+
+    monkeypatch.setattr(
+        match_module,
+        "MatchIngestionState",
+        lambda: _FakeRetryState("match", "match_ingestion_state", candidates, calls),
+    )
+    monkeypatch.setattr(
+        map_module,
+        "MapIngestionState",
+        lambda: _FakeRetryState("map", "map_ingestion_state", candidates, calls),
+    )
+
+
+def test_retry_requires_a_stage(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 3, "boom")], calls)
+
+    result = runner.invoke(app, ["retry"])
+
+    assert result.exit_code != 0
+    assert calls == []
+
+
+def test_retry_defaults_to_failed_and_requeues_after_confirmation(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 3, "boom"), (2, 1, None)], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match"], input="y\n")
+
+    assert result.exit_code == 0
+    assert calls == [
+        ("fetch", "match", {"status": "failed", "limit": None, "id": None}),
+        ("requeue", "match", {"ids": [1, 2], "expected_status": "failed"}),
+    ]
+    assert "2 match row(s) in status 'failed'" in result.stdout
+    assert "Target database:" in result.stdout
+    assert "Requeued 2 row(s)" in result.stdout
+
+
+def test_retry_map_stage_uses_map_state(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(7, 2, "boom")], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "map"], input="y\n")
+
+    assert result.exit_code == 0
+    assert [call[1] for call in calls] == ["map", "map"]
+
+
+def test_retry_dead_and_partial_require_explicit_status(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 5, "gone")], calls)
+
+    result = runner.invoke(
+        app, ["retry", "--stage", "match", "--status", "dead"], input="y\n"
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        ("fetch", "match", {"status": "dead", "limit": None, "id": None}),
+        ("requeue", "match", {"ids": [1], "expected_status": "dead"}),
+    ]
+
+
+def test_retry_passes_limit_and_id_filters(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(42, 1, "boom")], calls)
+
+    result = runner.invoke(
+        app,
+        ["retry", "--stage", "match", "--limit", "5", "--id", "42"],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0
+    assert calls[0] == ("fetch", "match", {"status": "failed", "limit": 5, "id": 42})
+
+
+def test_retry_dry_run_reports_rows_without_writing(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 3, "boom")], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert [call[0] for call in calls] == ["fetch"]
+    assert "Dry run: no rows were changed." in result.stdout
+    assert "1 match row(s) in status 'failed'" in result.stdout
+
+
+def test_retry_aborts_without_confirmation(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 3, "boom")], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match"], input="n\n")
+
+    assert result.exit_code != 0
+    assert [call[0] for call in calls] == ["fetch"]
+    assert "Target database:" in result.stdout
+
+
+def test_retry_reports_when_nothing_matches(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match"])
+
+    assert result.exit_code == 0
+    assert [call[0] for call in calls] == ["fetch"]
+    assert "No failed rows to requeue in match_ingestion_state." in result.stdout
+
+
+def test_retry_exits_nonzero_when_fetch_fails(monkeypatch) -> None:
+    import importlib
+
+    from cs2_analytics.exceptions import MatchIngestionStateError
+
+    match_module = importlib.import_module(
+        "cs2_analytics.ingestion_state.match_ingestion_state"
+    )
+
+    class _FailingState:
+        def fetch_requeue_candidates(self, status, limit=None, id_value=None):
+            raise MatchIngestionStateError("db down")
+
+    monkeypatch.setattr(match_module, "MatchIngestionState", lambda: _FailingState())
+
+    result = runner.invoke(app, ["retry", "--stage", "match"])
+
+    assert result.exit_code == 1
 
 
 def test_status_prints_counts_per_table(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,11 +170,13 @@ class _FakeRetryState:
         table_name: str,
         candidates: list[tuple],
         calls: list[tuple[str, str, dict]],
+        requeue_result: int | None = None,
     ) -> None:
         self.table_name = table_name
         self._name = name
         self._candidates = candidates
         self._calls = calls
+        self._requeue_result = requeue_result
 
     def fetch_requeue_candidates(self, status, limit=None, id_value=None):
         self._calls.append(
@@ -186,10 +188,12 @@ class _FakeRetryState:
         self._calls.append(
             ("requeue", self._name, {"ids": ids, "expected_status": expected_status})
         )
+        if self._requeue_result is not None:
+            return self._requeue_result
         return len(ids)
 
 
-def _patch_retry_states(monkeypatch, candidates, calls):
+def _patch_retry_states(monkeypatch, candidates, calls, requeue_result=None):
     """Replace both lazily imported state classes with recording fakes."""
     import importlib
 
@@ -203,12 +207,16 @@ def _patch_retry_states(monkeypatch, candidates, calls):
     monkeypatch.setattr(
         match_module,
         "MatchIngestionState",
-        lambda: _FakeRetryState("match", "match_ingestion_state", candidates, calls),
+        lambda: _FakeRetryState(
+            "match", "match_ingestion_state", candidates, calls, requeue_result
+        ),
     )
     monkeypatch.setattr(
         map_module,
         "MapIngestionState",
-        lambda: _FakeRetryState("map", "map_ingestion_state", candidates, calls),
+        lambda: _FakeRetryState(
+            "map", "map_ingestion_state", candidates, calls, requeue_result
+        ),
     )
 
 
@@ -287,6 +295,34 @@ def test_retry_dry_run_reports_rows_without_writing(monkeypatch) -> None:
     assert [call[0] for call in calls] == ["fetch"]
     assert "Dry run: no rows were changed." in result.stdout
     assert "1 match row(s) in status 'failed'" in result.stdout
+
+
+def test_retry_truncates_long_error_previews(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    long_error = "x" * 100
+    _patch_retry_states(monkeypatch, [(1, 2, long_error)], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "x" * 60 + "..." in result.stdout
+    assert "x" * 61 not in result.stdout
+
+
+def test_retry_reports_rows_left_alone_when_status_changed(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(
+        monkeypatch, [(1, 3, "boom"), (2, 1, None)], calls, requeue_result=1
+    )
+
+    result = runner.invoke(app, ["retry", "--stage", "match"], input="y\n")
+
+    assert result.exit_code == 0
+    assert "Requeued 1 row(s)" in result.stdout
+    assert (
+        "1 row(s) changed status since the preview and were left alone."
+        in result.stdout
+    )
 
 
 def test_retry_aborts_without_confirmation(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Closes #122.

Adds `cs2a retry` to requeue failed ingestion work by resetting selected
`match_ingestion_state` / `map_ingestion_state` rows back to `discovered`
so the next `cs2a process` run picks them up. Recovery no longer requires
hand-written SQL against the database.

- `--stage match|map` selects the state table
- `--status` defaults to `failed`; `dead` and `partial` are only requeued
  when named explicitly, including when combined with `--id`
- `--limit N` bounds how much work is requeued; `--id` targets one row
- `--dry-run` prints the affected rows without writing
- Before writing, the command prints the affected rows, the row count, and
  the target database, then asks for confirmation (consistent with
  `cs2a db`, #120)

Per the architecture boundaries, the SQL lives in the ingestion-state
layer (`BaseIngestionState.fetch_requeue_candidates()` / `requeue()`);
the CLI stays a thin wrapper with lazy imports. `requeue()` only resets
rows still in the expected status, so an item that changed state between
preview and confirmation is left alone.

## failure_count decision

Requeueing preserves `failure_count` and `last_error_message` as history
rather than resetting them. The requeue itself is visible via
`last_updated_at`, and the next `mark_as_failed` keeps incrementing from
the preserved count, so repeat offenders stay identifiable across manual
requeues. Documented in the README and covered by tests.

## Test-isolation fix (separate commit)

The new CLI tests exposed a pre-existing leak in
`tests/storage/test_database_setup.py`: the import-safety test re-imports
storage/ingestion-state modules, and monkeypatch restored `sys.modules`
but not the rebound parent-package attributes, leaving two different
module objects answering to the same name. Tests patching via one lookup
path silently missed code importing via the other - the retry tests
passed in isolation but hit the real classes in the full suite. The fix
pins the parent attributes so teardown restores both paths to the same
object.

## Testing

- `uv run pytest --cov`: 193 passed, coverage 80.91% (floor 80%)
- CI-equivalent `ruff check` and `ruff format --check` pass
- Manual verification still pending: fail an item locally, run
  `cs2a retry --stage match`, confirm `cs2a process` reprocesses it

## Documentation check

README documents the new command, its flags, the confirmation behavior,
and the failure_count decision. `docs/backlog.md` not updated: ops/CLI
tasks (#120, #122) are not tracked as backlog roadmap items and no phase
or sequencing status changes. Architecture docs unchanged: the command
follows existing CLI and ingestion-state boundaries.

## Human review notes

As flagged in the issue: this writes lifecycle status transitions outside
the normal stage flow and will be run against production. Review the
default filters, the dead/partial opt-in, and the failure_count decision
before merge.