### PR TITLE
Allow cs2a retry to release stuck 'processing' rows (#142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,12 +294,17 @@ cs2a process --batch 50         # process pending matches, then maps
 cs2a status                     # ingestion-state row counts by status
 cs2a retry --stage match        # requeue failed matches for reprocessing
 cs2a retry --stage map --dry-run
+cs2a retry --stage map --status processing --dry-run   # inspect rows stuck by an interrupted run
 ```
 
 `cs2a retry` resets `failed` ingestion-state rows back to `discovered` so
-the next `cs2a process` run picks them up. `dead` and `partial` rows are
-only requeued when named explicitly via `--status`, including when
-targeting a single row with `--id`. `--limit` bounds how much work is
+the next `cs2a process` run picks them up. `dead`, `partial`, and
+`processing` rows are only requeued when named explicitly via `--status`,
+including when targeting a single row with `--id`. `--status processing`
+releases rows an interrupted run left behind (controllers also release
+them automatically at startup); the command warns that releasing them
+while a run is active can cause duplicate processing, so confirm no run
+is in flight first. `--limit` bounds how much work is
 requeued and `--dry-run` previews the affected rows without writing.
 Before writing, the command shows the affected row count and the target
 database and asks for confirmation. Requeueing preserves `failure_count`

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -91,6 +91,13 @@ class RetryStatus(StrEnum):
     FAILED = "failed"
     DEAD = "dead"
     PARTIAL = "partial"
+    PROCESSING = "processing"
+
+
+PROCESSING_RELEASE_WARNING = (
+    "Warning: releasing 'processing' rows while a pipeline run is active can "
+    "cause duplicate processing. Confirm no run is in flight before continuing."
+)
 
 
 RETRY_ERROR_PREVIEW_LENGTH = 60
@@ -116,8 +123,9 @@ def retry(
         RetryStatus,
         typer.Option(
             help=(
-                "Status to requeue. dead and partial rows are only requeued "
-                "when named here explicitly, including with --id."
+                "Status to requeue. dead, partial, and processing rows are only "
+                "requeued when named here explicitly, including with --id. "
+                "processing releases rows orphaned by an interrupted run."
             ),
         ),
     ] = RetryStatus.FAILED,
@@ -138,9 +146,13 @@ def retry(
 
     failure_count and last_error_message are preserved as history; the
     requeue itself is visible via last_updated_at. The next `cs2a process`
-    run picks the requeued rows up.
+    run picks the requeued rows up. --status processing releases rows
+    orphaned in 'processing' by an interrupted run (#142); the operator is
+    responsible for confirming no run is currently in flight.
     """
     state = _retry_state_for(stage)
+    if status is RetryStatus.PROCESSING:
+        typer.echo(PROCESSING_RELEASE_WARNING)
     try:
         candidates = state.fetch_requeue_candidates(
             status.value, limit=limit, id_value=item_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -476,3 +476,45 @@ def test_db_current_reports_revision_and_prints_target(monkeypatch) -> None:
     assert result.exit_code == 0
     assert calls == [("current", ())]
     assert "Target database:" in result.stdout
+
+
+def test_retry_processing_requires_explicit_status_and_warns(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(7, 0, None)], calls)
+
+    result = runner.invoke(
+        app, ["retry", "--stage", "map", "--status", "processing"], input="y\n"
+    )
+
+    assert result.exit_code == 0
+    assert "duplicate processing" in result.stdout
+    assert calls == [
+        ("fetch", "map", {"status": "processing", "limit": None, "id": None}),
+        ("requeue", "map", {"ids": [7], "expected_status": "processing"}),
+    ]
+
+
+def test_retry_processing_dry_run_previews_without_writing(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(7, 0, None), (8, 2, "boom")], calls)
+
+    result = runner.invoke(
+        app, ["retry", "--stage", "match", "--status", "processing", "--dry-run"]
+    )
+
+    assert result.exit_code == 0
+    assert [call[0] for call in calls] == ["fetch"]
+    assert "duplicate processing" in result.stdout
+    assert "2 match row(s) in status 'processing'" in result.stdout
+    assert "Dry run: no rows were changed." in result.stdout
+
+
+def test_retry_never_touches_processing_unless_named(monkeypatch) -> None:
+    calls: list[tuple[str, str, dict]] = []
+    _patch_retry_states(monkeypatch, [(1, 3, "boom")], calls)
+
+    result = runner.invoke(app, ["retry", "--stage", "match", "--id", "1"], input="y\n")
+
+    assert result.exit_code == 0
+    assert all(call[2].get("status", call[2].get("expected_status")) == "failed" for call in calls)
+    assert "duplicate processing" not in result.stdout


### PR DESCRIPTION
## Summary

Adds `processing` to the statuses `cs2a retry` can requeue, so rows
orphaned by an interrupted run can be inspected (`--dry-run`) and
released through the existing preview/confirmation flow instead of
hand-written SQL. It follows the same explicit-naming guard as `dead`
and `partial`, and prints a duplicate-processing warning whenever it is
named. Companion to #141 (automatic release at controller startup).

## Related Issue

Closes #142

## Scope

- `cs2_analytics/cli.py`: `RetryStatus.PROCESSING`; warning echoed when
  the status is named; `--status` help and command docstring updated;
  `fetch_requeue_candidates` / `requeue` reused unchanged
- `tests/test_cli.py`: explicit-status release with warning, dry-run
  preview with warning and no writes, guard (default and `--id` paths
  never touch `processing`)
- `README.md`: retry section documents the new status and the warning

## Out of Scope

- Detecting whether a run is active (no run registry in the
  single-process design)
- Startup reconciliation (#141, merged) and lease-based claiming

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Extends an existing command along an existing axis, behind an
explicit flag, with the existing dry-run and confirmation gates. No
storage, controller, or schema changes.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: A CLI command's accepted values and output changed; README's
retry section and the command's help text describe the new status and
its warning.

Backlog: Update not needed

Reason: Not a roadmap-phase item; an ingestion operations fix tracked by
its issue.

## Verification

Commands run:

- `uv run pytest tests/test_cli.py`; `uv run pytest --cov`; ruff; mypy
- `cs2a retry --help`
- Read-only against the deployed database:
  `cs2a retry --stage match --status processing --dry-run` and the map
  equivalent

Results:

- CLI tests: 30 passed (3 new); full suite: 225 passed, 2 skipped
  (opt-in DB tests); total coverage 80.61% (gate 80%). Ruff and mypy
  clean.
- Live dry run previewed the 1 match row and 4 map rows currently stuck
  in `processing`, printed the warning, and changed nothing.

## Review Notes

- The five stuck production rows are the manual verification fixture:
  after merge, either the next `cs2a process` run releases them (#141)
  or `cs2a retry --stage map --status processing` does so on demand
  with confirmation.