### PR TITLE
Gate DB-backed storage tests behind an opt-in and clean up their rows (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       DB_PASS: change_me
       DB_HOST: 127.0.0.1
       DB_PORT: "5432"
+      # Opt the DB-backed storage tests in; they run only against a local
+      # host (the service container here) and delete their own rows.
+      CS2_ALLOW_DB_TESTS: "true"
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -321,6 +321,19 @@ Then open the host and port configured by `API_HOST` and `API_PORT`, such as
 python -m pytest
 ```
 
+The DB-backed storage integration tests (`tests/storage/test_database.py`)
+write and delete real rows, so they are skipped unless you opt in with
+`CS2_ALLOW_DB_TESTS=true` *and* `DB_HOST` is a local database
+(`localhost`, `127.0.0.1`, or the compose `db` service); they never run
+against a remote database. CI opts in against its disposable service
+container. To run them locally, point `DB_*` at the compose database:
+
+```sh
+docker compose --env-file .env.example up -d db
+env CS2_ALLOW_DB_TESTS=true DB_HOST=127.0.0.1 DB_USER=postgres \
+  DB_PASS=change_me DB_NAME=cs2_db python -m pytest tests/storage/test_database.py
+```
+
 ### 10. Run dbt (analytics transformations)
 
 dbt is installed with the dev dependencies (`uv sync`). Its default target is a

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -13,8 +13,6 @@ import sys
 import unittest
 from datetime import UTC, datetime
 
-import pytest
-
 from cs2_analytics.models.map import Map
 from cs2_analytics.models.match import Match
 from cs2_analytics.models.player import Player
@@ -36,12 +34,9 @@ def db_tests_enabled() -> bool:
     return opted_in and os.getenv("DB_HOST", "") in LOCAL_DB_HOSTS
 
 
-pytestmark = pytest.mark.skipif(
-    not db_tests_enabled(),
-    reason=(
-        f"DB-backed storage tests run only with {OPT_IN_ENV} set and DB_HOST "
-        f"in {LOCAL_DB_HOSTS}; they write and delete real rows."
-    ),
+SKIP_REASON = (
+    f"DB-backed storage tests run only with {OPT_IN_ENV} set and DB_HOST "
+    f"in {LOCAL_DB_HOSTS}; they write and delete real rows."
 )
 
 
@@ -63,7 +58,13 @@ class TestDatabase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Runs once before all tests to initialize the database connection."""
+        """Enforce the opt-in guard, then open the database connection.
+
+        The guard lives here rather than in a pytest marker so it also
+        applies under `python -m unittest` and this file's own entry point.
+        """
+        if not db_tests_enabled():
+            raise unittest.SkipTest(SKIP_REASON)
         print("\n🚀 Setting up database connection for tests...")
         sys.stdout.flush()
         cls.db = Database()

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -1,6 +1,19 @@
+"""Integration tests for the storage layer against a disposable database.
+
+These tests write real rows through the storage modules, which commit on
+their own connections, so no rollback can undo them. They therefore run
+only when explicitly opted in (CS2_ALLOW_DB_TESTS) and only against a
+local database host, and they delete their fixed-ID rows before and after
+each test. CI opts in against its service container; a local run with the
+application .env skips.
+"""
+
+import os
 import sys
 import unittest
 from datetime import UTC, datetime
+
+import pytest
 
 from cs2_analytics.models.map import Map
 from cs2_analytics.models.match import Match
@@ -10,9 +23,43 @@ from cs2_analytics.storage.map_storage import store_maps
 from cs2_analytics.storage.match_storage import store_matches
 from cs2_analytics.storage.player_storage import store_players
 
+OPT_IN_ENV = "CS2_ALLOW_DB_TESTS"
+LOCAL_DB_HOSTS = ("localhost", "127.0.0.1", "db")
+TEST_MATCH_IDS = (999998, 999999)
+TEST_MAP_ID = 999999
+TEST_PLAYER_ID = 888888
+
+
+def db_tests_enabled() -> bool:
+    """True only when opted in and DB_HOST is a local database."""
+    opted_in = os.getenv(OPT_IN_ENV, "").strip().lower() in {"1", "true", "yes"}
+    return opted_in and os.getenv("DB_HOST", "") in LOCAL_DB_HOSTS
+
+
+pytestmark = pytest.mark.skipif(
+    not db_tests_enabled(),
+    reason=(
+        f"DB-backed storage tests run only with {OPT_IN_ENV} set and DB_HOST "
+        f"in {LOCAL_DB_HOSTS}; they write and delete real rows."
+    ),
+)
+
+
+def delete_test_rows(cur) -> None:
+    """Remove the fixed-ID rows these tests write, children first."""
+    cur.execute(
+        "DELETE FROM players WHERE map_id = %s OR player_id = %s;",
+        (TEST_MAP_ID, TEST_PLAYER_ID),
+    )
+    cur.execute(
+        "DELETE FROM maps WHERE map_id = %s OR match_id = ANY(%s);",
+        (TEST_MAP_ID, list(TEST_MATCH_IDS)),
+    )
+    cur.execute("DELETE FROM matches WHERE match_id = ANY(%s);", (list(TEST_MATCH_IDS),))
+
 
 class TestDatabase(unittest.TestCase):
-    """Unit tests for verifying database operations with rollback."""
+    """Integration tests for storage writes against a disposable database."""
 
     @classmethod
     def setUpClass(cls):
@@ -21,14 +68,25 @@ class TestDatabase(unittest.TestCase):
         sys.stdout.flush()
         cls.db = Database()
         cls.conn = cls.db.get_connection()
+        cls.conn.autocommit = True
         cls.cur = cls.conn.cursor()
-        cls.conn.autocommit = False  # ✅ Disable autocommit to allow rollbacks
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove test rows and release the connection."""
+        delete_test_rows(cls.cur)
+        cls.cur.close()
+        cls.db.release_connection(cls.conn)
 
     def setUp(self):
-        """Runs before each test. Rolls back any leftover changes from previous tests."""
-        print("\n🔄 Rolling back previous test data (if any)...")
+        """Runs before each test. Removes leftover test rows so reruns are repeat-safe."""
+        print("\n🔄 Removing previous test data (if any)...")
         sys.stdout.flush()
-        self.conn.rollback()  # ✅ Ensures each test starts fresh
+        delete_test_rows(self.cur)
+
+    def tearDown(self):
+        """Remove the rows this test wrote."""
+        delete_test_rows(self.cur)
 
     def test_store_match(self):
         """Tests inserting a match and retrieving it."""
@@ -175,21 +233,6 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(result[2], "Test Team A")
         self.assertEqual(result[3], 20)
         self.assertEqual(result[4], 8)
-
-    def tearDown(self):
-        """Runs after each test. Rolls back any changes made during the test."""
-        print("\n🛠️ Rolling back test transaction...")
-        sys.stdout.flush()
-        self.conn.rollback()  # ✅ Ensures test data is NOT permanently stored
-
-    @classmethod
-    def tearDownClass(cls):
-        """Runs once after all tests to clean up."""
-        print("\n❌ Closing test database connection...")
-        sys.stdout.flush()
-        cls.cur.close()
-        cls.db.release_connection(cls.conn)
-
 
 if __name__ == "__main__":
     print("\n🔵 Running database tests...\n")


### PR DESCRIPTION
## Summary

`tests/storage/test_database.py` wrote real rows to whatever `DB_HOST`
pointed at and never rolled them back (the storage layer commits on its
own connections); locally that was the production database, on every
pytest run since 2026-07-07. The tests now run only with
`CS2_ALLOW_DB_TESTS` set **and** a local `DB_HOST`, replace the
ineffective rollback with explicit deletion of their fixed IDs, and CI
opts in against its service container. Production cleanup of the rows
already written is tracked in #161.

## Related Issue

Closes #160

## Scope

- `tests/storage/test_database.py`: module-level skip gate (opt-in flag
  plus local-host allowlist), `delete_test_rows()` run before and after
  each test and at class teardown, autocommit connection; the original
  overriding `tearDown`/`tearDownClass` (rollback-based) removed
- `.github/workflows/ci.yml`: `CS2_ALLOW_DB_TESTS: "true"` on the test
  job so the tests still execute in CI
- `README.md` section 9: documents the opt-in and the compose recipe

## Out of Scope

- Removing the rows already in production (#161)
- Storage-layer commit behavior (ADR-0013) - unchanged
- Broader test-suite restructuring

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Test harness and CI env only. The change strictly reduces what
the suite can write to; CI coverage of the storage writes is preserved.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README section 9 explains the opt-in, the local-host guard, and
how to run the DB-backed tests against the compose database; test
command behavior changed, which the documentation policy covers.

Backlog: Update not needed

Reason: Not a roadmap item; a correctness fix to the test harness.

## Verification

Commands run:

- `uv run pytest tests/storage/test_database.py -rs` against `.env`
  (production), with the production test rows' timestamps captured
  before and after
- On a disposable local database (compose Postgres, migrated):
  `CS2_ALLOW_DB_TESTS=true` run twice consecutively, then row counts
- `CS2_ALLOW_DB_TESTS=true DB_HOST=some-remote.example.com` run
- `uv run pytest --cov`, ruff

Results:

- Against `.env`: 2 skipped with the explanatory reason; production row
  timestamps unchanged (no writes)
- Local database: 2 passed on both runs; 0 rows left in matches, maps,
  players afterward (repeat-safe)
- Remote-looking host with the flag: 2 skipped
- Full suite: 202 passed, 2 skipped locally (they execute in CI);
  total coverage 80.32% (gate 80%). Ruff clean.

## Review Notes

- Root cause detail: the original class set `autocommit=False` and
  rolled back its own connection, while the writes committed through
  `get_db().get_cursor()`; the original `tearDown`/`tearDownClass` at
  the bottom of the class also silently overrode any earlier
  definitions, which is why the first attempt at delete-based cleanup
  appeared not to run.
- The flag name `CS2_ALLOW_DB_TESTS` and the allowlist mirror the CI
  fixture seeder's local-host guard for consistency.