### PR TITLE
Record Phase 4.5 dbt operations plan in backlog and label taxonomy (#146)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -17,6 +17,10 @@
   color: "1d76db"
   description: "dbt transformation layer work."
 
+- name: "phase: 4.5"
+  color: "1465b3"
+  description: "dbt operations and depth work after the initial transformation layer."
+
 - name: "phase: 5"
   color: "0052cc"
   description: "Airflow orchestration work."

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -742,6 +742,51 @@ writes into.
   `docs/dbt_models.md`
 - [ ] Prefer dbt as the transformation layer, not as a replacement for ingestion logic
 
+### Follow-through: legibility
+
+The transformation layer is built; these make it visible from outside the
+repo.
+
+- [ ] Present the shipped dbt layer in the README: lineage diagram, SCD2
+      snapshot callout, mart grain table (#143)
+- [ ] Run dbt build (models, snapshots, tests) in CI against a disposable
+      Postgres with seeded fixtures (#144)
+- [ ] Publish generated dbt docs (lineage DAG) to GitHub Pages (#145)
+
+---
+
+## Phase 4.5: dbt Operations and Depth
+
+Goal:
+Make the shipped dbt layer operate continuously and deepen it, without
+pulling Airflow (Phase 5) forward.
+
+The SCD2 snapshot only records roster changes during runs that observe
+them, and history cannot be backfilled - so scheduled execution is the
+time-sensitive item and leads this phase.
+
+### Planned work
+
+- [ ] Schedule a daily `dbt build --target prod` against the deployed
+      database (GitHub Actions cron preferred, local cron fallback) with a
+      basic source-freshness gate so SCD2 history accrues (#146)
+- [ ] Normalize audit-field timestamps on matches and players to
+      TIMESTAMPTZ - pulled forward from deferred as the incremental
+      watermark enabler (#132)
+- [ ] Convert `fact_player_map_stats` to an incremental materialization
+      with a `unique_key` and `is_incremental()` watermark filter; evaluate
+      `fact_matches` alongside (#147, after #132)
+- [ ] Deepen data quality: per-source freshness thresholds, warn/error
+      test severities, store_failures audit tables, and selective
+      distribution tests (#148)
+
+### After Phase 4.5
+
+- Point API read paths at the dbt marts (already tracked under Deferred
+  Work / API Expansion) once the marts are continuously rebuilt
+- Cloud warehouse (BigQuery) and Airflow (Phase 5) stay downstream; the
+  #146 scheduled workflow is the interim orchestration Phase 5 replaces
+
 ---
 
 ## Phase 5: Airflow Orchestration

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,23 +11,27 @@ stable stage-service boundaries, controller retry hardening, relational
 match/map/player storage contracts, Alembic-managed schema, a containerized
 runtime, CI gates for both stacks, and a first cloud deployment (Render API
 and PostgreSQL, GitHub Pages frontend). Frontend Phase A is complete and the
-public demo is live.
+public demo is live. The Phase 4 dbt transformation layer is built end to
+end (#109-#114, #130): staging, intermediate, and mart models, data tests
+on every layer, lineage/docs generation, and the SCD2
+player-roster-history snapshot.
 
 Current priorities:
 
-- establish a solid ingestion baseline: run the scraper locally, persist to
+- finish the final Phase 4 tasks before moving to Phase 4.5: the build
+  itself is done, so what remains is the legibility follow-through -
+  README presents the shipped layer (#143), dbt build runs in CI (#144),
+  dbt docs publish to GitHub Pages (#145)
+- then start Phase 4.5 (dbt operations and depth), led by the scheduled
+  prod dbt build so SCD2 roster history starts accruing (#146), followed
+  by #132, #147, and #148 in dependency order
+- keep the ingestion baseline solid: run the scraper locally, persist to
   the Render database, with controllable quantity (`cs2a` caps and batch
   sizes) and a schedulable entry point
-- continue Phase 4 (dbt) without moving ingestion responsibilities into
-  dbt: the project is initialized (#109), staging models exist (#110),
-  the first intermediate model exists (#111), the initial marts exist (#112),
-  data tests cover every layer (#113), lineage/docs generation is done
-  (#114), and the SCD2 player-roster-history snapshot exists (#130);
-  Phase 3.9 tooling hardening (#67-#70, #86) and the Phase 4 entry bugs
-  (#71, #74) are closed
 - keep `docs/schema_target_pre_dbt.md` as planning guidance for later parsed
   source schema normalization
-- defer demo expansion and Airflow until after the initial dbt layer exists
+- defer demo expansion, cloud warehouse work, and Airflow (Phase 5) until
+  after Phase 4.5
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 4 (dbt transformation layer) planned work is complete, but the backlog did not say what comes next for dbt. This records the plan agreed today:

- Phase 4 gains a **Follow-through: legibility** checklist referencing #143 (README presents the shipped layer), #144 (dbt build in CI), #145 (dbt docs on Pages).
- New **Phase 4.5: dbt Operations and Depth** section between Phases 4 and 5, with planned work in dependency order: #146 (scheduled daily dbt build --target prod so SCD2 history accrues - time-sensitive, since check-strategy snapshot history cannot be backfilled), #132 (TIMESTAMPTZ audit-field normalization, pulled forward as the incremental watermark enabler), #147 (incremental fact_player_map_stats, after #132), #148 (source freshness, test severities, store_failures).
- An **After Phase 4.5** note keeps API-on-marts, BigQuery, and Airflow (Phase 5) explicitly downstream, and frames the #146 scheduled workflow as the interim orchestration Phase 5 replaces.
- .github/labels.yml gains the phase: 4.5 entry, matching the label already created on GitHub.

Docs-only; no code or model changes.

Refs #146, #132, #143, #144, #145, #147, #148