### PR TITLE
Run dbt build in CI against a disposable Postgres with seeded fixtures (#144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,66 @@ jobs:
           name: coverage-badge
           path: coverage-badge.json
 
+  dbt-build:
+    name: dbt Build And Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: cs2_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: change_me
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d cs2_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # DB_* drive Alembic and the fixture seeder; DBT_DB_* drive dbt's
+      # default dev target. Both point at the disposable service container
+      # only - CI never touches a deployed database.
+      DB_NAME: cs2_db
+      DB_USER: postgres
+      DB_PASS: change_me
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+      DBT_DB_HOST: 127.0.0.1
+
+    steps:
+      - name: Check out repository
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run migrations
+        run: uv run alembic -c cs2_analytics/alembic.ini upgrade head
+
+      - name: Seed dbt fixture data
+        run: uv run python scripts/seed_dbt_ci_fixture.py
+
+      - name: Install dbt packages
+        run: uv run dbt deps --project-dir dbt --profiles-dir dbt
+
+      - name: Build dbt models, snapshots, and tests
+        run: uv run dbt build --project-dir dbt --profiles-dir dbt
+
   publish-coverage-badge:
     name: Publish Coverage Badge
     needs: lint-type-test

--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ set -a; source .env; set +a
 uv run dbt run --project-dir dbt --profiles-dir dbt --target prod
 ```
 
+The dbt layer is CI-verified: the `dbt-build` job in
+`.github/workflows/ci.yml` runs `dbt build` (models, snapshots, and data
+tests) on every push and pull request against a disposable Postgres
+service container, migrated with Alembic and seeded with a small
+checked-in fixture (`scripts/seed_dbt_ci_fixture.py`) that writes through
+the real storage layer. Any model or data-test failure fails CI.
+
 The deployed database is also rebuilt automatically: the Scheduled dbt
 Build workflow (`.github/workflows/scheduled-dbt-build.yml`) runs
 `dbt build --target prod` daily (10:00 UTC, plus manual dispatch) so the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,10 +23,11 @@ Current priorities:
   SCD2 roster history only accrues while it runs, and gaps cannot be
   backfilled. It is delivered by the Scheduled dbt Build workflow.
 - finish the Phase 4 legibility follow-through: README presents the
-  shipped layer (#143), dbt build runs in CI (#144), dbt docs publish to
-  GitHub Pages (#145)
+  shipped layer (#143) and dbt docs publish to GitHub Pages (#145); dbt
+  build now runs in CI on every push/PR (#144)
 - continue Phase 4.5 (dbt operations and depth) with #132, #147, and #148
-  in dependency order, then point API read paths at the marts (#150)
+  in dependency order; the API read paths already point at the marts
+  (#150)
 - keep the ingestion baseline solid: run the scraper locally, persist to
   the Render database, with controllable quantity (`cs2a` caps and batch
   sizes) and a schedulable entry point
@@ -755,8 +756,10 @@ repo.
 
 - [ ] Present the shipped dbt layer in the README: lineage diagram, SCD2
       snapshot callout, mart grain table (#143)
-- [ ] Run dbt build (models, snapshots, tests) in CI against a disposable
-      Postgres with seeded fixtures (#144)
+- [x] Run dbt build (models, snapshots, tests) in CI against a disposable
+      Postgres with seeded fixtures (#144) - the ci.yml dbt-build job
+      migrates a service container, seeds a checked-in fixture through
+      the real storage layer, and fails on any model or test failure
 - [ ] Publish generated dbt docs (lineage DAG) to GitHub Pages (#145)
 
 ---

--- a/scripts/seed_dbt_ci_fixture.py
+++ b/scripts/seed_dbt_ci_fixture.py
@@ -1,0 +1,203 @@
+"""Seed a small fixture dataset for the CI dbt build.
+
+Writes two matches, four maps, and six player-map rows through the real
+storage layer so the CI dbt job (ci.yml, dbt-build) has source data that
+exercises the grain, relationship, and derivation tests meaningfully:
+match winners equal one of the two team names (losing_team stays
+non-null), map names repeat across matches (dim_maps grain), and one
+player appears across maps and dates (current-team derivation and the
+SCD2 snapshot).
+
+Intended for disposable databases only. The script refuses to run when
+DB_HOST is not local unless --allow-remote is passed explicitly.
+"""
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+
+from cs2_analytics.models.map import Map
+from cs2_analytics.models.match import Match
+from cs2_analytics.models.player import Player
+from cs2_analytics.storage.map_storage import store_maps
+from cs2_analytics.storage.match_storage import store_matches
+from cs2_analytics.storage.player_storage import store_players
+from cs2_analytics.utils.log_manager import get_logger
+
+logger = get_logger(__name__)
+
+LOCAL_HOSTS = ("localhost", "127.0.0.1", "db")
+FIXTURE_MATCH_IDS = (940_000_001, 940_000_002)
+FIXTURE_MAP_IDS = (940_000_101, 940_000_102, 940_000_103, 940_000_104)
+FIXTURE_PLAYER_IDS = (940_000_201, 940_000_202, 940_000_203)
+
+TEAM_ALPHA = "Fixture Alpha"
+TEAM_BRAVO = "Fixture Bravo"
+TEAM_CHARLIE = "Fixture Charlie"
+
+
+def require_local_database(allow_remote: bool) -> None:
+    """Refuse to write anywhere but a local database without explicit opt-in."""
+    db_host = os.getenv("DB_HOST", "")
+    if allow_remote or db_host in LOCAL_HOSTS:
+        return
+    raise RuntimeError(
+        f"DB_HOST={db_host!r} is not local; pass --allow-remote to seed a"
+        " non-local disposable database on purpose."
+    )
+
+
+def fixture_matches(now: datetime) -> list[Match]:
+    """Two matches sharing a team so roster derivation spans dates."""
+    earlier = (now - timedelta(days=2)).isoformat()
+    later = (now - timedelta(days=1)).isoformat()
+    return [
+        Match(
+            match_id=FIXTURE_MATCH_IDS[0],
+            match_url=f"https://fixture.local/matches/{FIXTURE_MATCH_IDS[0]}",
+            map_links=[
+                (map_id, f"https://fixture.local/stats/maps/{map_id}")
+                for map_id in FIXTURE_MAP_IDS[:3]
+            ],
+            demo_links=[],
+            team1=TEAM_ALPHA,
+            team2=TEAM_BRAVO,
+            score1=2,
+            score2=1,
+            winner=TEAM_ALPHA,
+            event="CI Fixture Cup",
+            match_type="bo3",
+            forfeit=False,
+            date=earlier,
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        ),
+        Match(
+            match_id=FIXTURE_MATCH_IDS[1],
+            match_url=f"https://fixture.local/matches/{FIXTURE_MATCH_IDS[1]}",
+            map_links=[
+                (
+                    FIXTURE_MAP_IDS[3],
+                    f"https://fixture.local/stats/maps/{FIXTURE_MAP_IDS[3]}",
+                )
+            ],
+            demo_links=[],
+            team1=TEAM_ALPHA,
+            team2=TEAM_CHARLIE,
+            score1=0,
+            score2=1,
+            winner=TEAM_CHARLIE,
+            event="CI Fixture Cup",
+            match_type="bo1",
+            forfeit=False,
+            date=later,
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        ),
+    ]
+
+
+def fixture_maps(now: datetime) -> list[Map]:
+    """Four maps; Mirage repeats across matches to exercise dim_maps grain."""
+    earlier = (now - timedelta(days=2)).isoformat()
+    later = (now - timedelta(days=1)).isoformat()
+    specs = [
+        (FIXTURE_MAP_IDS[0], FIXTURE_MATCH_IDS[0], "Mirage", 1, 13, 7, TEAM_ALPHA, earlier),
+        (FIXTURE_MAP_IDS[1], FIXTURE_MATCH_IDS[0], "Inferno", 2, 9, 13, TEAM_BRAVO, earlier),
+        (FIXTURE_MAP_IDS[2], FIXTURE_MATCH_IDS[0], "Nuke", 3, 13, 11, TEAM_ALPHA, earlier),
+        (FIXTURE_MAP_IDS[3], FIXTURE_MATCH_IDS[1], "Mirage", 1, 8, 13, TEAM_CHARLIE, later),
+    ]
+    return [
+        Map(
+            map_id=map_id,
+            match_id=match_id,
+            map_url=f"https://fixture.local/stats/maps/{map_id}",
+            map_name=map_name,
+            map_order=map_order,
+            team1_score=score1,
+            team2_score=score2,
+            map_winner=winner,
+            date=date,
+            inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
+        for map_id, match_id, map_name, map_order, score1, score2, winner, date in specs
+    ]
+
+
+def fixture_players(now: datetime) -> list[Player]:
+    """Six player-map rows over three players and two teams per map."""
+    specs = [
+        (FIXTURE_MAP_IDS[0], FIXTURE_PLAYER_IDS[0], "fixA1", TEAM_ALPHA, "Mirage", 1.35),
+        (FIXTURE_MAP_IDS[0], FIXTURE_PLAYER_IDS[1], "fixB1", TEAM_BRAVO, "Mirage", 0.87),
+        (FIXTURE_MAP_IDS[1], FIXTURE_PLAYER_IDS[0], "fixA1", TEAM_ALPHA, "Inferno", 1.02),
+        (FIXTURE_MAP_IDS[1], FIXTURE_PLAYER_IDS[1], "fixB1", TEAM_BRAVO, "Inferno", 1.18),
+        (FIXTURE_MAP_IDS[3], FIXTURE_PLAYER_IDS[0], "fixA1", TEAM_ALPHA, "Mirage", 0.95),
+        (FIXTURE_MAP_IDS[3], FIXTURE_PLAYER_IDS[2], "fixC1", TEAM_CHARLIE, "Mirage", 1.44),
+    ]
+    return [
+        Player(
+            map_id=map_id,
+            player_id=player_id,
+            player_name=player_name,
+            player_url=f"https://fixture.local/player/{player_id}",
+            map_name=map_name,
+            team_name=team_name,
+            kills=20,
+            headshots=10,
+            assists=4,
+            flash_assists=2,
+            deaths=15,
+            traded_deaths=3,
+            opening_kills=2,
+            opening_deaths=1,
+            multi_kills=3,
+            clutches_won=1,
+            kast=72.5,
+            kd_diff=5,
+            adr=81.3,
+            fk_diff=1,
+            round_swing=0.1,
+            rating=rating,
+            last_inserted_at=now,
+            last_scraped_at=now,
+            last_updated_at=now,
+            data_complete=True,
+        )
+        for map_id, player_id, player_name, team_name, map_name, rating in specs
+    ]
+
+
+def main() -> int:
+    """Seed the fixture rows through the storage layer."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="Permit seeding a non-local disposable database.",
+    )
+    args = parser.parse_args()
+
+    require_local_database(args.allow_remote)
+    now = datetime.now(UTC)
+    store_matches(fixture_matches(now))
+    store_maps(fixture_maps(now))
+    store_players(fixture_players(now))
+    logger.info(
+        "Seeded dbt CI fixture: %d matches, %d maps, %d player rows.",
+        len(FIXTURE_MATCH_IDS),
+        len(FIXTURE_MAP_IDS),
+        6,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_dbt_ci_fixture.py
+++ b/scripts/seed_dbt_ci_fixture.py
@@ -187,14 +187,17 @@ def main() -> int:
 
     require_local_database(args.allow_remote)
     now = datetime.now(UTC)
-    store_matches(fixture_matches(now))
-    store_maps(fixture_maps(now))
-    store_players(fixture_players(now))
+    matches = fixture_matches(now)
+    maps = fixture_maps(now)
+    players = fixture_players(now)
+    store_matches(matches)
+    store_maps(maps)
+    store_players(players)
     logger.info(
         "Seeded dbt CI fixture: %d matches, %d maps, %d player rows.",
-        len(FIXTURE_MATCH_IDS),
-        len(FIXTURE_MAP_IDS),
-        6,
+        len(matches),
+        len(maps),
+        len(players),
     )
     return 0
 

--- a/tests/test_seed_dbt_ci_fixture.py
+++ b/tests/test_seed_dbt_ci_fixture.py
@@ -1,0 +1,49 @@
+"""Tests for the dbt CI fixture seeder's local-database guard and shape."""
+
+from scripts import seed_dbt_ci_fixture
+from scripts.seed_dbt_ci_fixture import (
+    fixture_maps,
+    fixture_matches,
+    fixture_players,
+    require_local_database,
+)
+from datetime import UTC, datetime
+
+
+def test_require_local_database_accepts_local_hosts(monkeypatch) -> None:
+    for host in seed_dbt_ci_fixture.LOCAL_HOSTS:
+        monkeypatch.setenv("DB_HOST", host)
+        require_local_database(allow_remote=False)
+
+
+def test_require_local_database_rejects_remote_host(monkeypatch) -> None:
+    monkeypatch.setenv("DB_HOST", "some-remote-host.example.com")
+
+    try:
+        require_local_database(allow_remote=False)
+    except RuntimeError as exc:
+        assert "not local" in str(exc)
+    else:
+        raise AssertionError("Expected a remote DB_HOST to be rejected")
+
+    require_local_database(allow_remote=True)
+
+
+def test_fixture_satisfies_tested_invariants() -> None:
+    now = datetime.now(UTC)
+    matches = fixture_matches(now)
+    maps = fixture_maps(now)
+    players = fixture_players(now)
+
+    team_pairs = {m.match_id: {m.team1, m.team2} for m in matches}
+    for match in matches:
+        assert match.winner in team_pairs[match.match_id]
+
+    map_ids = {m.map_id for m in maps}
+    map_names = {m.map_name for m in maps}
+    assert len({(m.match_id, m.map_order) for m in maps}) == len(maps)
+    for player in players:
+        assert player.map_id in map_ids
+        assert player.map_name in map_names
+        assert player.rating is not None
+    assert len({(p.map_id, p.player_id) for p in players}) == len(players)


### PR DESCRIPTION
## Summary

Adds a `dbt-build` job to ci.yml so every push and PR builds the full
dbt layer - models, the SCD2 snapshot, and all data tests - against a
disposable Postgres service container seeded with a small checked-in
fixture. With the API now serving from the marts (#150), a broken model
or failing test is a production-serving regression; until now nothing in
CI exercised dbt before merge (the #146 scheduled prod build only
catches breakage after). Any model or data-test failure fails the
workflow.

## Related Issue

Closes #144

## Scope

- `.github/workflows/ci.yml`: new `dbt-build` job (postgres:17 service,
  Alembic migrations, fixture seed, `dbt deps`, `dbt build`); runs in
  parallel with the existing lint/type/test job on the same triggers
- `scripts/seed_dbt_ci_fixture.py` (new): seeds two matches, four maps,
  and six player-map rows through the real storage layer
  (`store_matches`/`store_maps`/`store_players`), so the fixture cannot
  drift from the ingestion schema; refuses non-local `DB_HOST` without
  `--allow-remote`
- `tests/test_seed_dbt_ci_fixture.py` (new): covers the local-database
  guard and the fixture invariants the dbt tests depend on
- `README.md`: documents the CI-verified dbt layer
- `docs/backlog.md`: checks off the #144 legibility item

## Out of Scope

- No changes to dbt models or tests themselves
- No deployed-database runs; the job uses dbt's default dev target,
  whose `DBT_DB_*` defaults match the service container exactly
- dbt docs publishing (#145)

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: CI-only change plus a fixture script that guards against
non-local databases; no application, schema, or dbt-model changes. The
new job can only affect merges by failing them, which is its purpose.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README's dbt section now states the layer is CI-verified and
how the fixture works; CI behavior changes require doc updates per the
documentation policy.

Backlog: Updated

Reason: The #144 Phase 4 legibility checklist item is checked off and
Current Position reflects it.

## Verification

Commands run:

- `uv run pytest --cov`, ruff, mypy
- Full local dry run of the CI sequence against a disposable database
  (`cs2_db_ci` in the compose Postgres, dropped afterward): Alembic
  migrate, fixture seed, `dbt deps`, `dbt build`
- Red/green gate check: added a deliberately failing singular dbt test,
  reran `dbt build`, then reverted

Results:

- pytest: 204 passed; total coverage 81.50% (gate 80%). Ruff and mypy
  clean.
- Green path: `dbt build` passes 74/74 (5 views, 5 tables, 1 snapshot,
  63 data tests) on the seeded fixture in ~1.5s
- Red path: the failing test yields `FAIL 1` and exit code 1, which
  fails the workflow step; removing it restores 74/74
- This PR's own CI run is the workflow-level green verification of the
  new job

## Review Notes

- Fixture-seeding design choice from the issue: seeding through the
  storage layer was chosen over a raw SQL file so the fixture is
  validated by the real schema constraints and write path.
- Finding from red-path testing: the ingestion schema's PK/FK/CHECK
  constraints block source-level corruption (bad winner, orphan player
  rows), so this job's marginal value is guarding the transformation
  logic and tests themselves - which is exactly what changes most.
- The job adds roughly a uv sync plus ~10s of DB work per CI run and
  runs in parallel with the existing job, so wall-clock impact is
  minimal.
