### PR TITLE
Add cs2a failures command surfacing ingestion failure details (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,10 +292,20 @@ cs2a ingest discover            # scrape results pages, queue new matches
 cs2a ingest discover --mode backfill
 cs2a process --batch 50         # process pending matches, then maps
 cs2a status                     # ingestion-state row counts by status
+cs2a failures --stage match     # recent failed rows with error details
+cs2a failures --stage map --group   # aggregate failures by error message
 cs2a retry --stage match        # requeue failed matches for reprocessing
 cs2a retry --stage map --dry-run
 cs2a retry --stage map --status processing --dry-run   # inspect rows stuck by an interrupted run
 ```
+
+`cs2a failures` is read-only diagnostics for deciding whether to requeue:
+it lists recent `failed` rows (or `dead`/`partial` via `--status`) with
+`failure_count`, `last_failed_at`, and a truncated `last_error_message`,
+ordered most recently failed first (`--limit`, default 20). `--group`
+aggregates rows by error message so dominant failure modes - transient
+scraper noise versus a structural break like a page layout change - are
+obvious before running `cs2a retry`.
 
 `cs2a retry` resets `failed` ingestion-state rows back to `discovered` so
 the next `cs2a process` run picks them up. `dead`, `partial`, and

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -78,8 +78,8 @@ def process(
     MapController().run(batch_size=batch)
 
 
-class RetryStage(StrEnum):
-    """Ingestion stage whose state table a requeue targets."""
+class IngestionStage(StrEnum):
+    """Ingestion stage whose state table a command targets."""
 
     MATCH = "match"
     MAP = "map"
@@ -94,21 +94,37 @@ class RetryStatus(StrEnum):
     PROCESSING = "processing"
 
 
+class FailureStatus(StrEnum):
+    """Lifecycle statuses carrying failure diagnostics."""
+
+    FAILED = "failed"
+    DEAD = "dead"
+    PARTIAL = "partial"
+
+
 PROCESSING_RELEASE_WARNING = (
     "Warning: releasing 'processing' rows while a pipeline run is active can "
     "cause duplicate processing. Confirm no run is in flight before continuing."
 )
 
 
-RETRY_ERROR_PREVIEW_LENGTH = 60
+ERROR_PREVIEW_LENGTH = 60
 
 
-def _retry_state_for(stage: RetryStage) -> "BaseIngestionState[int]":
+def _error_preview(message: str | None) -> str:
+    """Truncate an error message for single-line terminal listings."""
+    preview = message or ""
+    if len(preview) > ERROR_PREVIEW_LENGTH:
+        preview = preview[:ERROR_PREVIEW_LENGTH] + "..."
+    return preview
+
+
+def _retry_state_for(stage: IngestionStage) -> "BaseIngestionState[int]":
     """Return the ingestion-state manager for the requested retry stage."""
     from cs2_analytics.ingestion_state.map_ingestion_state import MapIngestionState
     from cs2_analytics.ingestion_state.match_ingestion_state import MatchIngestionState
 
-    if stage is RetryStage.MATCH:
+    if stage is IngestionStage.MATCH:
         return MatchIngestionState()
     return MapIngestionState()
 
@@ -116,7 +132,7 @@ def _retry_state_for(stage: RetryStage) -> "BaseIngestionState[int]":
 @app.command()
 def retry(
     stage: Annotated[
-        RetryStage,
+        IngestionStage,
         typer.Option(help="Ingestion stage whose state rows to requeue."),
     ],
     status: Annotated[
@@ -166,10 +182,9 @@ def retry(
         return
 
     for row_id, failure_count, last_error in candidates:
-        error_preview = last_error or ""
-        if len(error_preview) > RETRY_ERROR_PREVIEW_LENGTH:
-            error_preview = error_preview[:RETRY_ERROR_PREVIEW_LENGTH] + "..."
-        typer.echo(f"  {row_id}  failures={failure_count or 0}  {error_preview}")
+        typer.echo(
+            f"  {row_id}  failures={failure_count or 0}  {_error_preview(last_error)}"
+        )
     typer.echo(f"{len(candidates)} {stage.value} row(s) in status '{status.value}'.")
 
     if dry_run:
@@ -189,6 +204,75 @@ def retry(
         typer.echo(
             f"{skipped} row(s) changed status since the preview and were left alone."
         )
+
+
+@app.command()
+def failures(
+    stage: Annotated[
+        IngestionStage,
+        typer.Option(help="Ingestion stage whose failure rows to show."),
+    ],
+    status: Annotated[
+        FailureStatus,
+        typer.Option(help="Lifecycle status to inspect."),
+    ] = FailureStatus.FAILED,
+    limit: Annotated[
+        int,
+        typer.Option(min=1, help="Show at most this many rows or groups."),
+    ] = 20,
+    group: Annotated[
+        bool,
+        typer.Option(
+            "--group",
+            help="Aggregate rows by error message instead of listing them.",
+        ),
+    ] = False,
+) -> None:
+    """Show recent ingestion failures with their stored error details.
+
+    Read-only: surfaces failure_count, last_failed_at, and a truncated
+    last_error_message so the operator can tell transient scraper noise
+    from a structural break before requeueing anything with `cs2a retry`.
+    """
+    from cs2_analytics.storage.ingestion_state_summary import (
+        FAILURE_STAGE_TABLES,
+        fetch_failure_groups,
+        fetch_failure_rows,
+    )
+
+    table, _ = FAILURE_STAGE_TABLES[stage.value]
+    try:
+        if group:
+            groups = fetch_failure_groups(stage.value, status.value, limit)
+        else:
+            rows = fetch_failure_rows(stage.value, status.value, limit)
+    except DatabaseConnectionError as e:
+        typer.echo(f"Database unavailable: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    if group:
+        if not groups:
+            typer.echo(f"No {status.value} rows in {table}.")
+            return
+        for message, row_count, latest_failed_at in groups:
+            typer.echo(
+                f"  count={row_count}  latest={latest_failed_at or '-'}"
+                f"  {_error_preview(message) or '(no error message)'}"
+            )
+        typer.echo(
+            f"{len(groups)} failure group(s) in status '{status.value}' in {table}."
+        )
+        return
+
+    if not rows:
+        typer.echo(f"No {status.value} rows in {table}.")
+        return
+    for row_id, row_status, failure_count, last_failed_at, message in rows:
+        typer.echo(
+            f"  {row_id}  {row_status}  failures={failure_count or 0}"
+            f"  last_failed={last_failed_at or '-'}  {_error_preview(message)}"
+        )
+    typer.echo(f"{len(rows)} {stage.value} row(s) in status '{status.value}'.")
 
 
 def _alembic_config():

--- a/cs2_analytics/storage/ingestion_state_summary.py
+++ b/cs2_analytics/storage/ingestion_state_summary.py
@@ -1,4 +1,11 @@
-"""Read-side summary of ingestion-state tables for status reporting."""
+"""Read-side summaries of ingestion-state tables for status reporting.
+
+All table and column names formatted into queries come from module
+constants, never from user input, so the formatting is safe; runtime
+values (status, limit) are always parametrized.
+"""
+
+import datetime as dt
 
 from cs2_analytics.storage.db_instance import get_db
 
@@ -9,6 +16,66 @@ INGESTION_STATE_TABLES = (
 )
 
 STATUS_COUNTS_QUERY = "SELECT status, COUNT(*) FROM {table} GROUP BY status;"
+
+# Stages with failure diagnostics exposed via `cs2a failures`; demo rows
+# stay out until the demo pipeline is active.
+FAILURE_STAGE_TABLES = {
+    "match": ("match_ingestion_state", "match_id"),
+    "map": ("map_ingestion_state", "map_id"),
+}
+
+FAILURE_ROWS_QUERY = """
+    SELECT {id_column}, status, failure_count, last_failed_at, last_error_message
+    FROM {table}
+    WHERE status = %s
+    ORDER BY last_failed_at DESC NULLS LAST, {id_column}
+    LIMIT %s;
+"""
+
+FAILURE_GROUPS_QUERY = """
+    SELECT last_error_message, COUNT(*), MAX(last_failed_at)
+    FROM {table}
+    WHERE status = %s
+    GROUP BY last_error_message
+    ORDER BY COUNT(*) DESC, MAX(last_failed_at) DESC NULLS LAST
+    LIMIT %s;
+"""
+
+
+def fetch_failure_rows(
+    stage: str, status: str, limit: int
+) -> list[tuple[int, str, int, dt.datetime | None, str | None]]:
+    """Return recent rows in the given lifecycle status for one stage.
+
+    Each row is (id, status, failure_count, last_failed_at,
+    last_error_message), most recently failed first; rows that never
+    recorded a failure timestamp sort last.
+    """
+    table, id_column = FAILURE_STAGE_TABLES[stage]
+    query = FAILURE_ROWS_QUERY.format(table=table, id_column=id_column)
+    with get_db().get_cursor() as cur:
+        cur.execute(query, (status, limit))
+        rows: list[tuple[int, str, int, dt.datetime | None, str | None]] = (
+            cur.fetchall()
+        )
+    return rows
+
+
+def fetch_failure_groups(
+    stage: str, status: str, limit: int
+) -> list[tuple[str | None, int, dt.datetime | None]]:
+    """Return failure rows grouped by error message for one stage.
+
+    Each group is (last_error_message, row_count, latest last_failed_at),
+    largest group first, so dominant failure modes are obvious at a
+    glance.
+    """
+    table, _ = FAILURE_STAGE_TABLES[stage]
+    query = FAILURE_GROUPS_QUERY.format(table=table)
+    with get_db().get_cursor() as cur:
+        cur.execute(query, (status, limit))
+        groups: list[tuple[str | None, int, dt.datetime | None]] = cur.fetchall()
+    return groups
 
 
 def fetch_ingestion_state_counts() -> dict[str, dict[str, int]]:

--- a/tests/storage/test_ingestion_state_summary.py
+++ b/tests/storage/test_ingestion_state_summary.py
@@ -1,0 +1,95 @@
+"""Tests for the failure-detail queries in ingestion_state_summary (#123).
+
+The helpers format table/column names from module constants and
+parametrize runtime values, so these tests assert the emitted SQL targets
+the right table and id column, passes (status, limit) as parameters, and
+returns cursor rows unchanged. The database is faked; no connection is
+opened.
+"""
+
+import pytest
+
+import cs2_analytics.storage.ingestion_state_summary as summary_module
+from cs2_analytics.storage.ingestion_state_summary import (
+    fetch_failure_groups,
+    fetch_failure_rows,
+)
+
+
+class _RecordingCursor:
+    def __init__(self, rows: list[tuple]) -> None:
+        self.rows = rows
+        self.executed: list[tuple[str, tuple]] = []
+
+    def __enter__(self) -> "_RecordingCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple) -> None:
+        self.executed.append((query, params))
+
+    def fetchall(self) -> list[tuple]:
+        return self.rows
+
+
+class _FakeDatabase:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _RecordingCursor:
+        return self.cursor
+
+
+def _install_fake_db(monkeypatch, rows: list[tuple]) -> _RecordingCursor:
+    cursor = _RecordingCursor(rows)
+    monkeypatch.setattr(summary_module, "get_db", lambda: _FakeDatabase(cursor))
+    return cursor
+
+
+@pytest.mark.parametrize(
+    ("stage", "table", "id_column"),
+    [
+        ("match", "match_ingestion_state", "match_id"),
+        ("map", "map_ingestion_state", "map_id"),
+    ],
+)
+def test_fetch_failure_rows_targets_stage_table(
+    monkeypatch, stage, table, id_column
+) -> None:
+    expected = [(1, "failed", 2, None, "boom")]
+    cursor = _install_fake_db(monkeypatch, expected)
+
+    rows = fetch_failure_rows(stage, "failed", 20)
+
+    assert rows == expected
+    query, params = cursor.executed[0]
+    assert f"FROM {table}" in query
+    assert f"SELECT {id_column}" in query
+    assert f"ORDER BY last_failed_at DESC NULLS LAST, {id_column}" in query
+    assert params == ("failed", 20)
+
+
+def test_fetch_failure_rows_parametrizes_status_and_limit(monkeypatch) -> None:
+    cursor = _install_fake_db(monkeypatch, [])
+
+    fetch_failure_rows("match", "dead", 5)
+
+    query, params = cursor.executed[0]
+    assert "dead" not in query
+    assert params == ("dead", 5)
+
+
+def test_fetch_failure_groups_aggregates_by_error_message(monkeypatch) -> None:
+    expected = [("boom", 4, None), (None, 1, None)]
+    cursor = _install_fake_db(monkeypatch, expected)
+
+    groups = fetch_failure_groups("map", "failed", 10)
+
+    assert groups == expected
+    query, params = cursor.executed[0]
+    assert "FROM map_ingestion_state" in query
+    assert "GROUP BY last_error_message" in query
+    assert "ORDER BY COUNT(*) DESC" in query
+    assert params == ("failed", 10)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -514,7 +514,7 @@ def test_failures_exits_nonzero_when_database_is_unavailable(monkeypatch) -> Non
     result = runner.invoke(app, ["failures", "--stage", "match"])
 
     assert result.exit_code == 1
-    assert "Database unavailable" in result.output
+    assert "Database unavailable" in result.stderr
 
 
 def test_db_upgrade_defaults_to_head_and_prints_target(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_help_lists_all_commands() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    for command in ("ingest", "process", "retry", "status", "db"):
+    for command in ("ingest", "process", "retry", "failures", "status", "db"):
         assert command in result.stdout
 
 
@@ -402,6 +402,119 @@ def test_status_exits_nonzero_when_database_is_unavailable(monkeypatch) -> None:
     result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 1
+
+
+def _patch_failure_queries(monkeypatch, rows=None, groups=None):
+    """Replace the failure query helpers with recorders in their module."""
+    import cs2_analytics.storage.ingestion_state_summary as summary_module
+
+    calls: list[tuple[str, tuple]] = []
+
+    def _rows(stage, status, limit):
+        calls.append(("rows", (stage, status, limit)))
+        return rows or []
+
+    def _groups(stage, status, limit):
+        calls.append(("groups", (stage, status, limit)))
+        return groups or []
+
+    monkeypatch.setattr(summary_module, "fetch_failure_rows", _rows)
+    monkeypatch.setattr(summary_module, "fetch_failure_groups", _groups)
+    return calls
+
+
+def test_failures_lists_rows_with_truncated_error(monkeypatch) -> None:
+    long_error = "MatchParseError: " + "x" * 100
+    calls = _patch_failure_queries(
+        monkeypatch,
+        rows=[
+            (940123, "failed", 3, "2026-08-30 10:00:00+00:00", long_error),
+            (940124, "failed", 1, None, None),
+        ],
+    )
+
+    result = runner.invoke(app, ["failures", "--stage", "match"])
+
+    assert result.exit_code == 0
+    assert calls == [("rows", ("match", "failed", 20))]
+    assert "940123" in result.stdout
+    assert "failures=3" in result.stdout
+    assert "2026-08-30 10:00:00+00:00" in result.stdout
+    assert "..." in result.stdout
+    assert long_error not in result.stdout
+    assert "last_failed=-" in result.stdout
+    assert "2 match row(s) in status 'failed'" in result.stdout
+
+
+def test_failures_group_aggregates_by_error_message(monkeypatch) -> None:
+    calls = _patch_failure_queries(
+        monkeypatch,
+        groups=[
+            ("MapParseError: layout changed", 5, "2026-08-30 10:00:00+00:00"),
+            (None, 1, None),
+        ],
+    )
+
+    result = runner.invoke(
+        app, ["failures", "--stage", "map", "--status", "dead", "--group"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("groups", ("map", "dead", 20))]
+    assert "count=5" in result.stdout
+    assert "MapParseError: layout changed" in result.stdout
+    assert "(no error message)" in result.stdout
+    assert (
+        "2 failure group(s) in status 'dead' in map_ingestion_state" in result.stdout
+    )
+
+
+def test_failures_passes_status_and_limit_filters(monkeypatch) -> None:
+    calls = _patch_failure_queries(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        ["failures", "--stage", "map", "--status", "partial", "--limit", "5"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("rows", ("map", "partial", 5))]
+    assert "No partial rows in map_ingestion_state." in result.stdout
+
+
+def test_failures_rejects_nonpositive_limit(monkeypatch) -> None:
+    calls = _patch_failure_queries(monkeypatch)
+
+    result = runner.invoke(app, ["failures", "--stage", "match", "--limit", "0"])
+
+    assert result.exit_code != 0
+    assert calls == []
+
+
+def test_failures_rejects_processing_status(monkeypatch) -> None:
+    calls = _patch_failure_queries(monkeypatch)
+
+    result = runner.invoke(
+        app, ["failures", "--stage", "match", "--status", "processing"]
+    )
+
+    assert result.exit_code != 0
+    assert calls == []
+
+
+def test_failures_exits_nonzero_when_database_is_unavailable(monkeypatch) -> None:
+    import cs2_analytics.storage.ingestion_state_summary as summary_module
+    from cs2_analytics.exceptions import DatabaseConnectionError
+
+    def _raise(stage, status, limit):
+        raise DatabaseConnectionError("no pool")
+
+    monkeypatch.setattr(summary_module, "fetch_failure_rows", _raise)
+
+    result = runner.invoke(app, ["failures", "--stage", "match"])
+
+    assert result.exit_code == 1
+    assert "Database unavailable" in result.output
 
 
 def test_db_upgrade_defaults_to_head_and_prints_target(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Adds a read-only `cs2a failures` command that surfaces the ingestion failure diagnostics the schema already stores (`failure_count`, `last_failed_at`, `last_error_message`) as a recent-rows listing and a grouped-by-error-message summary, so the operator can tell transient scraper noise from a structural break before requeueing anything with `cs2a retry`.

## Related Issue

Closes #123

## Scope

- `cs2_analytics/storage/ingestion_state_summary.py`: two read-only query helpers next to the existing status summary - `fetch_failure_rows` (recent rows in a status, ordered `last_failed_at` desc with nulls last) and `fetch_failure_groups` (counts per error message, largest group first). Table/id-column names come from module constants; status and limit are parametrized.
- `cs2_analytics/cli.py`: `cs2a failures --stage match|map` with `--status` (default `failed`; accepts `dead`, `partial`), `--limit` (default 20, min 1), and `--group`. Error messages truncate at 60 chars via `_error_preview`, a helper now shared with the retry preview. Database-unavailable prints to stderr and exits 1, matching `cs2a status`. `RetryStage` is renamed `IngestionStage` since both commands target the same stage tables (nothing outside `cli.py` referenced the old name).
- `tests/storage/test_ingestion_state_summary.py` (new): helper tests against a fake cursor - emitted SQL targets the right table and id column, runtime values are parametrized, rows pass through unchanged.
- `tests/test_cli.py`: listing output (truncation, null timestamp placeholder), grouped output, filter passthrough, empty-result message, nonpositive-limit and `processing`-status rejection, database-unavailable exit code; help test now includes `failures`.
- `README.md`: CLI examples and a paragraph describing the command.

## Out of Scope

- No requeue or write behavior (`cs2a retry` owns that); the command is strictly read-only.
- No schema changes and no new failure metadata.
- Demo-stage rows stay unexposed until the demo pipeline is active.
- `cs2a inspect` (#124) and `cs2a ingest coverage` (#125) are separate follow-ups.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Read-only SELECT queries behind a new CLI command; no controller, stage-service, scraper, or storage-write involvement, and no changes to existing command behavior beyond an internal enum rename and a shared truncation helper with identical output.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README documents the new command in the CLI section (examples plus a usage paragraph). No architecture docs needed - the command follows the established read-only summary pattern in the storage layer.

Backlog: Update not needed

Reason: The operational CLI commands (#123-#125) are not roadmap checklist items in docs/backlog.md; no phase, checklist, or sequencing status changes.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check ...` and `uv run mypy ...` (the CI invocations)
- Disposable Postgres 17: migrated, seeded 4 state rows (failed with long/short/null error messages, one dead), then ran the listing, `--group`, `--status dead`, and `--limit 1`
- Read-only against the deployed database: `cs2a failures --stage match`, `--stage map --group`, `--stage map --status dead`

Results:

- pytest: 235 passed, 2 skipped; total coverage 81.00% (CI floor 80%)
- ruff and mypy clean
- Disposable DB: rows ordered most recently failed first with never-failed rows last (`last_failed=-`), messages truncated at 60 chars, groups ordered by count with `(no error message)` for null messages, filters and limit behaved as documented
- Deployed DB (currently has no failed rows): clean empty-path output ("No failed rows in match_ingestion_state."), exit 0

## Review Notes

- The `RetryStage` -> `IngestionStage` rename is the one refactor bundled in; it avoids a duplicate identical enum and nothing outside `cli.py` used the old name.
- `--group` applies `--limit` to the number of groups shown, mirroring the row listing.
- The demo stage is deliberately absent from `FAILURE_STAGE_TABLES`; adding it later is a one-line constant change.
