### PR TITLE
Add cs2a inspect commands for per-item ingestion diagnostics (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ cs2a process --batch 50         # process pending matches, then maps
 cs2a status                     # ingestion-state row counts by status
 cs2a failures --stage match     # recent failed rows with error details
 cs2a failures --stage map --group   # aggregate failures by error message
+cs2a inspect match 2394877      # one match: state row + relational presence
+cs2a inspect map 230075         # one map: state row + player-stats count
 cs2a retry --stage match        # requeue failed matches for reprocessing
 cs2a retry --stage map --dry-run
 cs2a retry --stage map --status processing --dry-run   # inspect rows stuck by an interrupted run
@@ -306,6 +308,15 @@ ordered most recently failed first (`--limit`, default 20). `--group`
 aggregates rows by error message so dominant failure modes - transient
 scraper noise versus a structural break like a page layout change - are
 obvious before running `cs2a retry`.
+
+`cs2a inspect` is the single-item companion: given one ID it prints the
+full ingestion-state row (status, lifecycle timestamps, failure fields,
+source, priority) plus whether the relational data actually landed - for
+a match, whether the `matches` row exists, how many `maps` rows
+reference it, and each map's ingestion status; for a map, whether the
+`maps` row exists and its player-stats row count. Unknown IDs exit
+nonzero. Both commands are read-only against whichever database the
+environment points at.
 
 `cs2a retry` resets `failed` ingestion-state rows back to `discovered` so
 the next `cs2a process` run picks them up. `dead`, `partial`, and

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -30,6 +30,11 @@ db_app = typer.Typer(
     no_args_is_help=True,
 )
 app.add_typer(db_app, name="db")
+inspect_app = typer.Typer(
+    help="Read-only per-item ingestion diagnostics.",
+    no_args_is_help=True,
+)
+app.add_typer(inspect_app, name="inspect")
 
 
 class DiscoverMode(StrEnum):
@@ -273,6 +278,87 @@ def failures(
             f"  last_failed={last_failed_at or '-'}  {_error_preview(message)}"
         )
     typer.echo(f"{len(rows)} {stage.value} row(s) in status '{status.value}'.")
+
+
+def _echo_state_row(table: str, state: dict[str, object]) -> None:
+    """Print one ingestion-state row as aligned name/value lines."""
+    typer.echo(f"{table}:")
+    for name, value in state.items():
+        typer.echo(f"  {name:<20} {'-' if value is None else value}")
+
+
+@inspect_app.command("match")
+def inspect_match(
+    match_id: Annotated[
+        int,
+        typer.Argument(help="Match ID to inspect."),
+    ],
+) -> None:
+    """Show one match's ingestion-state row and relational presence.
+
+    Answers "this match says processed - is its data actually there?":
+    the full match_ingestion_state row, whether the matches row exists,
+    how many maps rows reference it, and each map's ingestion status.
+    """
+    from cs2_analytics.storage.ingestion_state_summary import fetch_match_inspection
+
+    try:
+        inspection = fetch_match_inspection(match_id)
+    except DatabaseConnectionError as e:
+        typer.echo(f"Database unavailable: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    state = inspection["state"]
+    if state is None:
+        typer.echo(f"No match_ingestion_state row for match {match_id}.")
+        if not inspection["match_row_exists"]:
+            typer.echo(f"Match {match_id} not found.", err=True)
+            raise typer.Exit(code=1)
+    else:
+        _echo_state_row("match_ingestion_state", state)
+    typer.echo(
+        f"matches row: {'present' if inspection['match_row_exists'] else 'MISSING'}"
+    )
+    typer.echo(f"maps rows: {inspection['map_rows']}")
+    map_states = inspection["map_states"]
+    if map_states:
+        typer.echo("map ingestion statuses:")
+        for map_id, map_status in map_states:
+            typer.echo(f"  {map_id}  {map_status}")
+
+
+@inspect_app.command("map")
+def inspect_map(
+    map_id: Annotated[
+        int,
+        typer.Argument(help="Map ID to inspect."),
+    ],
+) -> None:
+    """Show one map's ingestion-state row and relational presence.
+
+    The full map_ingestion_state row, whether the maps row exists, and
+    how many player-stats rows the map has.
+    """
+    from cs2_analytics.storage.ingestion_state_summary import fetch_map_inspection
+
+    try:
+        inspection = fetch_map_inspection(map_id)
+    except DatabaseConnectionError as e:
+        typer.echo(f"Database unavailable: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    state = inspection["state"]
+    if state is None:
+        typer.echo(f"No map_ingestion_state row for map {map_id}.")
+        if not inspection["map_row_exists"]:
+            typer.echo(f"Map {map_id} not found.", err=True)
+            raise typer.Exit(code=1)
+    else:
+        _echo_state_row("map_ingestion_state", state)
+    typer.echo(
+        f"maps row: {'present' if inspection['map_row_exists'] else 'MISSING'}"
+    )
+    typer.echo(f"players rows: {inspection['player_rows']}")
 
 
 def _alembic_config():

--- a/cs2_analytics/storage/ingestion_state_summary.py
+++ b/cs2_analytics/storage/ingestion_state_summary.py
@@ -6,6 +6,7 @@ values (status, limit) are always parametrized.
 """
 
 import datetime as dt
+from typing import TypedDict
 
 from cs2_analytics.storage.db_instance import get_db
 
@@ -76,6 +77,124 @@ def fetch_failure_groups(
         cur.execute(query, (status, limit))
         groups: list[tuple[str | None, int, dt.datetime | None]] = cur.fetchall()
     return groups
+
+
+# Full ingestion-state rows shown by `cs2a inspect`, in display order.
+MATCH_STATE_COLUMNS = (
+    "match_id",
+    "match_url",
+    "status",
+    "first_seen_at",
+    "last_seen_at",
+    "last_attempted_at",
+    "last_processed_at",
+    "last_failed_at",
+    "failure_count",
+    "last_error_message",
+    "source",
+    "priority",
+    "last_updated_at",
+)
+
+MAP_STATE_COLUMNS = (
+    "map_id",
+    "map_url",
+    "match_id",
+    "map_order",
+    "status",
+    "first_seen_at",
+    "last_seen_at",
+    "last_attempted_at",
+    "last_processed_at",
+    "last_failed_at",
+    "failure_count",
+    "last_error_message",
+    "source",
+    "priority",
+    "last_updated_at",
+)
+
+
+class MatchInspection(TypedDict):
+    """One match's ingestion-state row plus relational presence."""
+
+    state: dict[str, object] | None
+    match_row_exists: bool
+    map_rows: int
+    map_states: list[tuple[int, str]]
+
+
+class MapInspection(TypedDict):
+    """One map's ingestion-state row plus relational presence."""
+
+    state: dict[str, object] | None
+    map_row_exists: bool
+    player_rows: int
+
+
+def _fetch_state_row(
+    cur, table: str, id_column: str, columns: tuple[str, ...], item_id: int
+) -> dict[str, object] | None:
+    """Fetch one ingestion-state row as a column->value mapping."""
+    cur.execute(
+        f"SELECT {', '.join(columns)} FROM {table} WHERE {id_column} = %s;",
+        (item_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    return dict(zip(columns, row, strict=True))
+
+
+def fetch_match_inspection(match_id: int) -> MatchInspection:
+    """Return one match's full ingestion picture.
+
+    Combines the match_ingestion_state row (None when absent) with
+    relational presence: whether the matches row exists, how many maps
+    rows reference it, and each referencing map's ingestion status.
+    """
+    with get_db().get_cursor() as cur:
+        state = _fetch_state_row(
+            cur, "match_ingestion_state", "match_id", MATCH_STATE_COLUMNS, match_id
+        )
+        cur.execute("SELECT 1 FROM matches WHERE match_id = %s;", (match_id,))
+        match_row_exists = cur.fetchone() is not None
+        cur.execute("SELECT COUNT(*) FROM maps WHERE match_id = %s;", (match_id,))
+        map_rows = cur.fetchone()[0]
+        cur.execute(
+            "SELECT map_id, status FROM map_ingestion_state"
+            " WHERE match_id = %s ORDER BY map_id;",
+            (match_id,),
+        )
+        map_states = cur.fetchall()
+    return {
+        "state": state,
+        "match_row_exists": match_row_exists,
+        "map_rows": map_rows,
+        "map_states": map_states,
+    }
+
+
+def fetch_map_inspection(map_id: int) -> MapInspection:
+    """Return one map's full ingestion picture.
+
+    Combines the map_ingestion_state row (None when absent) with
+    relational presence: whether the maps row exists and how many
+    player-stats rows the map has.
+    """
+    with get_db().get_cursor() as cur:
+        state = _fetch_state_row(
+            cur, "map_ingestion_state", "map_id", MAP_STATE_COLUMNS, map_id
+        )
+        cur.execute("SELECT 1 FROM maps WHERE map_id = %s;", (map_id,))
+        map_row_exists = cur.fetchone() is not None
+        cur.execute("SELECT COUNT(*) FROM players WHERE map_id = %s;", (map_id,))
+        player_rows = cur.fetchone()[0]
+    return {
+        "state": state,
+        "map_row_exists": map_row_exists,
+        "player_rows": player_rows,
+    }
 
 
 def fetch_ingestion_state_counts() -> dict[str, dict[str, int]]:

--- a/tests/storage/test_ingestion_state_summary.py
+++ b/tests/storage/test_ingestion_state_summary.py
@@ -11,8 +11,12 @@ import pytest
 
 import cs2_analytics.storage.ingestion_state_summary as summary_module
 from cs2_analytics.storage.ingestion_state_summary import (
+    MAP_STATE_COLUMNS,
+    MATCH_STATE_COLUMNS,
     fetch_failure_groups,
     fetch_failure_rows,
+    fetch_map_inspection,
+    fetch_match_inspection,
 )
 
 
@@ -79,6 +83,85 @@ def test_fetch_failure_rows_parametrizes_status_and_limit(monkeypatch) -> None:
     query, params = cursor.executed[0]
     assert "dead" not in query
     assert params == ("dead", 5)
+
+
+class _SequencedCursor:
+    """Cursor fake returning one queued result per fetch call, in order."""
+
+    def __init__(self, results: list[object]) -> None:
+        self.results = list(results)
+        self.executed: list[tuple[str, tuple]] = []
+
+    def __enter__(self) -> "_SequencedCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple) -> None:
+        self.executed.append((query, params))
+
+    def fetchone(self) -> object:
+        return self.results.pop(0)
+
+    def fetchall(self) -> object:
+        return self.results.pop(0)
+
+
+def _install_sequenced_db(monkeypatch, results: list[object]) -> _SequencedCursor:
+    cursor = _SequencedCursor(results)
+    monkeypatch.setattr(summary_module, "get_db", lambda: _FakeDatabase(cursor))
+    return cursor
+
+
+def test_fetch_match_inspection_combines_state_and_relational_rows(
+    monkeypatch,
+) -> None:
+    state_row = tuple(range(len(MATCH_STATE_COLUMNS)))
+    cursor = _install_sequenced_db(
+        monkeypatch,
+        [state_row, (1,), (3,), [(201, "processed"), (202, "failed")]],
+    )
+
+    inspection = fetch_match_inspection(101)
+
+    assert inspection["state"] == dict(zip(MATCH_STATE_COLUMNS, state_row))
+    assert inspection["match_row_exists"] is True
+    assert inspection["map_rows"] == 3
+    assert inspection["map_states"] == [(201, "processed"), (202, "failed")]
+    queries = [query for query, _ in cursor.executed]
+    assert "FROM match_ingestion_state" in queries[0]
+    assert "FROM matches" in queries[1]
+    assert "FROM maps" in queries[2]
+    assert "FROM map_ingestion_state" in queries[3]
+    assert all(params == (101,) for _, params in cursor.executed)
+
+
+def test_fetch_match_inspection_reports_missing_state_row(monkeypatch) -> None:
+    _install_sequenced_db(monkeypatch, [None, None, (0,), []])
+
+    inspection = fetch_match_inspection(999)
+
+    assert inspection["state"] is None
+    assert inspection["match_row_exists"] is False
+    assert inspection["map_rows"] == 0
+    assert inspection["map_states"] == []
+
+
+def test_fetch_map_inspection_combines_state_and_relational_rows(monkeypatch) -> None:
+    state_row = tuple(range(len(MAP_STATE_COLUMNS)))
+    cursor = _install_sequenced_db(monkeypatch, [state_row, (1,), (10,)])
+
+    inspection = fetch_map_inspection(230075)
+
+    assert inspection["state"] == dict(zip(MAP_STATE_COLUMNS, state_row))
+    assert inspection["map_row_exists"] is True
+    assert inspection["player_rows"] == 10
+    queries = [query for query, _ in cursor.executed]
+    assert "FROM map_ingestion_state" in queries[0]
+    assert "FROM maps" in queries[1]
+    assert "FROM players" in queries[2]
+    assert all(params == (230075,) for _, params in cursor.executed)
 
 
 def test_fetch_failure_groups_aggregates_by_error_message(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,8 @@ def test_help_lists_all_commands() -> None:
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
-    for command in ("ingest", "process", "retry", "failures", "status", "db"):
+    commands = ("ingest", "process", "retry", "failures", "inspect", "status", "db")
+    for command in commands:
         assert command in result.stdout
 
 
@@ -512,6 +513,139 @@ def test_failures_exits_nonzero_when_database_is_unavailable(monkeypatch) -> Non
     monkeypatch.setattr(summary_module, "fetch_failure_rows", _raise)
 
     result = runner.invoke(app, ["failures", "--stage", "match"])
+
+    assert result.exit_code == 1
+    assert "Database unavailable" in result.stderr
+
+
+def _patch_inspections(monkeypatch, match=None, map=None):
+    """Replace the inspection helpers with canned results in their module."""
+    import cs2_analytics.storage.ingestion_state_summary as summary_module
+
+    calls: list[tuple[str, int]] = []
+
+    def _match(match_id):
+        calls.append(("match", match_id))
+        return match
+
+    def _map(map_id):
+        calls.append(("map", map_id))
+        return map
+
+    monkeypatch.setattr(summary_module, "fetch_match_inspection", _match)
+    monkeypatch.setattr(summary_module, "fetch_map_inspection", _map)
+    return calls
+
+
+def test_inspect_match_shows_state_and_relational_presence(monkeypatch) -> None:
+    calls = _patch_inspections(
+        monkeypatch,
+        match={
+            "state": {
+                "match_id": 101,
+                "status": "processed",
+                "failure_count": 0,
+                "last_error_message": None,
+            },
+            "match_row_exists": True,
+            "map_rows": 3,
+            "map_states": [(201, "processed"), (202, "failed")],
+        },
+    )
+
+    result = runner.invoke(app, ["inspect", "match", "101"])
+
+    assert result.exit_code == 0
+    assert calls == [("match", 101)]
+    assert "match_ingestion_state:" in result.stdout
+    assert "processed" in result.stdout
+    assert "last_error_message" in result.stdout
+    assert "-" in result.stdout
+    assert "matches row: present" in result.stdout
+    assert "maps rows: 3" in result.stdout
+    assert "202  failed" in result.stdout
+
+
+def test_inspect_match_unknown_id_exits_nonzero(monkeypatch) -> None:
+    _patch_inspections(
+        monkeypatch,
+        match={
+            "state": None,
+            "match_row_exists": False,
+            "map_rows": 0,
+            "map_states": [],
+        },
+    )
+
+    result = runner.invoke(app, ["inspect", "match", "999"])
+
+    assert result.exit_code == 1
+    assert "No match_ingestion_state row for match 999." in result.stdout
+    assert "Match 999 not found." in result.stderr
+
+
+def test_inspect_match_without_state_row_still_reports_relational(
+    monkeypatch,
+) -> None:
+    _patch_inspections(
+        monkeypatch,
+        match={
+            "state": None,
+            "match_row_exists": True,
+            "map_rows": 2,
+            "map_states": [],
+        },
+    )
+
+    result = runner.invoke(app, ["inspect", "match", "101"])
+
+    assert result.exit_code == 0
+    assert "No match_ingestion_state row for match 101." in result.stdout
+    assert "matches row: present" in result.stdout
+    assert "maps rows: 2" in result.stdout
+
+
+def test_inspect_map_shows_state_and_player_count(monkeypatch) -> None:
+    calls = _patch_inspections(
+        monkeypatch,
+        map={
+            "state": {"map_id": 230075, "status": "failed", "failure_count": 2},
+            "map_row_exists": False,
+            "player_rows": 0,
+        },
+    )
+
+    result = runner.invoke(app, ["inspect", "map", "230075"])
+
+    assert result.exit_code == 0
+    assert calls == [("map", 230075)]
+    assert "map_ingestion_state:" in result.stdout
+    assert "maps row: MISSING" in result.stdout
+    assert "players rows: 0" in result.stdout
+
+
+def test_inspect_map_unknown_id_exits_nonzero(monkeypatch) -> None:
+    _patch_inspections(
+        monkeypatch,
+        map={"state": None, "map_row_exists": False, "player_rows": 0},
+    )
+
+    result = runner.invoke(app, ["inspect", "map", "999"])
+
+    assert result.exit_code == 1
+    assert "Map 999 not found." in result.stderr
+
+
+def test_inspect_exits_nonzero_when_database_is_unavailable(monkeypatch) -> None:
+    import cs2_analytics.storage.ingestion_state_summary as summary_module
+    from cs2_analytics.exceptions import DatabaseConnectionError
+
+    def _raise(item_id):
+        raise DatabaseConnectionError("no pool")
+
+    monkeypatch.setattr(summary_module, "fetch_match_inspection", _raise)
+
+    result = runner.invoke(app, ["inspect", "match", "101"])
 
     assert result.exit_code == 1
     assert "Database unavailable" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,7 +518,7 @@ def test_failures_exits_nonzero_when_database_is_unavailable(monkeypatch) -> Non
     assert "Database unavailable" in result.stderr
 
 
-def _patch_inspections(monkeypatch, match=None, map=None):
+def _patch_inspections(monkeypatch, match_result=None, map_result=None):
     """Replace the inspection helpers with canned results in their module."""
     import cs2_analytics.storage.ingestion_state_summary as summary_module
 
@@ -526,11 +526,11 @@ def _patch_inspections(monkeypatch, match=None, map=None):
 
     def _match(match_id):
         calls.append(("match", match_id))
-        return match
+        return match_result
 
     def _map(map_id):
         calls.append(("map", map_id))
-        return map
+        return map_result
 
     monkeypatch.setattr(summary_module, "fetch_match_inspection", _match)
     monkeypatch.setattr(summary_module, "fetch_map_inspection", _map)
@@ -540,7 +540,7 @@ def _patch_inspections(monkeypatch, match=None, map=None):
 def test_inspect_match_shows_state_and_relational_presence(monkeypatch) -> None:
     calls = _patch_inspections(
         monkeypatch,
-        match={
+        match_result={
             "state": {
                 "match_id": 101,
                 "status": "processed",
@@ -569,7 +569,7 @@ def test_inspect_match_shows_state_and_relational_presence(monkeypatch) -> None:
 def test_inspect_match_unknown_id_exits_nonzero(monkeypatch) -> None:
     _patch_inspections(
         monkeypatch,
-        match={
+        match_result={
             "state": None,
             "match_row_exists": False,
             "map_rows": 0,
@@ -589,7 +589,7 @@ def test_inspect_match_without_state_row_still_reports_relational(
 ) -> None:
     _patch_inspections(
         monkeypatch,
-        match={
+        match_result={
             "state": None,
             "match_row_exists": True,
             "map_rows": 2,
@@ -608,7 +608,7 @@ def test_inspect_match_without_state_row_still_reports_relational(
 def test_inspect_map_shows_state_and_player_count(monkeypatch) -> None:
     calls = _patch_inspections(
         monkeypatch,
-        map={
+        map_result={
             "state": {"map_id": 230075, "status": "failed", "failure_count": 2},
             "map_row_exists": False,
             "player_rows": 0,
@@ -627,7 +627,7 @@ def test_inspect_map_shows_state_and_player_count(monkeypatch) -> None:
 def test_inspect_map_unknown_id_exits_nonzero(monkeypatch) -> None:
     _patch_inspections(
         monkeypatch,
-        map={"state": None, "map_row_exists": False, "player_rows": 0},
+        map_result={"state": None, "map_row_exists": False, "player_rows": 0},
     )
 
     result = runner.invoke(app, ["inspect", "map", "999"])


### PR DESCRIPTION
## Summary

Adds read-only `cs2a inspect match <id>` and `cs2a inspect map <id>` commands showing one item's full ingestion picture - the complete ingestion-state row plus whether the corresponding relational rows actually exist - replacing ad-hoc SQL for the "this item says processed, is its data actually there?" question.

## Related Issue

Closes #124

## Scope

- `cs2_analytics/storage/ingestion_state_summary.py`: `fetch_match_inspection` (full `match_ingestion_state` row, `matches`-row presence, `maps` row count, per-map ingestion statuses) and `fetch_map_inspection` (full `map_ingestion_state` row, `maps`-row presence, player-stats count). Results are TypedDicts (`MatchInspection`, `MapInspection`); state rows are column->value mappings built from module column constants, item ids always parametrized.
- `cs2_analytics/cli.py`: new `inspect` sub-app with `match`/`map` commands. State rows print as aligned name/value lines with `-` for nulls, followed by relational presence lines. Unknown IDs (no state row and no relational row) exit 1 with a stderr message; a missing state row with relational data present still reports what exists (exit 0). Database-unavailable exits 1, matching `status` and `failures`.
- `tests/storage/test_ingestion_state_summary.py`: helper tests with a sequenced multi-query cursor fake - query targets, parametrization, found and missing-row shapes.
- `tests/test_cli.py`: state rendering, presence lines, unknown-id exit, state-missing-but-data-present, database-unavailable exit; help test includes `inspect`.
- `README.md`: examples and a usage paragraph next to `cs2a failures`.

## Out of Scope

- No writes of any kind.
- No scraper-driven re-fetch/diff behavior; `scripts/debug_match_ingestion.py` and `scripts/debug_map_ingestion.py` keep covering the scrape->parse->store debugging path (decision below).
- Demo stage stays unexposed until the demo pipeline is active.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Read-only SELECT queries behind new CLI commands; no controller, stage-service, scraper, or storage-write involvement, and no changes to any existing command's behavior.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README documents the new commands in the CLI section. No architecture docs needed - the commands extend the established read-only summary pattern in the storage layer.

Backlog: Update not needed

Reason: The operational CLI commands (#123-#125) are not roadmap checklist items in docs/backlog.md; no phase, checklist, or sequencing status changes.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check` / `uv run mypy` (CI invocations)
- Read-only against the deployed database: `cs2a inspect match 2394877` (processed match), `cs2a inspect map 230075` (processed map), `cs2a inspect match 1` (unknown)

Results:

- pytest: 244 passed, 2 skipped; total coverage 81.60% (CI floor 80%)
- ruff and mypy clean
- Live match inspect: full state row rendered, `matches row: present`, and it surfaced a real finding - the match is `processed` with 0 `maps` rows and its map still `discovered` (queued for the next process run), exactly the discrepancy view the issue asked for
- Live map inspect: full state row, `maps row: present`, `players rows: 10`
- Unknown ID: "No match_ingestion_state row for match 1." plus stderr "Match 1 not found.", exit 1

## Review Notes

- Debug-scripts decision (acceptance criterion): `debug_match_ingestion.py` and `debug_map_ingestion.py` stay. They exercise the scrape->parse->store path including writes, which `inspect` deliberately does not cover, so nothing became redundant. Recorded here rather than removing them.
- When the state row is missing but relational data exists, the command reports what exists and exits 0 - only a fully unknown ID (neither state nor relational row) exits 1.
- The per-map status list comes from `map_ingestion_state.match_id`, so it also shows maps discovered but not yet present in `maps`.
