### PR TITLE
Publish generated dbt docs to GitHub Pages under /dbt-docs/ (#145)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,4 +1,13 @@
-name: Deploy Frontend To GitHub Pages
+name: Deploy GitHub Pages
+
+# Publishes the single GitHub Pages artifact: the React frontend at the
+# site root plus the generated dbt docs site under /dbt-docs/. Pages
+# deployments replace the whole site, so both must ship in one artifact -
+# a frontend-only deploy would drop the dbt docs and vice versa.
+#
+# The dbt docs are generated against a disposable Postgres service seeded
+# with the CI fixture (scripts/seed_dbt_ci_fixture.py); no deployed
+# database is involved.
 
 on:
   push:
@@ -6,6 +15,8 @@ on:
       - main
     paths:
       - "frontend/**"
+      - "dbt/**"
+      - "scripts/seed_dbt_ci_fixture.py"
       - ".github/workflows/deploy-frontend.yml"
   workflow_dispatch:
 
@@ -20,13 +31,32 @@ concurrency:
 
 jobs:
   build:
-    name: Build Frontend
+    name: Build Frontend And dbt Docs
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
-    defaults:
-      run:
-        working-directory: frontend
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: cs2_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: change_me
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d cs2_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_NAME: cs2_db
+      DB_USER: postgres
+      DB_PASS: change_me
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+      DBT_DB_HOST: 127.0.0.1
 
     steps:
       - name: Check out repository
@@ -41,14 +71,51 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies
+      - name: Install frontend dependencies
         run: npm ci
+        working-directory: frontend
 
-      - name: Build
+      - name: Build frontend
         run: npm run build
+        working-directory: frontend
 
       - name: Add SPA fallback for deep links
         run: cp dist/index.html dist/404.html
+        working-directory: frontend
+
+      - name: Set up Python
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run migrations
+        run: uv run alembic -c cs2_analytics/alembic.ini upgrade head
+
+      - name: Seed dbt fixture data
+        run: uv run python scripts/seed_dbt_ci_fixture.py
+
+      - name: Install dbt packages
+        run: uv run dbt deps --project-dir dbt --profiles-dir dbt
+
+      - name: Build dbt models, snapshots, and tests
+        run: uv run dbt build --project-dir dbt --profiles-dir dbt
+
+      - name: Generate dbt docs
+        run: >-
+          uv run dbt docs generate --static
+          --project-dir dbt --profiles-dir dbt
+
+      - name: Add dbt docs to the Pages artifact
+        run: |
+          mkdir -p frontend/dist/dbt-docs
+          cp dbt/target/static_index.html frontend/dist/dbt-docs/index.html
 
       - name: Upload Pages artifact
         # actions/upload-pages-artifact@v5.0.0

--- a/README.md
+++ b/README.md
@@ -357,8 +357,10 @@ uv run dbt docs generate --project-dir dbt --profiles-dir dbt
 uv run dbt docs serve --project-dir dbt --profiles-dir dbt
 ```
 
-The generated site lives in `dbt/target/`, which is gitignored; docs are
-generated on demand, not committed or published.
+The generated site lives in `dbt/target/`, which is gitignored. The docs
+are also published: the Pages deploy workflow regenerates the static site
+whenever dbt models change on `main` and serves it at
+<https://dardenkyle.github.io/CS2-analytics/dbt-docs/>.
 
 To run against a deployed database on purpose, export its `DB_*` values and
 name the `prod` target explicitly:
@@ -489,8 +491,11 @@ run over run, which is why the scheduled daily build exists.
 Every layer carries data tests (uniqueness of the declared grains,
 not-null keys, and relationship tests between models - 63 in total), run
 by `dbt build` locally, in CI against a disposable Postgres, and daily
-against production behind a source-freshness gate. Local run instructions
-are in [section 10](#10-run-dbt-analytics-transformations); model-level
+against production behind a source-freshness gate. The generated dbt docs
+site - interactive lineage DAG and column-level documentation - is
+published at <https://dardenkyle.github.io/CS2-analytics/dbt-docs/>.
+Local run instructions are in
+[section 10](#10-run-dbt-analytics-transformations); model-level
 documentation lives in `docs/dbt_models.md`.
 
 ## Design Decisions & Tradeoffs

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,9 +22,9 @@ Current priorities:
   Phase 4 legibility tasks because it is the only calendar-sensitive item:
   SCD2 roster history only accrues while it runs, and gaps cannot be
   backfilled. It is delivered by the Scheduled dbt Build workflow.
-- finish the Phase 4 legibility follow-through: dbt docs publish to
-  GitHub Pages (#145) is the remaining item; the README presents the
-  shipped layer (#143) and dbt build runs in CI on every push/PR (#144)
+- the Phase 4 legibility follow-through is complete: the README presents
+  the shipped layer (#143), dbt build runs in CI on every push/PR (#144),
+  and the dbt docs site publishes to GitHub Pages (#145)
 - continue Phase 4.5 (dbt operations and depth) with #132, #147, and #148
   in dependency order; the API read paths already point at the marts
   (#150)
@@ -763,7 +763,10 @@ repo.
       Postgres with seeded fixtures (#144) - the ci.yml dbt-build job
       migrates a service container, seeds a checked-in fixture through
       the real storage layer, and fails on any model or test failure
-- [ ] Publish generated dbt docs (lineage DAG) to GitHub Pages (#145)
+- [x] Publish generated dbt docs (lineage DAG) to GitHub Pages (#145) -
+      the Pages deploy workflow composes one artifact: React frontend at
+      the site root, static dbt docs (generated against the CI fixture)
+      under /dbt-docs/; regenerates when dbt models change on main
 
 ---
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -815,6 +815,10 @@ Each model should have:
 
 This makes the project stronger both for maintainability and portfolio presentation.
 
+The generated docs site is published (#145): the Pages deploy workflow
+regenerates it whenever dbt models change on `main`, and it is browsable
+at `https://dardenkyle.github.io/CS2-analytics/dbt-docs/`.
+
 ---
 
 ## Relationship to the API Layer

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,11 +113,17 @@ Pages origin. For a project page such as
 
 ## Frontend GitHub Pages Deployment
 
-The public React SPA deploys to GitHub Pages through
-`.github/workflows/deploy-frontend.yml`. Pushes to `main` that touch
-`frontend/**` (or the workflow file) build the SPA with Node 24 (`npm ci`,
-`npm run build`) and publish `frontend/dist` to the `github-pages`
-environment. The workflow can also be run manually from the Actions tab.
+The public React SPA and the generated dbt docs site deploy to GitHub
+Pages together through `.github/workflows/deploy-frontend.yml`. Pages
+deployments replace the whole site, so the workflow composes one
+artifact: pushes to `main` that touch `frontend/**`, `dbt/**`, the CI
+fixture seeder, or the workflow file build the SPA with Node 24
+(`npm ci`, `npm run build`), generate the static dbt docs against a
+disposable Postgres service (migrations, fixture seed, `dbt build`,
+`dbt docs generate --static`), place them under `dist/dbt-docs/`, and
+publish `frontend/dist` to the `github-pages` environment. The dbt docs
+are served at `https://dardenkyle.github.io/CS2-analytics/dbt-docs/`.
+The workflow can also be run manually from the Actions tab.
 
 Deployment details:
 


### PR DESCRIPTION
## Summary

Publishes the generated dbt docs site (interactive lineage DAG,
column-level docs) to GitHub Pages at
`https://dardenkyle.github.io/CS2-analytics/dbt-docs/`. The Pages deploy
workflow now composes a single artifact - React frontend at the site
root, static dbt docs under `/dbt-docs/` - because Pages deployments
replace the whole site, so the two must ship together to avoid
clobbering each other. Docs regenerate automatically whenever dbt models
change on `main`.

## Related Issue

Closes #145

## Scope

- `.github/workflows/deploy-frontend.yml`: build job gains the #144 CI
  pattern (disposable postgres:17 service, Alembic migrations, fixture
  seed, `dbt build`) followed by `dbt docs generate --static`, whose
  single self-contained `static_index.html` is copied to
  `dist/dbt-docs/index.html` before the Pages artifact upload; triggers
  extended to `dbt/**` and the fixture seeder; filename kept (badge and
  three docs reference it), display name updated to Deploy GitHub Pages
- `README.md`: Transformation Layer section and the dbt run section link
  the published URL; the "not committed or published" claim corrected
- `docs/deployment.md`: describes the composed artifact and triggers
- `docs/dbt_models.md`: records the published URL
- `docs/backlog.md`: checks off #145; Phase 4 legibility follow-through
  (#143, #144, #145) recorded complete

## Out of Scope

- No model/column documentation content changes
- No custom styling of the dbt docs site
- No changes to the CI dbt job (#144) or scheduled prod build (#146)

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: Touches the production Pages deployment path shared with the
public frontend. Mitigated by keeping the frontend build steps
unchanged, composing rather than replacing the artifact, and the
concurrency group already serializing deploys. Docs generation uses only
the disposable service container - no deployed database involvement.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: Deployment behavior changed, so docs/deployment.md is updated;
README and docs/dbt_models.md link the published site and correct the
stale unpublished claim.

Backlog: Updated

Reason: #145 checked off; Current Position records the Phase 4
legibility follow-through as complete.

## Verification

Commands run:

- Full local dry run of the workflow's dbt steps against a disposable
  database (created and dropped in the compose Postgres): Alembic
  migrate, fixture seed, `dbt build`, `dbt docs generate --static`
- `uv run pytest --cov` (suite unaffected by workflow/docs changes)

Results:

- dbt build: 74/74 on the fixture; docs generate produced a 2.7MB
  self-contained `static_index.html` containing the staging,
  intermediate, mart, and snapshot models (verified by content grep)
- pytest: 204 passed; total coverage 81.50% (gate 80%)
- End-to-end Pages verification is post-merge by nature: the merge
  triggers the workflow (paths include the workflow file), then open
  the published URL, click through the DAG, spot-check
  `dim_player_roster_history` and the snapshot, and confirm the
  frontend remains live at the site root

## Review Notes

- Pages layout decision from the issue: subpath (`/dbt-docs/`) in one
  composed artifact, since the modern deploy-pages flow replaces the
  entire site per deployment - a separate Pages site would need a second
  repo.
- `--static` was chosen over the default docs output because it bundles
  manifest/catalog into one HTML file, avoiding runtime JSON fetches
  and subpath pathing issues.
- The docs are generated from the CI fixture, so lineage/columns/tests
  are fully representative but row counts in the docs reflect fixture
  data, not production - acceptable for a public design artifact and
  keeps deployed credentials out of the Pages build entirely.
