### PR TITLE
Serve top players API read path from dbt marts (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ The API is available at `http://localhost:8000` by default. See
 `docs/deployment.md` for Docker build, environment variable, runtime data, and
 container command details.
 
+The `/api/top_players` endpoint reads the dbt-built marts
+(`analytics.fact_player_map_stats`, `analytics.dim_players`), not the raw
+ingestion tables, so on a fresh database run `dbt build` (section 10) after
+migrations before exercising the API read path; the deployment smoke path
+below is the exception and provisions its own minimal stand-ins.
+
 Run the deterministic deployment smoke path after PostgreSQL, migrations, and
 the API are available:
 
@@ -257,7 +263,9 @@ docker compose --profile tools run --rm smoke
 
 The smoke path seeds a tiny fixed-ID dataset, checks `/health`, verifies the API
 can query PostgreSQL through the top players read path, and removes the smoke
-rows before exiting. It should run against a local or deployment-validation
+rows before exiting. Because the API reads the dbt-built `analytics` marts and
+the smoke database never runs dbt, the smoke script creates minimal mart
+stand-ins (schema and the columns the read path uses) and seeds them directly. It should run against a local or deployment-validation
 database, not a production analytics database, and does not depend on live
 website scraping.
 

--- a/api/services/player_service.py
+++ b/api/services/player_service.py
@@ -20,6 +20,11 @@ class PlayerService:
         """
         Fetches top players based on average rating, filtered by minimum maps played.
 
+        Reads the dbt-built marts (analytics schema), not the raw ingestion
+        tables: fact_player_map_stats carries the per-map performance grain
+        and dim_players carries player identity, so aggregation is keyed on
+        player_id rather than on raw player_name values.
+
         Args:
             min_maps (int): Minimum number of maps a player must have played.
             limit (int): Number of players to return.
@@ -29,11 +34,13 @@ class PlayerService:
         """
         sql: str = """
             SELECT
-                player_name,
+                dim_players.player_name,
                 COUNT(*) AS maps_played,
-                ROUND(AVG(rating)::numeric, 2) AS avg_rating
-            FROM players
-            GROUP BY player_name
+                ROUND(AVG(fact_player_map_stats.rating)::numeric, 2) AS avg_rating
+            FROM analytics.fact_player_map_stats
+            JOIN analytics.dim_players
+                ON dim_players.player_id = fact_player_map_stats.player_id
+            GROUP BY fact_player_map_stats.player_id, dim_players.player_name
             HAVING COUNT(*) >= %s
             ORDER BY avg_rating DESC
             LIMIT %s;

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -125,7 +125,9 @@ gate and then `dbt build` daily against the deployed database, using the
 repository's `DB_*` Actions secrets through the `prod` profile target. Its
 read/write boundary: dbt reads the Alembic-owned `public` ingestion tables
 as sources only and writes exclusively to the `analytics` schema (models
-and the SCD2 snapshot). The read-only rule for production validation above
+and the SCD2 snapshot). The API's read path consumes the `analytics`
+marts (#150), so the marts are the serving contract and the ingestion
+schema has no direct API consumers. The read-only rule for production validation above
 applies to the application/ingestion surface; the scheduled dbt build's
 `analytics`-schema writes are the deliberate exception.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -791,8 +791,11 @@ time-sensitive item and leads this phase.
 
 ### After Phase 4.5
 
-- Point API read paths at the dbt marts (#150, also tracked under
-  Deferred Work / API Expansion) once the marts are continuously rebuilt
+- [x] Point API read paths at the dbt marts (#150) - `/api/top_players`
+      now reads `analytics.fact_player_map_stats` joined to
+      `analytics.dim_players`, aggregated on `player_id`, with the
+      deployment smoke path seeding mart stand-ins for the disposable
+      smoke database
 - Cloud warehouse (BigQuery) and Airflow (Phase 5) stay downstream; the
   #146 scheduled workflow is the interim orchestration Phase 5 replaces
 
@@ -824,8 +827,9 @@ deployment baseline work, and dbt.
       environment-driven host/port settings, and CORS configuration
 - [ ] Add endpoints for matches and teams
 - [ ] Add pagination/filtering patterns
-- [ ] Evaluate querying transformed dbt models for read paths after dbt marts
-      exist
+- [x] Evaluate querying transformed dbt models for read paths after dbt marts
+      exist - done (#150): the top players read path is served from the
+      marts; future endpoints should read marts by default
 
 ### Demo Pipeline
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -826,12 +826,16 @@ This makes the project stronger both for maintainability and portfolio presentat
 
 ## Relationship to the API Layer
 
-The FastAPI application should eventually prefer querying trusted transformed tables where appropriate.
+The FastAPI application reads the trusted transformed tables, not the raw
+ingestion tables. As of #150, the top players endpoint queries
+`fact_player_map_stats` joined to `dim_players`, aggregated on `player_id`,
+so the marts hold the API's data contract and the staging/intermediate
+layers can be restructured freely.
 
-Examples:
+Future endpoints should follow the same pattern:
 
 - recent matches endpoint -> fact_matches
-- player stats endpoint -> fact_player_map_stats or fact_player_match_stats
+- player stats endpoints -> fact_player_map_stats
 - team summaries -> fact_matches + dim_teams
 
 This keeps transformation logic out of the API code and reinforces separation of concerns.
@@ -851,6 +855,7 @@ Recommended rollout order:
 4. create intermediate reusable joins
 5. create fact and dimension marts
 6. update API/data consumers to use trusted marts where appropriate
+   (done for the top players read path in #150)
 
 ---
 

--- a/scripts/deployment_smoke.py
+++ b/scripts/deployment_smoke.py
@@ -35,8 +35,11 @@ def main() -> int:
         timeout_seconds = read_timeout_seconds()
         verify_migrated_tables()
         cleanup_smoke_source_rows()
+        cleanup_smoke_mart_rows()
         smoke_data_touched = True
         seed_smoke_source_rows()
+        ensure_smoke_mart_relations()
+        seed_smoke_mart_rows()
         verify_api_health(api_base_url, timeout_seconds)
         verify_top_players_read(api_base_url, timeout_seconds)
     except Exception as exc:
@@ -46,6 +49,7 @@ def main() -> int:
         if smoke_data_touched:
             try:
                 cleanup_smoke_source_rows()
+                cleanup_smoke_mart_rows()
             except Exception as exc:
                 logger.warning("Failed to clean up deployment smoke data: %s", exc)
 
@@ -181,6 +185,63 @@ def seed_smoke_source_rows() -> None:
     )
 
 
+def ensure_smoke_mart_relations() -> None:
+    """Create smoke-only stand-ins for the dbt-built mart relations.
+
+    The API reads the analytics marts, but the disposable smoke database
+    never runs dbt (the runtime image does not include it), so the
+    relations the read path uses are created here with only the columns
+    that path touches. Real environments get the full tables from
+    `dbt build`, which replaces these stand-ins.
+    """
+    db = Database()
+    with db.get_cursor() as cur:
+        cur.execute("CREATE SCHEMA IF NOT EXISTS analytics;")
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS analytics.fact_player_map_stats ("
+            "map_id BIGINT, player_id BIGINT, rating DOUBLE PRECISION);"
+        )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS analytics.dim_players ("
+            "player_id BIGINT, player_name TEXT);"
+        )
+
+
+def cleanup_smoke_mart_rows() -> None:
+    """Remove fixed-ID smoke rows from the mart relations if they exist."""
+    db = Database()
+    with db.get_cursor() as cur:
+        cur.execute("SELECT to_regclass('analytics.fact_player_map_stats');")
+        if cur.fetchone()[0] is not None:
+            cur.execute(
+                "DELETE FROM analytics.fact_player_map_stats"
+                " WHERE map_id = %s AND player_id = %s;",
+                (SMOKE_MAP_ID, SMOKE_PLAYER_ID),
+            )
+        cur.execute("SELECT to_regclass('analytics.dim_players');")
+        if cur.fetchone()[0] is not None:
+            cur.execute(
+                "DELETE FROM analytics.dim_players WHERE player_id = %s;",
+                (SMOKE_PLAYER_ID,),
+            )
+
+
+def seed_smoke_mart_rows() -> None:
+    """Seed mart rows so the API read check can see the smoke player."""
+    db = Database()
+    with db.get_cursor() as cur:
+        cur.execute(
+            "INSERT INTO analytics.fact_player_map_stats"
+            " (map_id, player_id, rating) VALUES (%s, %s, %s);",
+            (SMOKE_MAP_ID, SMOKE_PLAYER_ID, 9.99),
+        )
+        cur.execute(
+            "INSERT INTO analytics.dim_players"
+            " (player_id, player_name) VALUES (%s, %s);",
+            (SMOKE_PLAYER_ID, SMOKE_PLAYER_NAME),
+        )
+
+
 def verify_api_health(api_base_url: str, timeout_seconds: int) -> None:
     """Check the stable shallow API health endpoint."""
     payload = request_json(f"{api_base_url}/health", timeout_seconds)
@@ -190,7 +251,7 @@ def verify_api_health(api_base_url: str, timeout_seconds: int) -> None:
 
 
 def verify_top_players_read(api_base_url: str, timeout_seconds: int) -> None:
-    """Check that the API can read seeded source data from PostgreSQL."""
+    """Check that the API can read seeded mart data from PostgreSQL."""
     payload = request_json(
         f"{api_base_url}/api/top_players?min_maps=1&limit=100",
         timeout_seconds,

--- a/tests/api/test_player_service.py
+++ b/tests/api/test_player_service.py
@@ -1,0 +1,65 @@
+"""Tests for the PlayerService mart-backed read path."""
+
+from api.services import player_service
+from api.services.player_service import PlayerService
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple[object, ...]]) -> None:
+        self.rows = rows
+        self.executed: list[tuple[str, tuple[int, ...]]] = []
+        self.description = [("player_name",), ("maps_played",), ("avg_rating",)]
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple[int, ...]) -> None:
+        self.executed.append((query, params))
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return self.rows
+
+
+class _FakeDatabase:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _FakeCursor:
+        return self.cursor
+
+
+def test_fetch_top_players_reads_marts_grouped_by_player_id(monkeypatch) -> None:
+    cursor = _FakeCursor([("Smoke Test Player", 3, 1.25)])
+    monkeypatch.setattr(player_service, "Database", lambda: _FakeDatabase(cursor))
+
+    result = PlayerService().fetch_top_players(min_maps=2, limit=10)
+
+    query, params = cursor.executed[0]
+    assert "analytics.fact_player_map_stats" in query
+    assert "analytics.dim_players" in query
+    assert "players" not in query.replace("dim_players", "").replace(
+        "fact_player_map_stats", ""
+    )
+    assert "GROUP BY fact_player_map_stats.player_id" in query
+    assert params == (2, 10)
+    assert result[0].player_name == "Smoke Test Player"
+    assert result[0].maps_played == 3
+    assert result[0].avg_rating == 1.25
+
+
+def test_fetch_top_players_wraps_database_errors(monkeypatch) -> None:
+    class _FailingDatabase:
+        def get_cursor(self) -> None:
+            raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(player_service, "Database", lambda: _FailingDatabase())
+
+    try:
+        PlayerService().fetch_top_players(min_maps=1, limit=1)
+    except RuntimeError as exc:
+        assert "Failed to fetch top players" in str(exc)
+    else:
+        raise AssertionError("Expected a database failure to raise RuntimeError")

--- a/tests/test_deployment_smoke.py
+++ b/tests/test_deployment_smoke.py
@@ -5,7 +5,7 @@ from scripts import deployment_smoke
 
 class _RecordingCursor:
     def __init__(self, fetchone_results: list[tuple[object, ...]] | None = None) -> None:
-        self.executed: list[tuple[str, tuple[int, ...] | None]] = []
+        self.executed: list[tuple[str, tuple[object, ...] | None]] = []
         self.fetchone_results = list(fetchone_results or [])
 
     def __enter__(self) -> "_RecordingCursor":
@@ -14,7 +14,7 @@ class _RecordingCursor:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def execute(self, query: str, params: tuple[int, ...] | None = None) -> None:
+    def execute(self, query: str, params: tuple[object, ...] | None = None) -> None:
         self.executed.append((query, params))
 
     def fetchone(self) -> tuple[object, ...]:
@@ -87,6 +87,25 @@ def test_cleanup_smoke_source_rows_deletes_fixed_ids_in_dependency_order(
             (deployment_smoke.SMOKE_MATCH_ID,),
         ),
     ]
+
+
+def test_ensure_smoke_mart_relations_creates_schema_and_stand_ins(monkeypatch) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(
+        deployment_smoke,
+        "Database",
+        lambda: _FakeDatabase(cursor),
+    )
+
+    deployment_smoke.ensure_smoke_mart_relations()
+
+    executed_queries = [query for query, _params in cursor.executed]
+    assert executed_queries[0] == "CREATE SCHEMA IF NOT EXISTS analytics;"
+    assert "CREATE TABLE IF NOT EXISTS analytics.fact_player_map_stats" in (
+        executed_queries[1]
+    )
+    assert "CREATE TABLE IF NOT EXISTS analytics.dim_players" in executed_queries[2]
+    assert all("IF NOT EXISTS" in query for query in executed_queries)
 
 
 def test_seed_smoke_mart_rows_inserts_fixed_ids(monkeypatch) -> None:

--- a/tests/test_deployment_smoke.py
+++ b/tests/test_deployment_smoke.py
@@ -4,8 +4,9 @@ from scripts import deployment_smoke
 
 
 class _RecordingCursor:
-    def __init__(self) -> None:
-        self.executed: list[tuple[str, tuple[int, ...]]] = []
+    def __init__(self, fetchone_results: list[tuple[object, ...]] | None = None) -> None:
+        self.executed: list[tuple[str, tuple[int, ...] | None]] = []
+        self.fetchone_results = list(fetchone_results or [])
 
     def __enter__(self) -> "_RecordingCursor":
         return self
@@ -13,8 +14,11 @@ class _RecordingCursor:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def execute(self, query: str, params: tuple[int, ...]) -> None:
+    def execute(self, query: str, params: tuple[int, ...] | None = None) -> None:
         self.executed.append((query, params))
+
+    def fetchone(self) -> tuple[object, ...]:
+        return self.fetchone_results.pop(0)
 
 
 class _FakeDatabase:
@@ -81,6 +85,77 @@ def test_cleanup_smoke_source_rows_deletes_fixed_ids_in_dependency_order(
         (
             "DELETE FROM matches WHERE match_id = %s;",
             (deployment_smoke.SMOKE_MATCH_ID,),
+        ),
+    ]
+
+
+def test_seed_smoke_mart_rows_inserts_fixed_ids(monkeypatch) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(
+        deployment_smoke,
+        "Database",
+        lambda: _FakeDatabase(cursor),
+    )
+
+    deployment_smoke.seed_smoke_mart_rows()
+
+    fact_query, fact_params = cursor.executed[0]
+    dim_query, dim_params = cursor.executed[1]
+    assert "analytics.fact_player_map_stats" in fact_query
+    assert fact_params == (
+        deployment_smoke.SMOKE_MAP_ID,
+        deployment_smoke.SMOKE_PLAYER_ID,
+        9.99,
+    )
+    assert "analytics.dim_players" in dim_query
+    assert dim_params == (
+        deployment_smoke.SMOKE_PLAYER_ID,
+        deployment_smoke.SMOKE_PLAYER_NAME,
+    )
+
+
+def test_cleanup_smoke_mart_rows_skips_missing_relations(monkeypatch) -> None:
+    cursor = _RecordingCursor(fetchone_results=[(None,), (None,)])
+    monkeypatch.setattr(
+        deployment_smoke,
+        "Database",
+        lambda: _FakeDatabase(cursor),
+    )
+
+    deployment_smoke.cleanup_smoke_mart_rows()
+
+    executed_queries = [query for query, _params in cursor.executed]
+    assert all("to_regclass" in query for query in executed_queries)
+    assert not any("DELETE" in query for query in executed_queries)
+
+
+def test_cleanup_smoke_mart_rows_deletes_when_relations_exist(monkeypatch) -> None:
+    cursor = _RecordingCursor(
+        fetchone_results=[
+            ("analytics.fact_player_map_stats",),
+            ("analytics.dim_players",),
+        ]
+    )
+    monkeypatch.setattr(
+        deployment_smoke,
+        "Database",
+        lambda: _FakeDatabase(cursor),
+    )
+
+    deployment_smoke.cleanup_smoke_mart_rows()
+
+    delete_queries = [
+        (query, params) for query, params in cursor.executed if "DELETE" in query
+    ]
+    assert delete_queries == [
+        (
+            "DELETE FROM analytics.fact_player_map_stats"
+            " WHERE map_id = %s AND player_id = %s;",
+            (deployment_smoke.SMOKE_MAP_ID, deployment_smoke.SMOKE_PLAYER_ID),
+        ),
+        (
+            "DELETE FROM analytics.dim_players WHERE player_id = %s;",
+            (deployment_smoke.SMOKE_PLAYER_ID,),
         ),
     ]
 


### PR DESCRIPTION
## Summary

Repoints the API's only data read path from the raw `public.players`
ingestion table to the dbt-built marts: `GET /api/top_players` now
queries `analytics.fact_player_map_stats` joined to
`analytics.dim_players`, aggregated on `player_id`. The marts become the
API's serving contract - staging and intermediate models can be
restructured freely, and the mart data tests (run daily against
production by the #146 scheduled build) guard exactly the shape the API
depends on.

## Related Issue

Closes #150

## Scope

- `api/services/player_service.py`: mart-backed query, aggregation
  keyed on `player_id` with `player_name` from `dim_players`; response
  shape (`player_name`, `maps_played`, `avg_rating`) and the
  `min_maps`/`limit` parameters unchanged
- `scripts/deployment_smoke.py`: the disposable smoke database never
  runs dbt (the runtime image has no dbt install), so the smoke script
  now creates minimal `analytics` stand-ins (schema plus only the
  columns the read path uses), seeds a fixed-ID mart row alongside the
  existing raw-row seeding, and cleans both up (existence-guarded)
- `tests/api/test_player_service.py` (new): pins the service to the
  mart relations, the `player_id` grouping, and the error wrapping
- `tests/test_deployment_smoke.py`: covers mart seed/cleanup helpers,
  including the missing-relation guard
- Docs: README (mart read path, fresh-database `dbt build`
  prerequisite, smoke stand-in note), docs/dbt_models.md (API
  relationship moved from intended to actual), 
  docs/architecture/current_state.md (marts recorded as the serving
  contract), docs/backlog.md (#150 and the deferred API-expansion item
  checked off)

## Out of Scope

- No new endpoints and no response-shape changes
- No per-model indexes on the marts (current volumes seq-scan
  comfortably; revisit with volume/latency evidence)
- No dbt model, snapshot, or test changes
- No CI or scheduling changes (#144 remains separate)
- No frontend changes (the dashboard consumes the endpoint unchanged)

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: Changes the production serving path of the public dashboard's
only endpoint. Mitigated by an exact parity check against production
(details below), a read-only exercise of the real service against the
production marts, and the #146 daily build keeping the marts fresh.
Deploy ordering is satisfied: the marts already exist in the deployed
database and rebuild daily.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README, docs/dbt_models.md, and
docs/architecture/current_state.md all described or implied the raw
read path; each now records the mart-backed path and the smoke
stand-in behavior.

Backlog: Updated

Reason: Checks off the After Phase 4.5 item for #150 and the deferred
API Expansion evaluation item, both completed by this branch.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check ... --select E,F --ignore E501` and
  `uv run mypy api/...`
- Read-only parity check on the production database: old raw query vs
  new mart query at `min_maps=5`
- Read-only exercise of `PlayerService.fetch_top_players` against the
  production marts

Results:

- pytest: 200 passed; total coverage 81.50% (gate 80%)
- Ruff and mypy: clean
- Parity: identical results modulo tie ordering (the query has never
  had a secondary sort) and one intended correctness change - the raw
  grouping conflated two distinct players who both use the name
  "Magic" (ids 16865 and 23589) into a single fake 6-map qualifier;
  the mart grouping on `player_id` separates them (725 raw qualifiers
  vs 724 mart qualifiers)
- Live service call returned correct top players from the production
  marts

## Review Notes

- The `player_id` aggregation is a deliberate behavior change and
  strictly more correct than grouping by raw `player_name`; the Magic
  case above is the only observable difference in current data.
- The smoke stand-ins intentionally mirror only the columns the read
  path uses; real environments get the full tables from `dbt build`.
  If the mart columns the API reads ever change, the smoke stand-ins
  and the service query change together in the same PR.
- Follow-ups filed elsewhere: dbt build in CI (#144) and per-model
  mart indexes when volumes warrant.
