### PR TITLE
Strip only day ordinals when parsing results dates so August is discovered (#164)

### DIFF
--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -102,20 +102,28 @@ class ResultsScraper:
 
         matches: list[str] = []
         stop_scraping = False
+        sections_seen = 0
+        sections_parsed = 0
 
         for section in soup.find_all("div", class_="results-sublist"):
             date_header = section.find("div", class_="standard-headline")
             if not date_header:
                 continue
+            sections_seen += 1
 
+            # Strip only day ordinals (31st, 2nd); an unanchored strip also
+            # removes the "st" inside "August" and blanks the whole month.
             raw_date = re.sub(
-                r"(st|nd|rd|th)", "", date_header.text.replace("Results for ", "")
+                r"(?<=\d)(st|nd|rd|th)\b",
+                "",
+                date_header.text.replace("Results for ", ""),
             )
             try:
                 match_date = dt.datetime.strptime(raw_date.strip(), "%B %d %Y").date()
             except ValueError:
                 logger.warning("Could not parse date: %s", raw_date)
                 continue
+            sections_parsed += 1
 
             if match_date > self.end_date:
                 continue
@@ -131,6 +139,14 @@ class ResultsScraper:
                     continue
                 full_url = f"https://www.hltv.org{a_tag['href']}"
                 matches.append(full_url)
+
+        if sections_seen and not sections_parsed:
+            logger.warning(
+                "No date sections parsed on %s: %d section(s) skipped, so no "
+                "matches were discovered from this page.",
+                url,
+                sections_seen,
+            )
 
         return matches, stop_scraping
 

--- a/tests/scrapers/test_results_scraper.py
+++ b/tests/scrapers/test_results_scraper.py
@@ -164,6 +164,126 @@ def test_extract_matches_from_page_warns_and_skips_unparseable_date(
     assert stop is False
 
 
+MONTH_NAMES = (
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+
+
+@pytest.mark.parametrize("month_name", MONTH_NAMES)
+def test_extract_matches_from_page_parses_ordinal_dates_for_every_month(
+    scraper: ResultsScraper, month_name: str
+) -> None:
+    # Regression: an unanchored ordinal strip turned "August 31st 2026" into
+    # "Augu 31 2026" and silently dropped every August section.
+    scraper.driver = _FakePageDriver(
+        f"""
+        <html>
+          <body>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for {month_name} 3rd 2026</div>
+              <div class="result-con">
+                <a href="/matches/333/e-vs-f"></a>
+              </div>
+            </div>
+          </body>
+        </html>
+        """
+    )
+    scraper.start_date = dt.date(2026, 1, 1)
+    scraper.end_date = dt.date(2026, 12, 31)
+
+    with mock.patch.object(results_scraper_module.logger, "warning") as warning_mock:
+        matches, stop = scraper._extract_matches_from_page(
+            "https://www.hltv.org/results?offset=0"
+        )
+
+    warning_mock.assert_not_called()
+    assert matches == ["https://www.hltv.org/matches/333/e-vs-f"]
+    assert stop is False
+
+
+def test_extract_matches_from_page_parses_observed_august_headers(
+    scraper: ResultsScraper,
+) -> None:
+    scraper.driver = _FakePageDriver(
+        """
+        <html>
+          <body>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for August 31st 2026</div>
+              <div class="result-con"><a href="/matches/1/a-vs-b"></a></div>
+            </div>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for August 22nd 2026</div>
+              <div class="result-con"><a href="/matches/2/c-vs-d"></a></div>
+            </div>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for August 1st 2026</div>
+              <div class="result-con"><a href="/matches/3/e-vs-f"></a></div>
+            </div>
+          </body>
+        </html>
+        """
+    )
+    scraper.start_date = dt.date(2026, 8, 1)
+    scraper.end_date = dt.date(2026, 8, 31)
+
+    matches, stop = scraper._extract_matches_from_page(
+        "https://www.hltv.org/results?offset=0"
+    )
+
+    assert [m.rsplit("/", 2)[1] for m in matches] == ["1", "2", "3"]
+    assert stop is False
+
+
+def test_extract_matches_from_page_warns_when_no_sections_parse(
+    scraper: ResultsScraper,
+) -> None:
+    scraper.driver = _FakePageDriver(
+        """
+        <html>
+          <body>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for not-a-date</div>
+              <div class="result-con"><a href="/matches/1/a-vs-b"></a></div>
+            </div>
+            <div class="results-sublist">
+              <div class="standard-headline">Results for also-not-a-date</div>
+              <div class="result-con"><a href="/matches/2/c-vs-d"></a></div>
+            </div>
+          </body>
+        </html>
+        """
+    )
+    scraper.start_date = dt.date(2026, 1, 1)
+    scraper.end_date = dt.date(2026, 12, 31)
+
+    with mock.patch.object(results_scraper_module.logger, "warning") as warning_mock:
+        matches, stop = scraper._extract_matches_from_page(
+            "https://www.hltv.org/results?offset=0"
+        )
+
+    assert matches == []
+    assert stop is False
+    summary_calls = [
+        call for call in warning_mock.call_args_list
+        if call.args and str(call.args[0]).startswith("No date sections parsed")
+    ]
+    assert len(summary_calls) == 1
+    assert summary_calls[0].args[2] == 2
+
+
 def test_close_failure_raises_typed_error(scraper: ResultsScraper) -> None:
     def failing_quit() -> None:
         raise RuntimeError("browser already gone")


### PR DESCRIPTION
## Summary

Results discovery discovered zero matches for any August date: the
ordinal-suffix strip `re.sub(r"(st|nd|rd|th)", "")` was unanchored and
removed the `st` inside "August", so "August 31st 2026" became
"Augu 31 2026", `strptime` failed, and the whole date section was
skipped while the controller reported success. The strip is now anchored
to a preceding digit, and the scraper warns when a page's date sections
all fail to parse.

## Related Issue

Closes #164

## Scope

- `cs2_analytics/scrapers/results_scraper.py`: anchored ordinal strip
  (`(?<=\d)(st|nd|rd|th)\b`); warning when sections were present but
  none parsed, naming the skipped count
- `tests/scrapers/test_results_scraper.py`: parametrized regression over
  all twelve month names with an ordinal day, the exact observed August
  headers, and the no-sections-parsed warning

## Out of Scope

- Discovery pagination, caps, or backfill strategy (#121)
- Ingestion-state semantics; controller and stage services untouched

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Scraper-only regex fix plus a log line; behavior for every
other month is unchanged and covered by the parametrized test.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: No commands, configuration, architecture, or public interfaces
changed; this is an internal parsing fix with an added log line.

Backlog: Update not needed

Reason: Not a roadmap item; a bug fix.

## Verification

Commands run:

- `uv run pytest tests/scrapers/test_results_scraper.py`
- `uv run pytest --cov`, ruff, mypy
- `uv run cs2a ingest discover` against the live results page, before
  and after the fix

Results:

- Scraper tests: 21 passed (3 new tests, 12 parametrized cases)
- Full suite: 216 passed, 2 skipped (DB-backed tests, opt-in); total
  coverage 80.38% (gate 80%). Ruff and mypy clean.
- Live discovery: before - "Could not parse date: Augu 31 2026" (x3),
  Discovered 0 matches; after - Discovered 50 matches, recorded=50, no
  parse warnings

## Review Notes

- Timeline context: the last successful ingestion was 2026-07-16; this
  bug is why nothing was discovered since, and the freshness gate did
  not surface the gap because leaked test rows (#160/#161) were keeping
  it green. With both fixed, the gate now reflects reality.
- The new warning is intentionally a log line, not a failure: a page
  with unparseable sections should be loud but should not abort a run
  that may still have other pages.