### PR TITLE
Drop dependent dbt views before retyping audit columns in migration 0003 (#157)

### DIFF
--- a/cs2_analytics/alembic/versions/20260831_0003_normalize_audit_timestamps.py
+++ b/cs2_analytics/alembic/versions/20260831_0003_normalize_audit_timestamps.py
@@ -29,6 +29,15 @@ depends_on: str | Sequence[str] | None = None
 
 AUDIT_TABLES = ("matches", "players")
 AUDIT_COLUMNS = ("inserted_at", "last_scraped_at", "last_updated_at")
+DEPENDENT_DBT_VIEWS = ("analytics.stg_matches", "analytics.stg_players")
+
+
+def _drop_dependent_dbt_views() -> None:
+    # dbt-owned staging views select the audit columns, which blocks the
+    # type change; they hold no data and dbt rebuilds them. IF EXISTS keeps
+    # fresh databases (CI, new local setups) working.
+    for view_name in DEPENDENT_DBT_VIEWS:
+        op.execute(f"DROP VIEW IF EXISTS {view_name} CASCADE")
 
 
 def _convert_audit_columns(table_name: str, target_type: str) -> None:
@@ -44,6 +53,7 @@ def _convert_audit_columns(table_name: str, target_type: str) -> None:
 
 
 def upgrade() -> None:
+    _drop_dependent_dbt_views()
     for table_name in AUDIT_TABLES:
         op.alter_column(
             table_name,
@@ -54,6 +64,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    _drop_dependent_dbt_views()
     for table_name in AUDIT_TABLES:
         _convert_audit_columns(table_name, "TIMESTAMP")
         op.alter_column(

--- a/cs2_analytics/alembic/versions/20260831_0003_normalize_audit_timestamps.py
+++ b/cs2_analytics/alembic/versions/20260831_0003_normalize_audit_timestamps.py
@@ -13,6 +13,14 @@ audit fields. The skew is bounded, affects audit metadata only, and there
 is no per-row discriminator to correct it, so a uniform UTC
 interpretation is used.
 
+Derived-object dependency (issue #157): PostgreSQL refuses to change a
+column's type while a view depends on it, and the dbt staging views
+`analytics.stg_matches` and `analytics.stg_players` select these audit
+columns. The migration therefore drops those views first, with CASCADE
+taking the dependent intermediate views. They are derived, data-free
+objects that dbt recreates on its next build; the marts and the SCD2
+snapshot are tables and are not affected.
+
 Revision ID: 20260831_0003
 Revises: 20260716_0002
 Create Date: 2026-08-31
@@ -33,9 +41,12 @@ DEPENDENT_DBT_VIEWS = ("analytics.stg_matches", "analytics.stg_players")
 
 
 def _drop_dependent_dbt_views() -> None:
-    # dbt-owned staging views select the audit columns, which blocks the
-    # type change; they hold no data and dbt rebuilds them. IF EXISTS keeps
-    # fresh databases (CI, new local setups) working.
+    """Drop the dbt staging views that depend on the audit columns.
+
+    PostgreSQL blocks retyping a column a view selects. The views hold no
+    data and dbt rebuilds them on its next run; IF EXISTS keeps fresh
+    databases (CI, new local setups) working.
+    """
     for view_name in DEPENDENT_DBT_VIEWS:
         op.execute(f"DROP VIEW IF EXISTS {view_name} CASCADE")
 


### PR DESCRIPTION
## Summary

Migration `20260831_0003` failed on the deployed database with
`cannot alter type of a column used by a view or rule` because the dbt
staging views `analytics.stg_matches` / `analytics.stg_players` select
the audit columns being retyped. Alembic rolled it back, so production is
still at `20260716_0002` while `main` already writes `inserted_at`. The
migration now drops those dependent views (`DROP VIEW IF EXISTS ...
CASCADE`) before the type changes; dbt recreates them on its next build.

## Related Issue

Closes #157

## Scope

- `cs2_analytics/alembic/versions/20260831_0003_normalize_audit_timestamps.py`:
  `_drop_dependent_dbt_views()` called at the start of both `upgrade()`
  and `downgrade()`; docstring documents the dependency. Edited in place
  because 0003 has been applied to no persistent database (production
  rolled back; CI databases are ephemeral).

## Out of Scope

- What the migration converts or how naive values are interpreted
  (settled in #132 / PR #156)
- Making the CI dbt job build views before migrating (a generic guard is
  a separate discussion; this migration's verification covers the case)

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: High

Reason: Production schema migration, and Alembic drops dbt-owned
relations. Mitigations: the dropped objects are views (definitions only,
no data) that dbt regenerates; the marts and the SCD2 snapshot are
tables and are untouched, so the API keeps serving; verified in the
deployed order on a disposable database including downgrade/re-upgrade
with dbt's real views in place. Deploy plan: merge, run `alembic upgrade
head` against production immediately, dispatch the Scheduled dbt Build
to rebuild the views and confirm green.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: No behavior, command, schema shape, or workflow changes beyond
the migration's own internals; the dependency and rationale are
documented in the migration docstring, which is the executable schema
source of truth.

Backlog: Update not needed

Reason: #132 remains checked off (its outcome is unchanged); this is a
hotfix to land that migration, not a roadmap change.

## Verification

Commands run (disposable database in the compose Postgres, created and
dropped):

- Migrate to 0002, insert naive data, create views over the audit
  columns including a dependent intermediate view (reproducing the
  production condition), `alembic upgrade head`
- Fixture seed, `dbt build`, `alembic downgrade 20260716_0002`,
  `alembic upgrade head` (with dbt's real views in place), `dbt build`
- `uv run pytest --cov`, ruff

Results:

- Upgrade succeeds with 3 dependent views present, removes all 3
  (CASCADE), converts values to UTC, lands at 20260831_0003
- dbt build recreates 5 views and passes 74/74; downgrade and
  re-upgrade both succeed with dbt's views present; dbt build 74/74 again
- pytest: 204 passed; total coverage 80.42% (gate 80%). Ruff clean.

## Review Notes

- Why the original verification missed this: both my local dry run and
  the CI dbt job run migrations before dbt has built anything, so no
  view ever depended on the columns. Only the deployed database had the
  derived views at migration time. Lesson recorded: migration
  verification must include derived objects.
- Production is currently at 0002 with `main` expecting the new
  columns: do not scrape until the production migration runs; the
  10:00 UTC scheduled build fails until then (loud, by design).
