### PR TITLE
Release orphaned 'processing' rows at controller startup (#141)

### DIFF
--- a/cs2_analytics/controllers/map_controller.py
+++ b/cs2_analytics/controllers/map_controller.py
@@ -44,6 +44,7 @@ class MapController:
     def run(self, batch_size: int = 25) -> None:
         logger.info("Running MapController with batch size: %d", batch_size)
 
+        self._release_orphaned_processing()
         selected = self.state.fetch_with_match_context(batch_size)
         logger.info("%d pending maps selected from ingestion state", len(selected))
 
@@ -67,6 +68,17 @@ class MapController:
             run_state.retries,
         )
         logger.info("MapController complete.")
+
+    def _release_orphaned_processing(self) -> None:
+        """Reconciles rows an interrupted run left in 'processing' (#141)."""
+        released = self.state.release_orphaned_processing()
+        if released:
+            logger.warning(
+                "Released %d orphaned 'processing' row(s) in %s back to "
+                "'discovered' before selecting this batch.",
+                released,
+                self.state.table_name,
+            )
 
     def _rotate_scraper_if_due(self, run_state: BatchRunState[MapScraper]) -> None:
         """Swaps in a fresh scraper session after enough processed maps."""

--- a/cs2_analytics/controllers/match_controller.py
+++ b/cs2_analytics/controllers/match_controller.py
@@ -53,6 +53,7 @@ class MatchController:
         """Runs the match stage for a batch of pending match URLs."""
         logger.info("Running MatchController with batch size: %d", batch_size)
 
+        self._release_orphaned_processing()
         selected = self.match_state.fetch(limit=batch_size)
         logger.info("%d pending matches selected from ingestion state", len(selected))
 
@@ -74,6 +75,17 @@ class MatchController:
             run_state.retries,
         )
         logger.info("MatchController complete.")
+
+    def _release_orphaned_processing(self) -> None:
+        """Reconciles rows an interrupted run left in 'processing' (#141)."""
+        released = self.match_state.release_orphaned_processing()
+        if released:
+            logger.warning(
+                "Released %d orphaned 'processing' row(s) in %s back to "
+                "'discovered' before selecting this batch.",
+                released,
+                self.match_state.table_name,
+            )
 
     def _rotate_scraper_if_due(self, run_state: BatchRunState[MatchScraper]) -> None:
         """Swaps in a fresh scraper session after enough processed matches."""

--- a/cs2_analytics/ingestion_state/base_ingestion_state.py
+++ b/cs2_analytics/ingestion_state/base_ingestion_state.py
@@ -281,6 +281,36 @@ class BaseIngestionState[IdT: (int, str)]:
                 f"Failed to fetch requeue candidates from {self.table_name}."
             ) from e
 
+    def release_orphaned_processing(self) -> int:
+        """Resets every 'processing' row back to 'discovered' and returns the count.
+
+        Startup reconciliation for interrupted runs: mark_as_processing commits
+        before the item is processed and the terminal status is written only
+        afterward, so Ctrl+C, a crash, or a kill in that window leaves the row
+        stuck in 'processing' where fetch() never selects it again.
+
+        This assumes the pipeline is single-process: any 'processing' row seen
+        when a controller starts belongs to no live run and is therefore
+        orphaned. If parallel runs are ever introduced, replace this with
+        lease-based claiming; blanket reconciliation cannot tell a peer's live
+        claim from an orphan. failure_count and last_error_message are
+        preserved as history; the release is visible via last_updated_at.
+        """
+        now = dt.datetime.now()
+        query = f"""
+        UPDATE {self.table_name}
+        SET status = 'discovered', last_updated_at = %s
+        WHERE status = 'processing';
+        """
+        try:
+            with self.db.get_cursor() as cur:
+                cur.execute(query, (now,))
+                return int(cur.rowcount)
+        except Exception as e:
+            raise self.error_cls(
+                f"Failed to release orphaned processing rows in {self.table_name}."
+            ) from e
+
     def requeue(self, ids: list[IdT], expected_status: str) -> int:
         """Resets rows back to 'discovered' so processing picks them up again.
 

--- a/docs/architecture/current_state.md
+++ b/docs/architecture/current_state.md
@@ -67,6 +67,16 @@ Lifecycle fields must stay distinct:
 
 Do not add `inserted_at` or `last_inserted_at` to ingestion-state tables.
 
+Lifecycle reconciliation (#141): the claim is not crash-safe -
+`mark_as_processing` commits before an item is processed and the terminal
+status is written only afterward - so an interrupted run (Ctrl+C, crash,
+kill) leaves rows stuck in `processing`, which `fetch()` never selects.
+`MatchController.run()` and `MapController.run()` therefore start by
+resetting every `processing` row in their table back to `discovered`
+(logging a warning with the count), before batch selection. This relies
+on the pipeline being single-process; parallel runs would require
+lease-based claiming instead.
+
 ## Component Boundaries
 
 Controllers own:

--- a/tests/controllers/test_map_controller.py
+++ b/tests/controllers/test_map_controller.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from cs2_analytics.controllers import map_controller as map_module
@@ -7,14 +9,23 @@ from tests.support import FakeTransactionDb
 
 
 class _FakeMapState:
+    table_name = "map_ingestion_state"
+    orphaned_processing = 0
+
     def __init__(self) -> None:
         self.failed: list[tuple[int, str]] = []
         self.processed: list[int] = []
         self.processing: list[int] = []
+        self.calls: list[str] = []
+
+    def release_orphaned_processing(self) -> int:
+        self.calls.append("release")
+        return self.orphaned_processing
 
     def fetch_with_match_context(
         self, _limit: int = 25
     ) -> list[tuple[int, str, int | None, int | None]]:
+        self.calls.append("fetch")
         return [
             (1, "https://www.hltv.org/stats/matches/mapstatsid/1/test", 101, 1),
             (2, "https://www.hltv.org/stats/matches/mapstatsid/2/test", 102, 2),
@@ -333,3 +344,24 @@ def test_map_controller_marks_failed_once_after_exhausting_retryable_errors(
         and call_args[1:] == (1, 0, 1, 2)
         for call_args, _ in info_calls
     )
+
+
+def test_map_controller_releases_orphaned_processing_before_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_map_controller(
+        monkeypatch, _SuccessfulScraper, _SuccessfulParser
+    )
+    monkeypatch.setattr(_FakeMapState, "orphaned_processing", 4)
+
+    with mock.patch.object(map_module.logger, "warning") as warning_mock:
+        controller.run(batch_size=5)
+
+    assert controller.state.calls[:2] == ["release", "fetch"]
+    release_warnings = [
+        call for call in warning_mock.call_args_list
+        if "orphaned" in str(call.args[0])
+    ]
+    assert len(release_warnings) == 1
+    assert release_warnings[0].args[1] == 4
+    assert release_warnings[0].args[2] == "map_ingestion_state"

--- a/tests/controllers/test_match_controller.py
+++ b/tests/controllers/test_match_controller.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from cs2_analytics.controllers import match_controller as match_module
@@ -6,13 +8,22 @@ from tests.support import FakeTransactionDb
 
 
 class _FakeMatchState:
+    table_name = "match_ingestion_state"
+    orphaned_processing = 0
+
     def __init__(self) -> None:
         self.failed: list[tuple[int, str]] = []
         self.processed: list[int] = []
         self.processing: list[int] = []
+        self.calls: list[str] = []
+
+    def release_orphaned_processing(self) -> int:
+        self.calls.append("release")
+        return self.orphaned_processing
 
     def fetch(self, limit: int = 25) -> list[tuple[int, str]]:
         assert limit > 0
+        self.calls.append("fetch")
         return [(1, "https://www.hltv.org/matches/1/test")]
 
     def mark_as_failed(self, item_id: int, reason: str) -> None:
@@ -293,3 +304,39 @@ def test_match_controller_applies_cooldown_after_consecutive_retryable_errors(
         and call_args[1:] == (1, 1, 0, 2)
         for call_args, _ in info_calls
     )
+
+
+def test_match_controller_releases_orphaned_processing_before_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_match_controller(
+        monkeypatch, _SuccessfulScraper, _SuccessfulParser
+    )
+    monkeypatch.setattr(_FakeMatchState, "orphaned_processing", 3)
+
+    with mock.patch.object(match_module.logger, "warning") as warning_mock:
+        controller.run(batch_size=5)
+
+    assert controller.match_state.calls[:2] == ["release", "fetch"]
+    release_warnings = [
+        call for call in warning_mock.call_args_list
+        if "orphaned" in str(call.args[0])
+    ]
+    assert len(release_warnings) == 1
+    assert release_warnings[0].args[1] == 3
+    assert release_warnings[0].args[2] == "match_ingestion_state"
+
+
+def test_match_controller_stays_quiet_when_nothing_is_orphaned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _build_match_controller(
+        monkeypatch, _SuccessfulScraper, _SuccessfulParser
+    )
+    monkeypatch.setattr(_FakeMatchState, "orphaned_processing", 0)
+
+    with mock.patch.object(match_module.logger, "warning") as warning_mock:
+        controller.run(batch_size=5)
+
+    assert controller.match_state.calls[0] == "release"
+    assert not any("orphaned" in str(c.args[0]) for c in warning_mock.call_args_list)

--- a/tests/ingestion_state/test_release_orphaned_processing.py
+++ b/tests/ingestion_state/test_release_orphaned_processing.py
@@ -1,0 +1,78 @@
+"""Tests for the startup reconciliation of orphaned 'processing' rows (#141)."""
+
+from contextlib import contextmanager
+
+import pytest
+
+from cs2_analytics.exceptions import MapIngestionStateError, MatchIngestionStateError
+from cs2_analytics.ingestion_state import base_ingestion_state as base_state_module
+from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
+from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
+
+
+class _RecordingCursor:
+    def __init__(self, rowcount: int = 0) -> None:
+        self.execute_query: str | None = None
+        self.execute_values: tuple[object, ...] | None = None
+        self.rowcount = rowcount
+
+    def execute(self, query: str, values: tuple[object, ...]) -> None:
+        self.execute_query = query
+        self.execute_values = values
+
+
+class _RecordingStateDb:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+
+    @contextmanager
+    def get_cursor(self):
+        yield self.cursor
+
+
+class _FailingStateDb:
+    @contextmanager
+    def get_cursor(self):
+        raise RuntimeError("db down")
+        yield
+
+
+def test_release_orphaned_processing_resets_only_processing_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(rowcount=2)
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+
+    released = MatchIngestionState().release_orphaned_processing()
+
+    assert released == 2
+    assert cursor.execute_query is not None
+    assert "UPDATE match_ingestion_state" in cursor.execute_query
+    assert "SET status = 'discovered', last_updated_at = %s" in cursor.execute_query
+    assert "WHERE status = 'processing'" in cursor.execute_query
+    # History is preserved: nothing touches failure_count or last_error_message.
+    assert "failure_count" not in cursor.execute_query
+    assert "last_error_message" not in cursor.execute_query
+    assert cursor.execute_values is not None and len(cursor.execute_values) == 1
+
+
+def test_release_orphaned_processing_returns_zero_when_nothing_is_stuck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor(rowcount=0)
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _RecordingStateDb(cursor))
+
+    assert MapIngestionState().release_orphaned_processing() == 0
+    assert cursor.execute_query is not None
+    assert "UPDATE map_ingestion_state" in cursor.execute_query
+
+
+def test_release_orphaned_processing_wraps_db_errors_per_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(base_state_module, "get_db", lambda: _FailingStateDb())
+
+    with pytest.raises(MatchIngestionStateError, match="match_ingestion_state"):
+        MatchIngestionState().release_orphaned_processing()
+    with pytest.raises(MapIngestionStateError, match="map_ingestion_state"):
+        MapIngestionState().release_orphaned_processing()


### PR DESCRIPTION
## Summary

Interrupted runs leave rows stuck in `status = 'processing'` forever:
`mark_as_processing` commits before the item is processed, the terminal
status is written only afterward, and `fetch()` selects only
`discovered`. Production has 1 match and 4 maps in that state right now.
Both controllers now start `run()` by resetting every `processing` row
in their table back to `discovered` (logging a warning with the count),
before batch selection, so the queue self-heals on the next run.

## Related Issue

Closes #141

## Scope

- `cs2_analytics/ingestion_state/base_ingestion_state.py`:
  `release_orphaned_processing()` - one UPDATE, returns the count,
  bumps `last_updated_at`, preserves `failure_count` and
  `last_error_message` as history; docstring states the single-process
  assumption
- `cs2_analytics/controllers/match_controller.py`,
  `map_controller.py`: `_release_orphaned_processing()` called at the top
  of `run()` before `fetch()`; warning with count and table when nonzero
- Tests: new `tests/ingestion_state/test_release_orphaned_processing.py`;
  controller tests assert release runs before fetch, the warning payload,
  and silence when nothing is orphaned (fakes gained the new method)
- `docs/architecture/current_state.md`: records the startup transition

## Out of Scope

- Lease/timeout-based claiming or any schema change (parallel-runs
  design)
- Manual release via `cs2a retry` (#142, next)
- Per-item interrupt handlers

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: A new lifecycle transition (`processing` -> `discovered`) on
every controller start, on production state tables. It is correct only
under the single-process assumption, which is the current design and
is documented at the call site and in the architecture doc. No schema
change; the UPDATE is idempotent.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: Lifecycle semantics changed (a new startup transition), so
docs/architecture/current_state.md now describes the reconciliation and
its single-process assumption.

Backlog: Update not needed

Reason: Not a roadmap-phase item; an ingestion hardening fix tracked by
its issue.

## Verification

Commands run:

- `uv run pytest tests/ingestion_state tests/controllers`
- `uv run pytest --cov`, ruff, mypy
- Real-Postgres check on a disposable database (compose Postgres,
  migrated): seeded match_ingestion_state rows in processing (x2, one
  with failure history), discovered, processed, and failed; called
  `release_orphaned_processing()`; inspected rows; called `fetch()`

Results:

- Focused tests: 34 passed; full suite: 222 passed, 2 skipped (opt-in
  DB tests); total coverage 80.57% (gate 80%). Ruff and mypy clean.
- Real Postgres: released exactly 2; both processing rows became
  discovered with `failure_count` 2 / `last_error_message` "boom"
  preserved on the one that had history; processed and failed rows
  untouched; `fetch()` then selected the released rows

## Review Notes

- Lifecycle-semantics change, so human review before merge per the
  agent change policy.
- Manual production verification is available immediately after merge:
  the next `cs2a process` run should log a warning releasing 1 match
  row and, on the map stage, 4 map rows, and `cs2a status` should show
  `processing 0` afterward.
- #142 (manual release via `cs2a retry`) follows and can reuse the same
  state method.