### PR TITLE
Add scheduled daily dbt build with source-freshness gate (#146)

### DIFF
--- a/.github/workflows/scheduled-dbt-build.yml
+++ b/.github/workflows/scheduled-dbt-build.yml
@@ -1,0 +1,75 @@
+name: Scheduled dbt Build
+
+# Runs dbt against the DEPLOYED database on a daily schedule so the SCD2
+# player_roster_history_snapshot observes roster changes as they happen.
+# The snapshot uses the check strategy: it can only record a change during
+# a run that sees it, and missed days can never be backfilled.
+#
+# Source freshness runs first as a gate: a stale scraper fails the workflow
+# loudly instead of letting snapshot history silently freeze.
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-dbt-build
+  cancel-in-progress: false
+
+jobs:
+  dbt-build:
+    name: Source Freshness Gate And dbt Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASS: ${{ secrets.DB_PASS }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+
+    steps:
+      - name: Check out repository
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Check required secrets
+        run: |
+          missing=0
+          for name in DB_NAME DB_USER DB_PASS DB_HOST DB_PORT; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing GitHub Actions secret: ${name}"
+              missing=1
+            fi
+          done
+          exit "${missing}"
+
+      - name: Set up Python
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Install dbt packages
+        run: uv run dbt deps --project-dir dbt --profiles-dir dbt
+
+      - name: Check source freshness
+        run: >-
+          uv run dbt source freshness
+          --project-dir dbt --profiles-dir dbt --target prod
+
+      - name: Build models, snapshots, and data tests
+        run: >-
+          uv run dbt build
+          --project-dir dbt --profiles-dir dbt --target prod

--- a/README.md
+++ b/README.md
@@ -350,6 +350,14 @@ set -a; source .env; set +a
 uv run dbt run --project-dir dbt --profiles-dir dbt --target prod
 ```
 
+The deployed database is also rebuilt automatically: the Scheduled dbt
+Build workflow (`.github/workflows/scheduled-dbt-build.yml`) runs
+`dbt build --target prod` daily (10:00 UTC, plus manual dispatch) so the
+SCD2 roster snapshot observes changes as they happen - missed runs are
+roster history that cannot be backfilled. Each run is gated by
+`dbt source freshness`, so stale ingestion data fails the workflow
+instead of silently freezing snapshot history.
+
 dbt owns analytics transformations only; the ingestion schema stays owned by
 Alembic migrations. Sources are declared for the `matches`, `maps`, and
 `players` tables. The staging layer (`stg_matches`, `stg_maps`, `stg_players`)

--- a/dbt/models/staging/_ingestion__sources.yml
+++ b/dbt/models/staging/_ingestion__sources.yml
@@ -12,11 +12,12 @@ sources:
     # Freshness gates the scheduled prod run (.github/workflows/
     # scheduled-dbt-build.yml): a stale scraper fails the run loudly
     # instead of letting the SCD2 snapshot silently freeze history.
-    # Scraping is manual today, so thresholds are generous; the cast to
-    # timestamptz covers the tables whose audit columns are still naive
-    # TIMESTAMP (see #132).
+    # Scraping is manual today, so thresholds are generous. Thresholds
+    # live here at the source level; loaded_at_field is per table because
+    # matches and players store naive UTC TIMESTAMP audit columns (#132)
+    # and need AT TIME ZONE 'UTC' so freshness age never shifts with the
+    # session timezone, while maps is already TIMESTAMPTZ.
     config:
-      loaded_at_field: "last_scraped_at::timestamptz"
       freshness:
         warn_after: { count: 3, period: day }
         error_after: { count: 7, period: day }
@@ -25,6 +26,8 @@ sources:
         description: >
           One row per professional match: teams, series score, winner,
           event, match type, and match date.
+        config:
+          loaded_at_field: "last_scraped_at AT TIME ZONE 'UTC'"
         columns:
           - name: match_id
             description: Primary key; grain of this table.
@@ -35,6 +38,8 @@ sources:
         description: >
           One row per map played within a match, keyed by map_id with a
           foreign key to matches and a per-match map_order.
+        config:
+          loaded_at_field: last_scraped_at
         columns:
           - name: map_id
             description: Primary key; grain of this table.
@@ -45,6 +50,8 @@ sources:
         description: >
           Per-player per-map performance statistics (kills, deaths, ADR,
           KAST, rating, and related fields), keyed by (map_id, player_id).
+        config:
+          loaded_at_field: "last_scraped_at AT TIME ZONE 'UTC'"
         data_tests:
           - dbt_utils.unique_combination_of_columns:
               arguments:

--- a/dbt/models/staging/_ingestion__sources.yml
+++ b/dbt/models/staging/_ingestion__sources.yml
@@ -9,6 +9,17 @@ sources:
       boundary; relationship tests live on the staging models, which are thin
       views over these tables.
     schema: public
+    # Freshness gates the scheduled prod run (.github/workflows/
+    # scheduled-dbt-build.yml): a stale scraper fails the run loudly
+    # instead of letting the SCD2 snapshot silently freeze history.
+    # Scraping is manual today, so thresholds are generous; the cast to
+    # timestamptz covers the tables whose audit columns are still naive
+    # TIMESTAMP (see #132).
+    config:
+      loaded_at_field: "last_scraped_at::timestamptz"
+      freshness:
+        warn_after: { count: 3, period: day }
+        error_after: { count: 7, period: day }
     tables:
       - name: matches
         description: >

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -42,3 +42,6 @@ cs2_analytics:
       dbname: "{{ env_var('DB_NAME') }}"
       schema: analytics
       threads: 4
+      # Deployed Postgres requires TLS; require prevents a silent
+      # plaintext fallback. Override only for a non-TLS target.
+      sslmode: "{{ env_var('DB_SSLMODE', 'require') }}"

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -26,7 +26,8 @@ boundary but remains deferred.
 
 ## Stable Source Grains
 
-Phase 3.5 made the active parsed-source tables ready for downstream dbt staging:
+Phase 3.5 stabilized the active parsed-source tables, which the dbt staging
+layer now consumes as sources:
 
 - `matches`: one row per match
 - `maps`: one row per played map
@@ -101,8 +102,8 @@ controller, and stage-service implementation was moved off `main` to the
 `feature/demo-parsing` branch.
 
 Full demo download, parse, event extraction, and local artifact cleanup remain
-deferred until after the initial dbt layer exists and downstream demo needs are
-clearer.
+deferred; the initial dbt layer now exists, but downstream demo needs are
+still unclear.
 
 ## Transformation And Orchestration Boundary
 
@@ -115,8 +116,18 @@ browser validation is tracked by #91, and cloud scraping remains blocked by
 Scheduled scraper runs stay deferred until match and map batch behavior is
 validated. Manual migrations remain the release path, with write-based smoke
 checks limited to separate smoke or staging databases and production
-validation kept read-only. dbt comes after Phase 3.9 and the Phase 4 entry
-criteria.
+validation kept read-only.
+
+The Phase 4 dbt transformation layer is built and is now a scheduled
+production runtime component (#146): the Scheduled dbt Build workflow
+(`.github/workflows/scheduled-dbt-build.yml`) runs a `dbt source freshness`
+gate and then `dbt build` daily against the deployed database, using the
+repository's `DB_*` Actions secrets through the `prod` profile target. Its
+read/write boundary: dbt reads the Alembic-owned `public` ingestion tables
+as sources only and writes exclusively to the `analytics` schema (models
+and the SCD2 snapshot). The read-only rule for production validation above
+applies to the application/ingestion surface; the scheduled dbt build's
+`analytics`-schema writes are the deliberate exception.
 
 Normal database setup applies Alembic migrations through
 `alembic -c cs2_analytics/alembic.ini upgrade head` or
@@ -170,8 +181,11 @@ deferred until recurring deployment validation needs one; until then,
 production validation stays read-only and limited live ingestion validation is
 used to prove the deployed pipeline path.
 
-dbt will be added after the deployment baseline and must remain downstream of
-ingestion. It should transform stable source tables, not own ingestion logic or
-application/source schema.
+dbt is in place and remains downstream of ingestion: it transforms the stable
+source tables and owns neither ingestion logic nor the application/source
+schema. It runs on the daily scheduled workflow described under
+Transformation And Orchestration Boundary.
 
-Airflow comes after dbt and must not drive schema semantics prematurely.
+Airflow comes after dbt maturity and must not drive schema semantics
+prematurely; the scheduled dbt workflow is the interim orchestration Airflow
+would replace.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,13 +18,15 @@ player-roster-history snapshot.
 
 Current priorities:
 
-- finish the final Phase 4 tasks before moving to Phase 4.5: the build
-  itself is done, so what remains is the legibility follow-through -
-  README presents the shipped layer (#143), dbt build runs in CI (#144),
-  dbt docs publish to GitHub Pages (#145)
-- then start Phase 4.5 (dbt operations and depth), led by the scheduled
-  prod dbt build so SCD2 roster history starts accruing (#146), followed
-  by #132, #147, and #148 in dependency order
+- the scheduled prod dbt build (#146) was pulled ahead of the remaining
+  Phase 4 legibility tasks because it is the only calendar-sensitive item:
+  SCD2 roster history only accrues while it runs, and gaps cannot be
+  backfilled. It is delivered by the Scheduled dbt Build workflow.
+- finish the Phase 4 legibility follow-through: README presents the
+  shipped layer (#143), dbt build runs in CI (#144), dbt docs publish to
+  GitHub Pages (#145)
+- continue Phase 4.5 (dbt operations and depth) with #132, #147, and #148
+  in dependency order, then point API read paths at the marts (#150)
 - keep the ingestion baseline solid: run the scraper locally, persist to
   the Render database, with controllable quantity (`cs2a` caps and batch
   sizes) and a schedulable entry point
@@ -771,9 +773,12 @@ time-sensitive item and leads this phase.
 
 ### Planned work
 
-- [ ] Schedule a daily `dbt build --target prod` against the deployed
-      database (GitHub Actions cron preferred, local cron fallback) with a
-      basic source-freshness gate so SCD2 history accrues (#146)
+- [x] Schedule a daily `dbt build --target prod` against the deployed
+      database with a basic source-freshness gate so SCD2 history accrues
+      (#146) - delivered as the Scheduled dbt Build GitHub Actions
+      workflow (daily 10:00 UTC cron plus workflow_dispatch); the
+      deployed database accepts Actions runner connections, so the local
+      cron fallback was not needed
 - [ ] Normalize audit-field timestamps on matches and players to
       TIMESTAMPTZ - pulled forward from deferred as the incremental
       watermark enabler (#132)
@@ -786,8 +791,8 @@ time-sensitive item and leads this phase.
 
 ### After Phase 4.5
 
-- Point API read paths at the dbt marts (already tracked under Deferred
-  Work / API Expansion) once the marts are continuously rebuilt
+- Point API read paths at the dbt marts (#150, also tracked under
+  Deferred Work / API Expansion) once the marts are continuously rebuilt
 - Cloud warehouse (BigQuery) and Airflow (Phase 5) stay downstream; the
   #146 scheduled workflow is the interim orchestration Phase 5 replaces
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -665,9 +665,12 @@ The Scheduled dbt Build workflow
 10:00 UTC (plus `workflow_dispatch`) against the deployed database:
 
 1. `dbt source freshness --target prod` - gate. The ingestion sources
-   declare `loaded_at_field: last_scraped_at` with warn-after 3 days and
-   error-after 7 days; stale sources fail the workflow loudly instead of
-   letting snapshot history freeze while runs stay green.
+   declare per-table `loaded_at_field`s on `last_scraped_at` (with an
+   explicit `AT TIME ZONE 'UTC'` conversion for the naive TIMESTAMP
+   columns on matches and players, see #132, so freshness age never
+   shifts with the session timezone) and warn-after 3 days /
+   error-after 7 days; stale sources fail the workflow loudly instead
+   of letting snapshot history freeze while runs stay green.
 2. `dbt build --target prod` - models, snapshots, and data tests.
 
 Connection settings come from the repository's `DB_*` Actions secrets

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -656,6 +656,26 @@ where roster.team_name = 'Some Team'
   )
 ```
 
+## Scheduled execution (#146)
+
+The snapshot's `check` strategy can only record a roster change during a
+run that observes it, so unscheduled execution silently loses history.
+The Scheduled dbt Build workflow
+(`.github/workflows/scheduled-dbt-build.yml`) therefore runs daily at
+10:00 UTC (plus `workflow_dispatch`) against the deployed database:
+
+1. `dbt source freshness --target prod` - gate. The ingestion sources
+   declare `loaded_at_field: last_scraped_at` with warn-after 3 days and
+   error-after 7 days; stale sources fail the workflow loudly instead of
+   letting snapshot history freeze while runs stay green.
+2. `dbt build --target prod` - models, snapshots, and data tests.
+
+Connection settings come from the repository's `DB_*` Actions secrets
+through the `prod` profile target (TLS required via `sslmode`). Freshness
+thresholds are set for today's manual scraping cadence; tightening them
+belongs to the data-quality depth work (#148). This workflow is interim
+orchestration ("Phase 5 lite") and is what Airflow later replaces.
+
 ---
 
 ## Planned Directory Structure


### PR DESCRIPTION
## Summary

Adds the Scheduled dbt Build workflow: a daily 10:00 UTC cron (plus
`workflow_dispatch`) that runs `dbt deps`, a `dbt source freshness` gate,
and `dbt build` against the deployed database using the existing `DB_*`
Actions secrets through the `prod` profile target. The SCD2
`player_roster_history_snapshot` uses the `check` strategy, so it can only
record roster changes during runs that observe them; without scheduled
execution, history silently fails to accrue and can never be backfilled.
Before this PR, dbt had never run against the deployed database at all
(no `analytics` relations existed there).

## Related Issue

Closes #146

## Scope

- `.github/workflows/scheduled-dbt-build.yml` (new): daily cron +
  manual dispatch, secrets presence check, freshness gate, then
  `dbt build --target prod`; concurrency-grouped, `contents: read`
- `dbt/models/staging/_ingestion__sources.yml`: source-level freshness
  thresholds (warn 3 days, error 7 days) with per-table
  `loaded_at_field`s - explicit `AT TIME ZONE 'UTC'` for the naive
  TIMESTAMP audit columns on matches and players (#132), native
  TIMESTAMPTZ column on maps - so freshness age never shifts with the
  database session timezone
- `dbt/profiles.yml`: `prod` target gains `sslmode`
  (env-overridable, default `require`)
- `README.md`, `docs/dbt_models.md`: document the scheduled run
- `docs/architecture/current_state.md`: dbt was still described as
  future work; now records the shipped layer and the scheduled dbt
  runtime path with its read/write boundary (reads the Alembic-owned
  `public` ingestion tables as sources only, writes confined to the
  `analytics` schema as the deliberate exception to read-only
  production validation)
- `docs/backlog.md`: check off the #146 Phase 4.5 item; record that the
  schedule was pulled ahead of the Phase 4 legibility tasks (#143-#145)
  because it is the only calendar-sensitive item

## Out of Scope

- dbt build in CI on an ephemeral Postgres (#144, a correctness gate,
  not a production run)
- Deeper data quality: per-source thresholds, severities,
  store_failures (#148)
- Incremental materializations (#147) and the TIMESTAMPTZ audit-column
  normalization it depends on (#132)
- Pointing API read paths at the marts (#150)
- Airflow (Phase 5); this workflow is the interim orchestration it
  replaces

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: The workflow writes to the production database on a schedule
(rebuilds `analytics` models and appends snapshot intervals) and handles
prod credentials via Actions secrets. Writes are confined to the
`analytics` schema plus dbt snapshot tables; the Alembic-owned ingestion
schema stays read-only to dbt. No application code changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README documents the scheduled prod run alongside the existing
manual opt-in instructions, docs/dbt_models.md gains a Scheduled
execution section covering the gate, thresholds, and secrets flow, and
docs/architecture/current_state.md is updated per the
deployment/runtime documentation policy to record dbt as a scheduled
production runtime component with its read/write boundary (it
previously described dbt as future work).

Backlog: Updated

Reason: Checks off the #146 Phase 4.5 checklist item, records the
runner-location decision (GitHub Actions; local-cron fallback not
needed), and updates Current Position for the resequencing ahead of
#143-#145.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run dbt parse --project-dir dbt --profiles-dir dbt`
- `uv run dbt source freshness --project-dir dbt --profiles-dir dbt
  --target prod` followed by `uv run dbt build ... --target prod` - the
  exact command sequence the workflow runs, executed against the
  deployed database (a `workflow_dispatch` test was not possible
  pre-merge: GitHub does not register a schedule/dispatch-only workflow
  until it exists on the default branch)
- `uv run dbt snapshot ... --target prod` re-run plus before/after row
  counts on `analytics.player_roster_history_snapshot` to verify
  idempotency

Results:

- pytest: 195 passed; total coverage 80.97% (gate 80%)
- dbt parse: clean, no deprecation warnings for the freshness config
- Freshness gate: PASS on all 3 sources; first prod build: 74 of 74
  passed (5 view models, 5 table models, 1 snapshot, 63 data tests) in
  19.5s, seeding 1046 roster intervals
- Snapshot re-run with no roster changes: PASS, row count unchanged at
  1046 (all intervals open, as expected for the seed run)
- After the per-table UTC freshness fix: `dbt parse` clean and
  `dbt source freshness --target prod` re-run PASS on all three sources

## Review Notes

- Prod-credential handling: the workflow only references the five
  existing `DB_*` repo secrets (already used by the Manual Pipeline
  Worker); no new secret surface.
- Runner location decision from the issue is settled as GitHub Actions;
  runner-to-database reachability is evidenced by the Manual Pipeline
  Worker (same secrets, same database). Two acceptance criteria are
  inherently post-merge: the first scheduled/dispatched runner execution,
  and history accrual across two scheduled runs - dispatch the workflow
  once after merge to confirm the runner path.
- Freshness thresholds (warn 3d / error 7d) are sized for today's
  manual scraping cadence; tightening them is #148's scope.
- The first scheduled/dispatched run creates all `analytics` relations
  and seeds the snapshot: every player's current membership starts with
  `dbt_valid_from` at that run's timestamp, per the documented seeding
  semantics.
