### PR TITLE
Add per-source freshness, test severities, and store_failures to the dbt project (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,9 +512,13 @@ from observed changes rather than trusting parsed dates. History accrues
 run over run, which is why the scheduled daily build exists.
 
 Every layer carries data tests (uniqueness of the declared grains,
-not-null keys, and relationship tests between models - 63 in total), run
-by `dbt build` locally, in CI against a disposable Postgres, and daily
-against production behind a source-freshness gate. The generated dbt docs
+not-null keys, relationship tests between models, and warn-severity
+distribution checks on the mart stat columns - 76 in total), run by
+`dbt build` locally, in CI against a disposable Postgres, and daily
+against production behind a per-source freshness gate. Structural tests
+fail the build; distribution tests warn until proven stable, and every
+test stores its failing rows in an audit schema for triage (severity
+policy in `docs/dbt_models.md`). The generated dbt docs
 site - interactive lineage DAG and column-level documentation - is
 published at <https://dardenkyle.github.io/CS2-analytics/dbt-docs/>.
 Local run instructions are in

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -26,6 +26,18 @@ clean-targets:
   - "target"
   - "dbt_packages"
 
+# Every data test stores its failing rows in an audit table so a red or
+# yellow run can be triaged by querying the rows, not by re-running the
+# test (#148). With the profile's schema set to "analytics", the custom
+# schema suffix lands the audit tables in "analytics_dbt_test__audit".
+# Severity policy (see docs/dbt_models.md): structural grain/key/
+# relationship tests stay at the default error; distribution-style
+# tests are declared warn at the test site until proven stable.
+data_tests:
+  cs2_analytics:
+    +store_failures: true
+    +schema: dbt_test__audit
+
 models:
   cs2_analytics:
     staging:

--- a/dbt/models/intermediate/_intermediate__models.yml
+++ b/dbt/models/intermediate/_intermediate__models.yml
@@ -45,7 +45,9 @@ models:
       - name: match_date
         description: Parent match date/time (stg_matches.date).
       - name: map_order
-        description: Position of this map within the match, from 1 to 5.
+        description: >
+          Position of this map within the match, 1-based. Best-of-5 is
+          the longest observed series format today.
       - name: map_name
         description: Canonical map name from stg_maps.
       - name: map_winner

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -71,7 +71,10 @@ models:
                 to: ref('dim_maps')
                 field: map_name
       - name: map_order
-        description: Position of this map within the match, from 1 to 5.
+        description: >
+          Position of this map within the match, 1-based. Best-of-5 is the
+          longest observed series format today; the range test allows up
+          to 7 as headroom for longer showmatch formats.
         data_tests:
           - dbt_utils.accepted_range:
               arguments:

--- a/dbt/models/marts/_marts__models.yml
+++ b/dbt/models/marts/_marts__models.yml
@@ -16,6 +16,21 @@ models:
             combination_of_columns:
               - map_id
               - player_id
+      # Derivation-consistency checks: the source publishes kd_diff and
+      # fk_diff alongside their operands, so a parser regression that
+      # misreads any of the four columns surfaces here. Null operands
+      # pass (no false alarms on incomplete rows). Warn severity per the
+      # distribution-test policy in docs/dbt_models.md (#148).
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "kd_diff = kills - deaths"
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "fk_diff = opening_kills - opening_deaths"
+          config:
+            severity: warn
     columns:
       - name: match_id
         description: Parent match identifier.
@@ -57,6 +72,13 @@ models:
                 field: map_name
       - name: map_order
         description: Position of this map within the match, from 1 to 5.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 7
+              config:
+                severity: warn
       - name: map_date
         description: Map date/time.
       - name: map_winner
@@ -67,8 +89,22 @@ models:
         description: Rounds won by team2 on this map.
       - name: kills
         description: Total kills on this map.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 60
+              config:
+                severity: warn
       - name: deaths
         description: Total deaths on this map.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 60
+              config:
+                severity: warn
       - name: assists
         description: Total assists on this map.
       - name: flash_assists
@@ -86,17 +122,47 @@ models:
       - name: clutches_won
         description: Clutch rounds won on this map.
       - name: kast
-        description: KAST percentage on this map.
+        description: >
+          KAST on this map, stored as a fraction between 0 and 1 (the
+          parser divides the source percentage by 100).
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+              config:
+                severity: warn
       - name: adr
         description: Average damage per round on this map.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 250
+              config:
+                severity: warn
       - name: rating
         description: Performance rating from the source on this map.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 4
+              config:
+                severity: warn
       - name: kd_diff
         description: Kill/death differential on this map.
       - name: fk_diff
         description: First-kill differential on this map.
       - name: round_swing
         description: Round swing contribution from the source on this map.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: -1
+                max_value: 1
+              config:
+                severity: warn
 
       - name: source_updated_at
         description: >
@@ -150,9 +216,17 @@ models:
       - name: forfeit
         description: Whether the match was recorded as a forfeit.
       - name: map_count
-        description: Number of maps recorded for this match in stg_maps.
+        description: >
+          Number of maps recorded for this match in stg_maps. Zero is
+          legitimate while a match's maps are still queued for processing.
         data_tests:
           - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 7
+              config:
+                severity: warn
       - name: data_complete
         description: >
           Whether the source match row satisfies its required-field contract.

--- a/dbt/models/staging/_ingestion__sources.yml
+++ b/dbt/models/staging/_ingestion__sources.yml
@@ -12,19 +12,24 @@ sources:
     # Freshness gates the scheduled prod run (.github/workflows/
     # scheduled-dbt-build.yml): a stale scraper fails the run loudly
     # instead of letting the SCD2 snapshot silently freeze history.
-    # Scraping is manual today, so thresholds are generous. All audit
-    # columns are TIMESTAMPTZ (#132), so one source-level
-    # loaded_at_field covers every table.
+    # All audit columns are TIMESTAMPTZ (#132), so one source-level
+    # loaded_at_field covers every table; thresholds are declared per
+    # table (#148) so a single source can tighten or relax without
+    # touching the others. Scraping is manual today, so warn at 3 days
+    # means "probably forgot to scrape" and error at 7 days means "the
+    # snapshot is losing roster history" - revisit warn first if the
+    # cadence changes.
     config:
       loaded_at_field: last_scraped_at
-      freshness:
-        warn_after: { count: 3, period: day }
-        error_after: { count: 7, period: day }
     tables:
       - name: matches
         description: >
           One row per professional match: teams, series score, winner,
           event, match type, and match date.
+        config:
+          freshness:
+            warn_after: { count: 3, period: day }
+            error_after: { count: 7, period: day }
         columns:
           - name: match_id
             description: Primary key; grain of this table.
@@ -35,6 +40,10 @@ sources:
         description: >
           One row per map played within a match, keyed by map_id with a
           foreign key to matches and a per-match map_order.
+        config:
+          freshness:
+            warn_after: { count: 3, period: day }
+            error_after: { count: 7, period: day }
         columns:
           - name: map_id
             description: Primary key; grain of this table.
@@ -45,6 +54,10 @@ sources:
         description: >
           Per-player per-map performance statistics (kills, deaths, ADR,
           KAST, rating, and related fields), keyed by (map_id, player_id).
+        config:
+          freshness:
+            warn_after: { count: 3, period: day }
+            error_after: { count: 7, period: day }
         data_tests:
           - dbt_utils.unique_combination_of_columns:
               arguments:

--- a/dbt/models/staging/_staging__models.yml
+++ b/dbt/models/staging/_staging__models.yml
@@ -75,7 +75,9 @@ models:
       - name: map_url
         description: Canonical source URL for the map stats page.
       - name: map_order
-        description: Position of this map within the match, from 1 to 5.
+        description: >
+          Position of this map within the match, 1-based. Best-of-5 is
+          the longest observed series format today.
       - name: map_name
         description: Map name, such as Mirage or Inferno.
         data_tests:

--- a/dbt/tests/assert_fact_player_map_stats_row_coverage.sql
+++ b/dbt/tests/assert_fact_player_map_stats_row_coverage.sql
@@ -1,0 +1,24 @@
+-- Row-coverage check for fact_player_map_stats (#148): the fact is built
+-- from stg_players through inner joins to maps and matches plus an
+-- incremental watermark filter, so rows can only ever be lost silently -
+-- a null join key, or a watermark bug that skips source rows. Warn when
+-- the fact holds fewer than 95% of the source player rows; the tolerance
+-- absorbs the normal in-flight window where players land before their
+-- parent rows finish processing. Warn severity per the distribution-test
+-- policy in docs/dbt_models.md.
+
+{{ config(severity='warn') }}
+
+with counts as (
+
+    select
+        (select count(*) from {{ ref('fact_player_map_stats') }}) as fact_rows,
+        (select count(*) from {{ ref('stg_players') }}) as source_rows
+
+)
+
+select
+    fact_rows,
+    source_rows
+from counts
+where fact_rows < 0.95 * source_rows

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -801,9 +801,14 @@ time-sensitive item and leads this phase.
       stays full-refresh (tiny, and map_count aggregates late-arriving
       child rows); full-refresh policy documented and exposed as a
       workflow_dispatch input
-- [ ] Deepen data quality: per-source freshness thresholds, warn/error
+- [x] Deepen data quality: per-source freshness thresholds, warn/error
       test severities, store_failures audit tables, and selective
-      distribution tests (#148)
+      distribution tests (#148) - each source declares warn 3 days /
+      error 7 days on `last_scraped_at`; structural tests stay error
+      while distribution tests (accepted_range bounds, kd_diff/fk_diff
+      derivation checks, a fact row-coverage test) start as warn; every
+      test stores failing rows in `analytics_dbt_test__audit`; policy
+      documented in docs/dbt_models.md
 
 ### After Phase 4.5
 

--- a/docs/dbt_models.md
+++ b/docs/dbt_models.md
@@ -657,16 +657,19 @@ The Scheduled dbt Build workflow
 
 1. `dbt source freshness --target prod` - gate. The ingestion sources
    declare a source-level `loaded_at_field` on `last_scraped_at` (all
-   audit columns are TIMESTAMPTZ since #132) with warn-after 3 days /
-   error-after 7 days; stale sources fail the workflow loudly instead
-   of letting snapshot history freeze while runs stay green.
+   audit columns are TIMESTAMPTZ since #132) with per-table thresholds
+   (#148) of warn-after 3 days / error-after 7 days; stale sources fail
+   the workflow loudly instead of letting snapshot history freeze while
+   runs stay green.
 2. `dbt build --target prod` - models, snapshots, and data tests.
 
 Connection settings come from the repository's `DB_*` Actions secrets
 through the `prod` profile target (TLS required via `sslmode`). Freshness
-thresholds are set for today's manual scraping cadence; tightening them
-belongs to the data-quality depth work (#148). This workflow is interim
-orchestration ("Phase 5 lite") and is what Airflow later replaces.
+thresholds are set for today's manual scraping cadence: warn at 3 days
+means "probably forgot to scrape", error at 7 days means "roster history
+is at risk". If the cadence changes, adjust warn first. This workflow is
+interim orchestration ("Phase 5 lite") and is what Airflow later
+replaces.
 
 ---
 
@@ -758,12 +761,67 @@ Routine daily runs stay incremental.
 
 ## Testing Strategy
 
-Status: implemented (#113). Grain `unique`/`not_null` tests cover every
-source table, staging model, intermediate model, and mart; `relationships`
-tests cover the key joins (maps -> matches, player rows -> maps/matches, and
-fact -> dim joins). Multi-column `(map_id, player_id)` grains use
-`dbt_utils.unique_combination_of_columns` (see `dbt/packages.yml`; install
-with `dbt deps`). Run everything with `dbt build`.
+Status: implemented (#113, extended by #148). Grain `unique`/`not_null`
+tests cover every source table, staging model, intermediate model, and
+mart; `relationships` tests cover the key joins (maps -> matches, player
+rows -> maps/matches, and fact -> dim joins). Multi-column
+`(map_id, player_id)` grains use `dbt_utils.unique_combination_of_columns`
+(see `dbt/packages.yml`; install with `dbt deps`). Run everything with
+`dbt build`.
+
+### Severity policy (#148)
+
+Two tiers, chosen so the scheduled prod run distinguishes "page me" from
+"look later":
+
+- **error** (dbt default, left implicit): structural tests - grain
+  uniqueness, not-null keys, and `relationships` joins. A failure means
+  downstream models cannot be trusted, so the build stops.
+- **warn**: distribution-style tests - `dbt_utils.accepted_range` bounds
+  on mart stat columns, the `expression_is_true` derivation checks
+  (`kd_diff = kills - deaths`, `fk_diff = opening_kills -
+  opening_deaths`), and the singular row-coverage test
+  (`dbt/tests/assert_fact_player_map_stats_row_coverage.sql`). These
+  encode assumptions about game-stat bounds, so they start as warnings
+  and get promoted to `error` deliberately once they have survived
+  enough real data.
+
+Every new distribution-style test starts at `warn`. Range values are
+grounded in the observed production distributions as of 2026-08-31 with
+headroom (for example, rating observed 0.15-3.19, tested 0-4); `kast` is
+a fraction (0-1), not a percentage, because the parser divides by 100.
+
+### Stored failures (#148)
+
+`store_failures` is enabled project-wide (`dbt_project.yml`,
+`data_tests` block), so every data test writes its failing rows to an
+audit table on each run - failed tests are triaged by querying rows, not
+by re-running SQL. With the profile schema set to `analytics`, audit
+tables land in the `analytics_dbt_test__audit` schema, named after the
+test (long test names are truncated and suffixed with a hash). To
+inspect a failure:
+
+```sql
+select * from analytics_dbt_test__audit.<test_name> limit 50;
+```
+
+The exact relation name appears in the dbt log output for the failing
+test. Audit tables
+are overwritten on every run, so they always reflect the latest build;
+they are diagnostic state, not history.
+
+### Source freshness (#148)
+
+Each source table (`matches`, `maps`, `players`) declares its own
+freshness thresholds on `last_scraped_at` (warn 3 days / error 7 days
+today). Run locally with:
+
+```sh
+uv run dbt source freshness --project-dir dbt --profiles-dir dbt
+```
+
+The scheduled prod workflow runs this as a gate before `dbt build`; see
+Scheduled execution above.
 
 dbt tests should be added to ensure trust in transformed models.
 

--- a/scripts/seed_dbt_ci_fixture.py
+++ b/scripts/seed_dbt_ci_fixture.py
@@ -160,7 +160,9 @@ def fixture_players(now: datetime) -> list[Player]:
             opening_deaths=1,
             multi_kills=3,
             clutches_won=1,
-            kast=72.5,
+            # Fraction scale, matching the parser (percentage / 100); the
+            # mart's accepted_range test on kast asserts 0-1.
+            kast=0.725,
             kd_diff=5,
             adr=81.3,
             fk_diff=1,


### PR DESCRIPTION
## Summary

Deepens the dbt data-quality layer so the scheduled prod run can distinguish "page me" failures from "look later" warnings and leave failing rows queryable: per-source freshness thresholds, explicit warn/error test severities, project-wide `store_failures` audit tables, and a first set of distribution-style tests grounded in the observed production distributions.

## Related Issue

Closes #148

## Scope

- `dbt/models/staging/_ingestion__sources.yml`: freshness declared per source table (`matches`, `maps`, `players`) instead of once at the source level; warn after 3 days, error after 7, matched to the manual scrape cadence.
- `dbt/dbt_project.yml`: `data_tests` block enabling `store_failures` project-wide with a `dbt_test__audit` custom schema (audit tables land in `analytics_dbt_test__audit`).
- `dbt/models/marts/_marts__models.yml`: warn-severity distribution tests - `dbt_utils.accepted_range` on `rating` (0-4), `kills`/`deaths` (0-60), `adr` (0-250), `kast` (0-1), `round_swing` (-1..1), `map_order` (1-7), and `fact_matches.map_count` (0-7); `dbt_utils.expression_is_true` derivation checks (`kd_diff = kills - deaths`, `fk_diff = opening_kills - opening_deaths`).
- `dbt/tests/assert_fact_player_map_stats_row_coverage.sql`: new singular warn test flagging when the fact holds fewer than 95% of `stg_players` rows (silent row loss from join keys or a watermark bug).
- `scripts/seed_dbt_ci_fixture.py`: fixture `kast` corrected to the parser's fraction scale (0.725, not 72.5) so the new 0-1 range test passes in CI.
- `docs/dbt_models.md`: severity policy, stored-failures triage instructions, per-table freshness notes.
- `README.md`: dbt test-count sentence updated (76 data tests, severity tiers, audit schema).
- `docs/backlog.md`: #148 checklist item checked off.

## Out of Scope

- No orchestration changes; the scheduled workflow already runs `dbt source freshness` then `dbt build` and needed no edits.
- No external alerting/monitoring stack; the failure surface remains the dbt run itself.
- No `dbt_expectations` package; everything needed exists in the locked `dbt_utils` 1.4.1.
- No Python test coverage changes beyond the fixture value correction.
- Promotion of distribution tests from warn to error is deliberate future work once they have survived real data.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Additive test configuration only - no model logic, schema, or pipeline changes. New tests are warn severity, so they cannot fail CI or the scheduled prod build; the only new failure mode is the per-table freshness config, which keeps the exact thresholds already running in production. `store_failures` writes to a new dedicated audit schema and touches no existing relations.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: `docs/dbt_models.md` gains the severity policy, stored-failures triage instructions (audit schema name, table naming, hash truncation), and the per-table freshness section; the scheduled-execution section no longer defers threshold tuning to #148. README's transformation-layer summary reflects the new test count and severity tiers.

Backlog: Updated

Reason: The #148 Phase 4.5 checklist item is checked off with a summary of what was delivered.

## Verification

Commands run:

- Disposable Postgres 17 container: `alembic upgrade head`, `scripts/seed_dbt_ci_fixture.py`, `dbt deps`, `dbt build`
- Injected an out-of-range player row (rating 9.99, adr 999, kast 72.5, kd_diff 99) through the storage layer, then `dbt build`
- Queried `analytics_dbt_test__audit` tables for the failing rows
- Set `dim_players.player_name` to NULL directly, then `dbt test --select dim_players`
- Deleted 3 fact rows, then `dbt test --select assert_fact_player_map_stats_row_coverage`
- Aged `last_scraped_at` to 10 days and 4 days, then `dbt source freshness`
- `uv run pytest --cov`

Results:

- Baseline build green: 87 items (76 data tests), PASS=87 WARN=0 ERROR=0
- Bad row: build completed with 4 warnings (adr, kast, rating ranges plus the kd_diff derivation check), exit 0 - warn severity does not fail the build
- Failing rows queryable in the audit schema with full row context
- Error-severity `not_null` failure: FAIL 1, exit code 1 - error severity fails the run
- Row-coverage test: WARN 1 after simulated row loss
- Freshness: 10 days -> ERROR STALE on all three sources, exit 1; 4 days -> WARN on all three, exit 0
- pytest: 225 passed, 2 skipped; total coverage 80.61% (CI floor 80%)

## Review Notes

- Threshold values are the review focus per the issue: freshness warn 3 days / error 7 days (unchanged numbers, now per-table), and accepted ranges chosen from measured production distributions with headroom (e.g. rating observed 0.15-3.19, tested 0-4; kast is a fraction 0-1 because the parser divides the source percentage by 100).
- The fixture `kast` correction (72.5 -> 0.725) aligns CI data with the parser's real output scale; other Python-test kast values on the percent scale never reach dbt and were left alone.
- Audit tables are overwritten each run (diagnostic state, not history); long test names truncate with a hash, and the exact relation name appears in the dbt log output.
