### PR TITLE
Document the full_refresh dispatch input in the README dbt section (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,12 @@ Build workflow (`.github/workflows/scheduled-dbt-build.yml`) runs
 SCD2 roster snapshot observes changes as they happen - missed runs are
 roster history that cannot be backfilled. Each run is gated by
 `dbt source freshness`, so stale ingestion data fails the workflow
-instead of silently freezing snapshot history.
+instead of silently freezing snapshot history. `fact_player_map_stats`
+is an incremental model, so routine runs only reprocess recently updated
+source rows; dispatch the workflow manually with the `full_refresh` input
+set to true to rebuild it from scratch after model logic changes,
+backfills, or bulk source corrections (see the full-refresh policy in
+`docs/dbt_models.md`).
 
 dbt owns analytics transformations only; the ingestion schema stays owned by
 Alembic migrations. Sources are declared for the `matches`, `maps`, and


### PR DESCRIPTION
## Summary

README section 10 describes the Scheduled dbt Build workflow but did not
mention the `full_refresh` workflow_dispatch input added with the
incremental `fact_player_map_stats` model in #159. It now states that
routine runs are incremental and how to dispatch a full rebuild.

## Related Issue

Refs #147 (docs follow-up to the merged implementation)

## Scope

- `README.md` section 10: one paragraph extension

## Out of Scope

- Any workflow or model changes

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Docs-only.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: This PR is the documentation change.

Backlog: Update not needed

Reason: No roadmap or checklist status changes; #147 is already recorded as complete.

## Verification

Commands run:

- Docs-only; tests not required (no executable behavior changed)

Results:

- Proofread in the rendered Markdown

## Review Notes

Closes the doc gap flagged by the repository's docs hook after #159 merged.