### PR TITLE
Present the shipped dbt layer in the README (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ idle periods.)
 This project is a Counter-Strike 2 analytics tool focused on collecting professional match, map, and player data and turning it into reliable, queryable analytics data.
 
 The system is deployed end to end: a Python ingestion pipeline writes to
-PostgreSQL, a FastAPI service on Render serves player statistics, and a React
-SPA on GitHub Pages presents them publicly.
+PostgreSQL, a dbt transformation layer builds tested fact and dimension
+marts from the raw tables (rebuilt daily against the deployed database),
+a FastAPI service on Render serves player statistics from those marts, and
+a React SPA on GitHub Pages presents them publicly.
 
 The current ingestion architecture uses PostgreSQL-backed ingestion-state tables, thin controllers for batch orchestration, and stage services for per-item match/map workflow boundaries.
 
@@ -31,24 +33,32 @@ The current ingestion architecture uses PostgreSQL-backed ingestion-state tables
 - Map processing collects player performance metrics such as kills, deaths, assists, ADR, KAST, opening duels, multi-kills, clutches, and round swing.
 - Ingestion hardening uses retry/backoff, browser session recovery, and lifecycle tracking for resilient scraping runs.
 
+### Analytics Transformation (dbt)
+
+- Staging, intermediate, and mart layers over the ingestion schema, with
+  data tests on every layer (see
+  [Transformation Layer (dbt)](#transformation-layer-dbt)).
+- SCD2 `player_roster_history_snapshot` records player-to-team roster
+  history from observed changes.
+- The marts serve the API's read paths, rebuild daily against the deployed
+  database behind a source-freshness gate, and build in CI on every push.
+
 ### Deferred / Later-Phase Work
 
 - Demo processing: deferred; the demo subsystem lives on the
   `feature/demo-parsing` branch, while demo link discovery and
   `demo_ingestion_state` tracking remain on `main`.
-- Deployment baseline: containerized runtime, environment-driven configuration,
-  migrations, CI, and smoke tests come before dbt.
-- dbt transformation layer: dbt follows the deployment baseline and stays
-  downstream of ingestion.
-- Airflow orchestration: Airflow comes after dbt and clean stage boundaries.
+- Airflow orchestration: Airflow comes after dbt operational depth; the
+  scheduled daily dbt build is the interim orchestration it would replace.
 
 ## Tech Stack
 
 - Python 3.12
 - SeleniumBase and BeautifulSoup for web scraping
 - PostgreSQL for structured data storage, with Alembic-managed migrations
-- dbt for the downstream analytics transformation layer (Phase 4, in
-  progress)
+- dbt for the analytics transformation layer (staging / intermediate /
+  marts, SCD2 snapshot, data tests; CI-verified and rebuilt daily in
+  production)
 - FastAPI for the public read API (deployed on Render)
 - React, TypeScript, and Vite for the public frontend (deployed on GitHub
   Pages)
@@ -215,8 +225,8 @@ python manage_db.py --wipe
 ```
 
 The wipe command asks for `y` confirmation before dropping tables. Alembic owns
-the application/source schema; future dbt models will remain downstream and
-will not manage ingestion tables.
+the application/source schema; the dbt models are downstream and do not
+manage ingestion tables.
 
 ### 6. Run With Docker Compose
 
@@ -376,7 +386,7 @@ instead of silently freezing snapshot history.
 dbt owns analytics transformations only; the ingestion schema stays owned by
 Alembic migrations. Sources are declared for the `matches`, `maps`, and
 `players` tables. The staging layer (`stg_matches`, `stg_maps`, `stg_players`)
-is thin views over those sources. See `docs/dbt_models.md` for the planned
+is thin views over those sources. See `docs/dbt_models.md` for the
 model layers.
 
 Note: Demo processing is still deferred and intentionally remains outside the active ingestion pipeline; its implementation lives on the `feature/demo-parsing` branch.
@@ -404,6 +414,84 @@ results discovery
 -> MapStageService per-item workflow
 -> relational storage
 ```
+
+## Transformation Layer (dbt)
+
+The analytics warehouse is a shipped dbt project (`dbt/`) layered over the
+ingestion schema: staging views standardize the Alembic-owned source
+tables, intermediate views factor the reusable joins, and mart tables are
+the analytics-facing contract. The marts are not a side artifact - the
+API's read paths query them in production, they are rebuilt daily against
+the deployed database by a scheduled workflow, and the whole DAG builds
+and tests in CI on every push.
+
+```mermaid
+flowchart LR
+    subgraph sources["public schema (Alembic-owned)"]
+        matches
+        maps
+        players
+    end
+    subgraph staging["staging (views)"]
+        stg_matches
+        stg_maps
+        stg_players
+    end
+    subgraph intermediate["intermediate (views)"]
+        int_mps["int_match_player_stats"]
+        int_pct["int_player_current_team"]
+    end
+    subgraph marts["marts (tables)"]
+        fact_matches
+        fact_pms["fact_player_map_stats"]
+        dim_players
+        dim_maps
+        dim_prh["dim_player_roster_history"]
+    end
+    snap["player_roster_history_snapshot (SCD2)"]
+    api["FastAPI read paths"]
+
+    matches --> stg_matches
+    maps --> stg_maps
+    players --> stg_players
+    stg_matches --> int_mps
+    stg_maps --> int_mps
+    stg_players --> int_mps
+    stg_matches --> fact_matches
+    stg_maps --> fact_matches
+    stg_maps --> dim_maps
+    stg_players --> dim_players
+    int_mps --> fact_pms
+    int_mps --> int_pct
+    int_pct --> snap
+    snap --> dim_prh
+    marts --> api
+```
+
+Mart grains:
+
+| Model | Grain | Notes |
+| --- | --- | --- |
+| `fact_player_map_stats` | one row per player per map (`map_id`, `player_id`) | per-map performance stats; serves the top players API read path |
+| `fact_matches` | one row per match (`match_id`) | derives winning/losing team and map count |
+| `dim_players` | one row per player (`player_id`) | player identity for joins |
+| `dim_maps` | one row per map name (`map_name`) | map catalog across matches |
+| `dim_player_roster_history` | one row per player-team membership interval (`player_id`, `valid_from`) | SCD2 shaped over the snapshot, with `is_current` flag |
+
+The SCD2 piece is `player_roster_history_snapshot`: a dbt snapshot that
+records player-to-team roster membership over time. The source data has no
+reliable roster-change timestamps, so a `check`-strategy snapshot is the
+right tool - each run compares every player's derived current team against
+recorded history and effective-dates any change, so validity ranges come
+from observed changes rather than trusting parsed dates. History accrues
+run over run, which is why the scheduled daily build exists.
+
+Every layer carries data tests (uniqueness of the declared grains,
+not-null keys, and relationship tests between models - 63 in total), run
+by `dbt build` locally, in CI against a disposable Postgres, and daily
+against production behind a source-freshness gate. Local run instructions
+are in [section 10](#10-run-dbt-analytics-transformations); model-level
+documentation lives in `docs/dbt_models.md`.
 
 ## Design Decisions & Tradeoffs
 
@@ -448,7 +536,7 @@ The parsed source tables were locked to explicit grains before any
 analytics work: `matches` is one row per match, `maps` one row per played
 map, `players` one row per player per map. Storage writes are upserts that
 refresh trusted fields, so re-running ingestion over the same matches never
-duplicates rows. This was done ahead of the planned dbt layer because
+duplicates rows. This was done ahead of the dbt layer because
 transformation models are only as trustworthy as their sources — building
 dbt on tables that could drift or duplicate would push data-quality
 firefighting downstream where it is hardest to debug. The tradeoff is
@@ -466,17 +554,17 @@ Docker Compose (`python run_api.py` for the API, `python main.py` for the
 pipeline) — one runtime to debug instead of a separate cloud configuration.
 Production validation is read-only by policy: health checks and DB-backed
 reads, with write-based smoke tests restricted to disposable databases. The tradeoff is fewer operational
-capabilities (no scheduling, manual migrations) in exchange for a
-deployment simple enough to reason about while the data layer is still
-evolving.
+capabilities (no ingestion scheduling, manual migrations) in exchange for a
+deployment simple enough to reason about while the data layer was still
+evolving; the scheduled daily dbt build was added once the transformation
+layer stabilized.
 
 ### Demo parsing deferred behind a preserved boundary
 
 Demo files introduce a different workload class: large binary downloads,
 temporary-file lifecycle, long parses, and event-level extraction. Rather
 than bolt that onto the match/map surface, demo processing is deferred
-until the analytics layer (dbt) exists and downstream demo needs are
-concrete. The boundary is kept, not deleted: demo links are still
+until downstream demo needs are concrete. The boundary is kept, not deleted: demo links are still
 discovered during match processing and tracked in the demo
 ingestion-state table, while the non-working downloader/parser
 implementation lives on the `feature/demo-parsing` branch until
@@ -485,15 +573,20 @@ controller/stage-service pattern later. The tradeoff is no event-level
 stats yet, in exchange for keeping the active pipeline small enough to
 harden and deploy.
 
-## Data Insights & Usage (planned)
+## Data Insights & Usage
 
-- Current API surface includes a player-oriented read path for top players by
-  average rating, shown live on the public demo page.
+Live today:
+
+- Top players by average rating, served from the dbt marts and shown on
+  the public demo page.
+- Point-in-time roster queries over `dim_player_roster_history` (SCD2).
+
+Planned:
+
 - View per-match player performance.
 - Compare teams' win rates on specific maps.
 - Identify key players in matchups.
-- Add transformed analytics models through dbt.
-- Expand API read paths over trusted transformed tables.
+- Additional API read paths over the mart layer (matches, teams).
 
 ## Developer Notes
 
@@ -501,14 +594,17 @@ See `docs/` for architecture and roadmap details.
 
 Current architecture direction:
 
-- Phases 2, 3, 3.5, 3.6, and 3.75 are complete.
+- Phases 2 through 3.9 are complete, as is Phase 4 (the dbt transformation
+  layer: staging / intermediate / marts, data tests, and the SCD2 roster
+  snapshot).
 - Frontend Phase A shipped the public GitHub Pages demo backed by the live
   API (see `docs/frontend_backlog.md`).
-- Phase 3.9 (environment and tooling hardening) is in progress.
-- Phase 4 (dbt transformation layer) follows Phase 3.9. Entry criteria include
-  v1.0 hardening items for ingestion layer correctness and atomic writes.
+- Phase 4.5 (dbt operations and depth) is in progress: the scheduled daily
+  prod build, CI dbt build, and mart-backed API read paths are shipped;
+  incremental materializations and deeper data quality remain.
 - Demo pipeline implementation remains deferred.
-- Airflow comes after dbt and clean transformation boundaries.
+- Airflow comes after dbt operational depth and would replace the
+  scheduled-build workflow.
 
 ## License
 

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -1,9 +1,9 @@
 # Current Architecture State
 
-This document summarizes the active architecture as of the first cloud
-deployment and the enforced scraper boundary (post-Phase 3.75, frontend
-Phase A complete, Phase 3.9 in progress). For the longer architecture
-overview, see `docs/architecture/overview.md`.
+This document summarizes the active architecture as of the shipped dbt
+transformation layer and its operations baseline (Phases 2-4 and frontend
+Phase A complete; Phase 4.5 dbt operations and depth in progress). For
+the longer architecture overview, see `docs/architecture/overview.md`.
 
 ## Active Runtime Flow
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -15,9 +15,10 @@ The schema uses PostgreSQL ingestion-state tables directly, and the active resul
 - demo processing remains deferred; its implementation lives on the
   `feature/demo-parsing` branch while demo link discovery and
   `demo_ingestion_state` tracking stay on `main`
-- deployment baseline work is the next architecture phase before dbt
-- dbt remains the next analytics layer after deployment baseline hardening
-- Airflow remains later, after dbt
+- the deployment baseline and the dbt transformation layer are complete:
+  the marts serve the API read paths, rebuild daily against the deployed
+  database, and build with their tests in CI
+- Airflow remains later, after dbt operational depth
 
 ## Current Flow
 
@@ -46,11 +47,12 @@ The intended design is:
 - stage-specific processing reads from those lifecycle rows
 - per-item stage workflow is handled by dedicated stage services
 - controllers stay thin and focus on batch-level concerns
-- deployment baseline work happens before dbt so runtime, configuration,
-  migrations, containers, CI, and smoke tests are reproducible
-- dbt is added after ingestion semantics, stage boundaries, and deployment
-  baseline assumptions are stable
-- Airflow is added only after dbt exists and the stage boundaries are clean
+- deployment baseline work happened before dbt so runtime, configuration,
+  migrations, containers, CI, and smoke tests were reproducible first
+- dbt was added after ingestion semantics, stage boundaries, and deployment
+  baseline assumptions stabilized; it stays downstream of ingestion
+- Airflow is added only after dbt operational depth and would replace the
+  scheduled dbt build workflow
 
 ## Stage Responsibilities
 
@@ -187,12 +189,13 @@ The demo processing implementation should stay deferred until:
 
 1. Keep the current `*_ingestion_state` tables stable.
 2. Keep controller/stage-service responsibilities clean as ingestion evolves.
-3. Finish Phase 3.9 tooling hardening and the Phase 4 entry criteria
-   (v1.0 hardening items) before adding dbt; the Phase 3.75 deployment
-   baseline is complete and live.
-4. Implement dbt models over the stable `matches`, `maps`, and `players`
-   parsed-source grains.
-5. Implement Airflow after dbt exists and the stage boundaries are clean.
+3. Keep the dbt layer downstream of ingestion: the models over the stable
+   `matches`, `maps`, and `players` grains are implemented, serve the API
+   read paths, and are rebuilt daily and CI-verified.
+4. Deepen dbt operations (incremental materializations, data-quality
+   depth) per the Phase 4.5 backlog.
+5. Implement Airflow after dbt operational depth; it replaces the
+   scheduled dbt build workflow.
 
 ## Rules
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,9 +22,9 @@ Current priorities:
   Phase 4 legibility tasks because it is the only calendar-sensitive item:
   SCD2 roster history only accrues while it runs, and gaps cannot be
   backfilled. It is delivered by the Scheduled dbt Build workflow.
-- finish the Phase 4 legibility follow-through: README presents the
-  shipped layer (#143) and dbt docs publish to GitHub Pages (#145); dbt
-  build now runs in CI on every push/PR (#144)
+- finish the Phase 4 legibility follow-through: dbt docs publish to
+  GitHub Pages (#145) is the remaining item; the README presents the
+  shipped layer (#143) and dbt build runs in CI on every push/PR (#144)
 - continue Phase 4.5 (dbt operations and depth) with #132, #147, and #148
   in dependency order; the API read paths already point at the marts
   (#150)
@@ -754,8 +754,11 @@ writes into.
 The transformation layer is built; these make it visible from outside the
 repo.
 
-- [ ] Present the shipped dbt layer in the README: lineage diagram, SCD2
-      snapshot callout, mart grain table (#143)
+- [x] Present the shipped dbt layer in the README: lineage diagram, SCD2
+      snapshot callout, mart grain table (#143) - Transformation Layer
+      section with Mermaid lineage, grain table, and test/CI/scheduled
+      run framing; stale planned/in-progress wording swept from README
+      and docs/dbt_models.md
 - [x] Run dbt build (models, snapshots, tests) in CI against a disposable
       Postgres with seeded fixtures (#144) - the ci.yml dbt-build job
       migrates a service container, seeds a checked-in fixture through

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -1,35 +1,28 @@
 # dbt Models
 
-This document describes the planned dbt model structure for the CS2 Analytics project.
+This document describes the dbt model structure for the CS2 Analytics project.
 
-dbt is the Phase 4 transformation layer. The project skeleton is initialized
-under `dbt/` (#109): an environment-driven Postgres profile reusing the
-application's `DB_*` variables, and source declarations for the Alembic-owned
-`matches`, `maps`, and `players` tables. Models are still planned work.
+The transformation layer is implemented (#109-#114, #130) under `dbt/`:
+staging, intermediate, and mart models, data tests on every layer, and the
+SCD2 `player_roster_history_snapshot`. The marts serve the API's read
+paths (#150), rebuild daily against the deployed database on a scheduled
+workflow (#146), and build with their tests in CI on every push (#144).
+Some sections below keep their original design-note voice; per-section
+`Status:` lines record what is implemented versus planning-only.
 
 dbt is not part of the ingestion pipeline; it consumes ingestion outputs
 downstream. Setup and run commands are in the README.
 
 Note:
-Planned raw snapshot tables (for example `raw_matches` and `raw_maps`) are expected to be introduced around dbt rollout time, not before.
-
-Completed prerequisite order:
-
-1. review lifecycle semantics for the current match/map discovery tables
-2. update the current state tables and their audit fields
-3. thin `MatchController` and `MapController` by introducing stage services
-4. stabilize the active `matches`, `maps`, and `players` grains for dbt
-   readiness
-
-Next dependency:
-
-5. add dbt scaffolding and staging models over the active parsed-source tables
+Raw snapshot tables (for example `raw_matches` and `raw_maps`) were not
+introduced; the pipeline does not persist raw HTML, so the `stg_raw_*`
+models below remain planning-only.
 
 ---
 
 ## Purpose
 
-dbt will be used to transform raw and structured PostgreSQL tables into clean, analytics-ready models.
+dbt transforms raw and structured PostgreSQL tables into clean, analytics-ready models.
 
 Its role in this project is to:
 
@@ -74,7 +67,7 @@ dbt should consume stable ingestion outputs, not compensate for ingestion-state 
 
 ---
 
-## Planned Model Layers
+## Model Layers
 
 The dbt project should be organized into three main layers:
 
@@ -110,7 +103,7 @@ Typical staging responsibilities:
 - expose one clean representation of each source table
 - avoid business-heavy logic
 
-## Planned staging models
+## Staging models
 
 ### stg_raw_matches
 
@@ -290,7 +283,7 @@ Typical intermediate responsibilities:
 - isolate transformation steps
 - reduce duplication across marts
 
-## Planned intermediate models
+## Intermediate models
 
 ### int_match_player_stats
 
@@ -410,7 +403,7 @@ Typical mart responsibilities:
 - support analytics and filtering
 - provide high-confidence tables for downstream consumers
 
-## Planned fact models
+## Fact models
 
 ### fact_matches
 
@@ -515,7 +508,7 @@ Use cases:
 
 ---
 
-## Planned dimension models
+## Dimension models
 
 ### dim_players
 
@@ -681,7 +674,7 @@ orchestration ("Phase 5 lite") and is what Airflow later replaces.
 
 ---
 
-## Planned Directory Structure
+## Directory Structure
 
 The dbt project should follow a clear folder structure:
 
@@ -842,7 +835,7 @@ This keeps transformation logic out of the API code and reinforces separation of
 
 ---
 
-## Planned Rollout Order
+## Rollout Order (as executed)
 
 dbt should be introduced now that lifecycle semantics, active-stage
 responsibilities, and match/map/player grains are stable.


### PR DESCRIPTION
## Summary

Presents the shipped dbt layer in the README instead of framing it as
future work. Adds a Transformation Layer (dbt) section with a Mermaid
lineage diagram (sources -> staging -> intermediate -> marts/snapshot ->
API), a mart grain table for all five marts, an SCD2 callout for
`player_roster_history_snapshot`, and the data-test / CI / scheduled-run
framing. Sweeps the stale "Phase 4, in progress" wording repo-wide in
the README and fixes the contradicting intro in docs/dbt_models.md.

## Related Issue

Closes #143

## Scope

- `README.md`: new Transformation Layer (dbt) section before Design
  Decisions; project overview names the mart-backed serving path;
  Features gains an Analytics Transformation subsection and drops dbt
  from deferred work; Tech Stack, Design Decisions prose, Data Insights,
  and Developer Notes updated where they described dbt as pending
- `docs/dbt_models.md`: intro said "Models are still planned work" -
  now records the implemented layer (#109-#114, #130) and operational
  state (#144, #146, #150); "Planned X" headings renamed, per-section
  Status lines still distinguish implemented from planning-only models
- `docs/backlog.md`: #143 legibility item checked off

## Out of Scope

- No model or SQL changes
- CI integration for dbt (#144, merged separately)
- Publishing dbt docs to GitHub Pages (#145)

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Docs-only. No code, configuration, or dbt models touched; the
documented commands are unchanged.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: This PR is the documentation change - README plus the
docs/dbt_models.md cross-check required by the issue's acceptance
criteria.

Backlog: Updated

Reason: The #143 Phase 4 legibility checklist item is checked off and
Current Position now names #145 as the remaining legibility item.

## Verification

Commands run:

- Proofread the rendered Markdown (diagram, table, anchors); the
  section link targets `### 10. Run dbt (analytics transformations)`
- Cross-checked lineage edges in the diagram against the actual
  `ref()`/`source()` calls in `dbt/models/` and `dbt/snapshots/`
- Docs-only; tests not required (no executable behavior changed, and
  the documented dbt commands are untouched)

Results:

- Lineage diagram matches the real DAG edge-for-edge
- No remaining "planned/in progress" framing for dbt in README (the
  survivors are the CLI's own help text and the deliberate Planned list
  in Data Insights)

## Review Notes

- Framing is portfolio-driven per the issue: the new section leads with
  the marts being consumed (API, daily rebuild, CI) rather than merely
  existing. Section ordering: the dbt section sits between Architecture
  Notes and Design Decisions - flagged in the issue for review.
- The mermaid diagram should be spot-checked once on the rendered
  GitHub view of this PR branch.
