### PR TITLE
Convert fact_player_map_stats to an incremental materialization (#147)

### DIFF
--- a/.github/workflows/scheduled-dbt-build.yml
+++ b/.github/workflows/scheduled-dbt-build.yml
@@ -12,6 +12,14 @@ on:
   schedule:
     - cron: "0 10 * * *"
   workflow_dispatch:
+    inputs:
+      full_refresh:
+        description: >-
+          Rebuild incremental models from scratch (dbt build --full-refresh).
+          Use after model logic changes or backfills; see docs/dbt_models.md.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -73,3 +81,4 @@ jobs:
         run: >-
           uv run dbt build
           --project-dir dbt --profiles-dir dbt --target prod
+          ${{ inputs.full_refresh && '--full-refresh' || '' }}

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -95,6 +95,13 @@ models:
       - name: rating
         description: Performance rating from the source on this map.
 
+      - name: source_updated_at
+        description: >
+          Incremental watermark for downstream facts: the greatest
+          last_updated_at across the joined players, maps, and matches rows,
+          so a re-scraped match or map re-emits its player rows.
+        data_tests:
+          - not_null
   - name: int_player_current_team
     description: >
       Each player's current team as observed in match data. Grain: one row

--- a/dbt/models/intermediate/int_match_player_stats.sql
+++ b/dbt/models/intermediate/int_match_player_stats.sql
@@ -72,7 +72,15 @@ joined as (
         players.adr,
         players.fk_diff,
         players.round_swing,
-        players.rating
+        players.rating,
+
+        -- incremental watermark: latest source update across the three
+        -- joined rows, so a re-scraped match or map re-emits its player rows
+        greatest(
+            players.last_updated_at,
+            maps.last_updated_at,
+            matches.last_updated_at
+        ) as source_updated_at
 
     from players
     inner join maps

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -5,8 +5,11 @@ models:
     description: >
       Player performance facts at the player-map grain. Grain: one row per
       player per map, keyed by (map_id, player_id). Projected from
-      int_match_player_stats. Intended consumers: player performance lookups,
-      player map splits, and rating/ADR trend analysis.
+      int_match_player_stats. Materialized incrementally (delete+insert on
+      the grain key, 3-day lookback on source_updated_at); the grain test
+      below doubles as the guard against incremental duplicate insertion.
+      Intended consumers: player performance lookups, player map splits, and
+      rating/ADR trend analysis.
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
@@ -94,6 +97,13 @@ models:
         description: First-kill differential on this map.
       - name: round_swing
         description: Round swing contribution from the source on this map.
+
+      - name: source_updated_at
+        description: >
+          Incremental watermark carried from int_match_player_stats: greatest
+          source last_updated_at across the player, map, and match rows.
+        data_tests:
+          - not_null
 
   - name: fact_matches
     description: >

--- a/dbt/models/marts/fact_player_map_stats.sql
+++ b/dbt/models/marts/fact_player_map_stats.sql
@@ -7,10 +7,45 @@
 --
 -- Intended consumers: player performance lookups, player map splits, and
 -- rating/ADR trend analysis (including the API read paths).
+--
+-- Materialization: incremental on the (map_id, player_id) grain with a
+-- delete+insert strategy, filtered on source_updated_at with a lookback
+-- window that absorbs late-arriving updates. Run with --full-refresh after
+-- logic changes to this model or its upstream, or for backfills; see
+-- docs/dbt_models.md (Materialization Strategy).
+
+{{
+    config(
+        materialized='incremental',
+        unique_key=['map_id', 'player_id'],
+        incremental_strategy='delete+insert',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+{#-
+    The watermark filter only applies when the existing target already has
+    source_updated_at. A target built before this column existed (the first
+    incremental run over a table created as a plain table) falls back to a
+    full reprocess, and on_schema_change adds the column - no manual
+    --full-refresh is needed for that transition.
+-#}
+{% set target_has_watermark = false %}
+{% if is_incremental() %}
+    {% set target_columns = adapter.get_columns_in_relation(this) | map(attribute='name') | map('lower') | list %}
+    {% set target_has_watermark = 'source_updated_at' in target_columns %}
+{% endif %}
 
 with enriched as (
 
     select * from {{ ref('int_match_player_stats') }}
+
+    {% if target_has_watermark %}
+    where source_updated_at >= (
+        select coalesce(max(source_updated_at), '1970-01-01'::timestamptz)
+        from {{ this }}
+    ) - interval '3 days'
+    {% endif %}
 
 ),
 
@@ -51,7 +86,10 @@ final as (
         rating,
         kd_diff,
         fk_diff,
-        round_swing
+        round_swing,
+
+        -- incremental watermark
+        source_updated_at
 
     from enriched
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -794,9 +794,13 @@ time-sensitive item and leads this phase.
       to inserted_at and converts the audit trio interpreting stored
       values as UTC; parsers now write timezone-aware UTC; the dbt
       freshness config drops its per-table UTC casts
-- [ ] Convert `fact_player_map_stats` to an incremental materialization
+- [x] Convert `fact_player_map_stats` to an incremental materialization
       with a `unique_key` and `is_incremental()` watermark filter; evaluate
-      `fact_matches` alongside (#147, after #132)
+      `fact_matches` alongside (#147, after #132) - delete+insert on the
+      grain with a 3-day lookback on `source_updated_at`; `fact_matches`
+      stays full-refresh (tiny, and map_count aggregates late-arriving
+      child rows); full-refresh policy documented and exposed as a
+      workflow_dispatch input
 - [ ] Deepen data quality: per-source freshness thresholds, warn/error
       test severities, store_failures audit tables, and selective
       distribution tests (#148)

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -710,21 +710,49 @@ Rules:
 
 ## Materialization Strategy
 
-Materialization can be adjusted later, but the likely default approach is:
+Implemented (dbt_project.yml plus per-model config):
 
 ### staging
 
-- views initially
+- views over the Alembic-owned sources
 
 ### intermediate
 
-- views or tables depending on cost and reuse
+- views (reusable joins); `int_match_player_stats` also exposes
+  `source_updated_at`, the greatest `last_updated_at` across the joined
+  player, map, and match rows, as the incremental watermark for facts
 
 ### marts
 
-- tables, or incremental models later if data volume justifies it
+- tables, except `fact_player_map_stats`, which is incremental (#147):
+  `unique_key` = (map_id, player_id), `incremental_strategy` =
+  delete+insert, `on_schema_change` = append_new_columns, and an
+  `is_incremental()` filter of `source_updated_at >= max(source_updated_at)
+  in the target - 3 days`. The lookback absorbs late-arriving updates and
+  the small residual timezone skew in pre-#132 audit values; because the
+  watermark is the greatest of the three source timestamps, a re-scraped
+  match or map re-emits its player rows, and delete+insert replaces them
+  in place. The existing grain test is the guard against duplicate
+  insertion.
+- `fact_matches` stays full-refresh on purpose: it is one row per match
+  (hundreds of rows), and its `map_count` aggregates child rows that
+  arrive after the match row, so a full rebuild is both cheaper and safer
+  than tracking child arrivals incrementally. Revisit only if match volume
+  makes the rebuild measurable.
 
-This should be decided after actual query patterns and table sizes are understood.
+### Full-refresh policy
+
+Run `dbt build --full-refresh` (locally, or via the Scheduled dbt Build
+workflow's `full_refresh` dispatch input against production) when:
+
+- the logic of `fact_player_map_stats` or anything upstream of it changes
+- a column is removed or retyped upstream (append_new_columns only adds)
+- a backfill or bulk correction touches source rows without bumping
+  `last_updated_at`
+- the incremental table is suspected to have drifted; a full refresh must
+  produce the same rows as the incremental table (parity check)
+
+Routine daily runs stay incremental.
 
 ---
 


### PR DESCRIPTION
## Summary

Converts `fact_player_map_stats` from a full-refresh table to an
incremental model: `unique_key` (map_id, player_id), `delete+insert`
strategy, `on_schema_change` append_new_columns, and an
`is_incremental()` filter on a new `source_updated_at` watermark with a
3-day lookback. `fact_matches` stays full-refresh on purpose. The
full-refresh policy is documented and exposed as a `full_refresh` dispatch
input on the Scheduled dbt Build workflow.

## Related Issue

Closes #147

## Scope

- `dbt/models/intermediate/int_match_player_stats.sql`: additive
  passthrough column `source_updated_at = greatest(players, maps,
  matches .last_updated_at)`, so a re-scraped match or map re-emits its
  player rows (the issue listed intermediate views as out of scope, but
  the intermediate carried no audit timestamp at all, so the watermark
  had to come from somewhere; this is the minimal, additive enabler)
- `dbt/models/marts/fact_player_map_stats.sql`: incremental config and
  watermark filter, self-healing for targets built before the column
  existed (skips the filter and lets append_new_columns add the column
  on that one run, so the first production run needs no manual
  `--full-refresh`)
- `_intermediate__models.yml`, `_marts__models.yml`: document
  `source_updated_at` with `not_null` tests; fact description notes the
  materialization and that the grain test guards duplicate insertion
- `.github/workflows/scheduled-dbt-build.yml`: `full_refresh` boolean
  `workflow_dispatch` input
- `docs/dbt_models.md`: Materialization Strategy rewritten as
  implemented, with the `fact_matches` decision and the full-refresh
  policy; `docs/backlog.md`: #147 checked off

## Out of Scope

- Snapshot changes; data-quality depth (#148)
- Per-model mart indexes (delete+insert on the grain key seq-scans at
  today's volume; revisit with the index issue when volume warrants)
- `fact_matches` incremental: kept full-refresh - hundreds of rows, and
  its `map_count` aggregates child rows that arrive after the match row

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: Changes how the API's serving table is rebuilt in production.
Mitigated by exact full-refresh parity, the grain test as a duplicate
guard, a lookback window that absorbs late updates and the residual
pre-#132 timezone skew, and a verified self-healing first run over the
existing production table. No schema migration; dbt-only plus a
workflow input.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: docs/dbt_models.md Materialization Strategy now describes the
implemented strategy, the fact_matches decision, and when to run
--full-refresh; the workflow input is documented there.

Backlog: Updated

Reason: #147 Phase 4.5 item checked off with the design summary.

## Verification

Commands run (disposable database in the compose Postgres, created and
dropped; fixture seeded):

- `dbt build` x2 (initial create, then incremental with no source
  changes), then a simulated late source update (`UPDATE players SET
  rating, last_updated_at = now()`) followed by `dbt build`, then
  `dbt build --full-refresh` with an EXCEPT-both-ways parity check
  against a copy of the incremental table
- Transition test: dropped `source_updated_at` from the built table to
  mirror the current production table, ran the incremental build, then
  ran it again
- `dbt compile` in incremental mode to confirm the filter renders
- `uv run pytest --cov`, ruff, `dbt parse`

Results:

- Initial build: 76 passed (two new not_null tests); incremental re-run:
  6 rows, 6 distinct keys, no duplicates; late update: rating 1.35 ->
  2.22 replaced in place, row count unchanged; parity: 0 rows differ in
  either direction
- Transition: run succeeds, re-adds the column, populates it on all
  rows, picks up the pending update (rating 3.33); next run compiles
  with the watermark filter present
- pytest: 204 passed; total coverage 80.42% (gate 80%). Ruff and parse
  clean.
- Note: on fixture data every row falls inside the 3-day lookback, so
  incremental runs reprocess all 6 rows; on production, rows span
  months and only recently updated rows re-emit

## Review Notes

- Design decisions to review: the 3-day lookback length, and
  `greatest()` of the three source timestamps as the watermark (chosen
  so match/map context corrections propagate to player rows).
- Scope deviation, flagged: one additive column on the intermediate
  view.
- Post-merge: nothing manual required - the next scheduled run
  transitions the production table itself. A `--full-refresh` can be
  dispatched any time via the new workflow input.
