### PR TITLE
Add cs2a ingest coverage command reporting discovery date coverage (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ obvious before running `cs2a retry`.
 `cs2a ingest coverage` reports discovery date coverage: the configured
 window (`START_DATE` through today), earliest/latest ingested match
 dates, how many periods (`--period week` default, or `day`) contain
-matches, contiguous zero-match gap ranges, and the
-discovered-but-unprocessed backlog so "not discovered" is
+matches, contiguous zero-match gap ranges, and the not-yet-processed
+backlog (every non-processed lifecycle status) so "not discovered" is
 distinguishable from "not yet processed". Backfill cursor state joins
 the report once the backfill strategy (#121) lands.
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Or use the `cs2a` CLI installed with the package for individual stages:
 ```sh
 cs2a ingest discover            # scrape results pages, queue new matches
 cs2a ingest discover --mode backfill
+cs2a ingest coverage            # discovery date coverage of the target window
 cs2a process --batch 50         # process pending matches, then maps
 cs2a status                     # ingestion-state row counts by status
 cs2a failures --stage match     # recent failed rows with error details
@@ -308,6 +309,14 @@ ordered most recently failed first (`--limit`, default 20). `--group`
 aggregates rows by error message so dominant failure modes - transient
 scraper noise versus a structural break like a page layout change - are
 obvious before running `cs2a retry`.
+
+`cs2a ingest coverage` reports discovery date coverage: the configured
+window (`START_DATE` through today), earliest/latest ingested match
+dates, how many periods (`--period week` default, or `day`) contain
+matches, contiguous zero-match gap ranges, and the
+discovered-but-unprocessed backlog so "not discovered" is
+distinguishable from "not yet processed". Backfill cursor state joins
+the report once the backfill strategy (#121) lands.
 
 `cs2a inspect` is the single-item companion: given one ID it prints the
 full ingestion-state row (status, lifecycle timestamps, failure fields,

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -86,10 +86,10 @@ def coverage(
 
     Read-only: compares the configured window (START_DATE through today)
     against match dates present in `matches`, lists zero-match periods as
-    gaps, and shows the discovered-but-unprocessed backlog so "not
-    discovered" is distinguishable from "not yet processed". Backfill
-    cursor state joins this report once the backfill strategy (#121)
-    lands.
+    gaps, and shows the not-yet-processed backlog (every non-processed
+    lifecycle status) so "not discovered" is distinguishable from "not
+    yet processed". Backfill cursor state joins this report once the
+    backfill strategy (#121) lands.
     """
     import datetime as dt
 
@@ -127,11 +127,11 @@ def coverage(
             typer.echo(f"  {gap_start} .. {gap_end}")
     pending = report["pending_by_status"]
     if pending:
-        typer.echo("Pending (discovered but not processed):")
+        typer.echo("Not yet processed (by status):")
         for status_name, row_count in pending.items():
             typer.echo(f"  {status_name:<12} {row_count}")
         typer.echo(
-            "Note: gaps may reflect pending backlog rather than"
+            "Note: gaps may reflect unprocessed backlog rather than"
             " undiscovered dates."
         )
 

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -68,6 +68,74 @@ def discover(
     ResultsController().run(max_matches=cap)
 
 
+class CoveragePeriod(StrEnum):
+    """Bucket size for the discovery-coverage report."""
+
+    DAY = "day"
+    WEEK = "week"
+
+
+@ingest_app.command("coverage")
+def coverage(
+    period: Annotated[
+        CoveragePeriod,
+        typer.Option(help="Bucket size for per-period counts and gaps."),
+    ] = CoveragePeriod.WEEK,
+) -> None:
+    """Report discovery date coverage of the target window.
+
+    Read-only: compares the configured window (START_DATE through today)
+    against match dates present in `matches`, lists zero-match periods as
+    gaps, and shows the discovered-but-unprocessed backlog so "not
+    discovered" is distinguishable from "not yet processed". Backfill
+    cursor state joins this report once the backfill strategy (#121)
+    lands.
+    """
+    import datetime as dt
+
+    from cs2_analytics.config.config import START_DATE
+    from cs2_analytics.storage.discovery_coverage import (
+        compute_gap_ranges,
+        fetch_discovery_coverage,
+    )
+
+    window_start = dt.date.fromisoformat(START_DATE)
+    window_end = dt.date.today()
+    try:
+        report = fetch_discovery_coverage(window_start, window_end, period.value)
+    except DatabaseConnectionError as e:
+        typer.echo(f"Database unavailable: {e}", err=True)
+        raise typer.Exit(code=1) from e
+
+    gaps = compute_gap_ranges(
+        window_start, window_end, period.value, report["period_counts"]
+    )
+    typer.echo(
+        f"Discovery window: {window_start} .. {window_end} (per {period.value})"
+    )
+    typer.echo(f"Earliest match: {report['earliest_match'] or '-'}")
+    typer.echo(f"Latest match:   {report['latest_match'] or '-'}")
+    typer.echo(
+        f"Matches in window: {report['window_matches']}"
+        f" (total in database: {report['total_matches']})"
+    )
+    covered = len(report["period_counts"])
+    typer.echo(f"Covered periods: {covered}; gap ranges: {len(gaps)}")
+    if gaps:
+        typer.echo(f"Gaps (no matches, per {period.value}):")
+        for gap_start, gap_end in gaps:
+            typer.echo(f"  {gap_start} .. {gap_end}")
+    pending = report["pending_by_status"]
+    if pending:
+        typer.echo("Pending (discovered but not processed):")
+        for status_name, row_count in pending.items():
+            typer.echo(f"  {status_name:<12} {row_count}")
+        typer.echo(
+            "Note: gaps may reflect pending backlog rather than"
+            " undiscovered dates."
+        )
+
+
 @app.command()
 def process(
     batch: Annotated[

--- a/cs2_analytics/storage/discovery_coverage.py
+++ b/cs2_analytics/storage/discovery_coverage.py
@@ -1,0 +1,119 @@
+"""Read-side discovery-coverage report over the matches table.
+
+Answers "is the backfill done?" by comparing the configured discovery
+window against the match dates actually present in `matches`, plus the
+match_ingestion_state backlog so undiscovered gaps are distinguishable
+from discovered-but-pending work. Discovered-but-unprocessed rows carry
+no match date yet, so the backlog is reported as aggregate counts rather
+than attributed to calendar periods.
+
+Once a backfill cursor exists (#121), its position belongs in this
+report as the completion state toward the window floor.
+"""
+
+import datetime as dt
+from typing import TypedDict
+
+from cs2_analytics.storage.db_instance import get_db
+
+COVERAGE_PERIODS = ("day", "week")
+
+DAYS_PER_PERIOD = {"day": 1, "week": 7}
+
+MATCH_DATE_BOUNDS_QUERY = "SELECT MIN(date), MAX(date), COUNT(*) FROM matches;"
+
+PERIOD_COUNTS_QUERY = """
+    SELECT date_trunc(%s, date)::date, COUNT(*)
+    FROM matches
+    WHERE date >= %s AND date < %s
+    GROUP BY 1
+    ORDER BY 1;
+"""
+
+PENDING_COUNTS_QUERY = """
+    SELECT status, COUNT(*)
+    FROM match_ingestion_state
+    WHERE status != 'processed'
+    GROUP BY status
+    ORDER BY status;
+"""
+
+
+class CoverageReport(TypedDict):
+    """Discovery coverage of the target window, plus pending backlog."""
+
+    earliest_match: dt.datetime | None
+    latest_match: dt.datetime | None
+    total_matches: int
+    window_matches: int
+    period_counts: list[tuple[dt.date, int]]
+    pending_by_status: dict[str, int]
+
+
+def align_period_start(day: dt.date, period: str) -> dt.date:
+    """Return the period-start date containing the given day.
+
+    Matches Postgres date_trunc semantics: days align to themselves,
+    weeks to Monday, so gap detection lines up with the SQL buckets.
+    """
+    if period == "week":
+        return day - dt.timedelta(days=day.weekday())
+    return day
+
+
+def compute_gap_ranges(
+    window_start: dt.date,
+    window_end: dt.date,
+    period: str,
+    period_counts: list[tuple[dt.date, int]],
+) -> list[tuple[dt.date, dt.date]]:
+    """Return contiguous runs of zero-match periods inside the window.
+
+    Each range is (first_period_start, last_period_start), inclusive,
+    covering consecutive periods with no counted matches.
+    """
+    step = dt.timedelta(days=DAYS_PER_PERIOD[period])
+    counted = {period_start for period_start, _ in period_counts}
+    gaps: list[tuple[dt.date, dt.date]] = []
+    current = align_period_start(window_start, period)
+    last_period = align_period_start(window_end, period)
+    run_start: dt.date | None = None
+    while current <= last_period:
+        if current in counted:
+            if run_start is not None:
+                gaps.append((run_start, current - step))
+                run_start = None
+        elif run_start is None:
+            run_start = current
+        current = current + step
+    if run_start is not None:
+        gaps.append((run_start, last_period))
+    return gaps
+
+
+def fetch_discovery_coverage(
+    window_start: dt.date, window_end: dt.date, period: str
+) -> CoverageReport:
+    """Return match-date coverage of the window and the pending backlog.
+
+    The window is [window_start, window_end] inclusive; the SQL upper
+    bound is exclusive at window_end + 1 day so the end date's matches
+    count. `period` must be one of COVERAGE_PERIODS and is passed to
+    date_trunc as a parameter.
+    """
+    upper_bound = window_end + dt.timedelta(days=1)
+    with get_db().get_cursor() as cur:
+        cur.execute(MATCH_DATE_BOUNDS_QUERY)
+        earliest, latest, total = cur.fetchone()
+        cur.execute(PERIOD_COUNTS_QUERY, (period, window_start, upper_bound))
+        period_counts = [(row[0], row[1]) for row in cur.fetchall()]
+        cur.execute(PENDING_COUNTS_QUERY)
+        pending = dict(cur.fetchall())
+    return {
+        "earliest_match": earliest,
+        "latest_match": latest,
+        "total_matches": total,
+        "window_matches": sum(count for _, count in period_counts),
+        "period_counts": period_counts,
+        "pending_by_status": pending,
+    }

--- a/cs2_analytics/storage/discovery_coverage.py
+++ b/cs2_analytics/storage/discovery_coverage.py
@@ -73,7 +73,7 @@ def compute_gap_ranges(
     covering consecutive periods with no counted matches.
     """
     step = dt.timedelta(days=DAYS_PER_PERIOD[period])
-    counted = {period_start for period_start, _ in period_counts}
+    counted = {period_start for period_start, count in period_counts if count > 0}
     gaps: list[tuple[dt.date, dt.date]] = []
     current = align_period_start(window_start, period)
     last_period = align_period_start(window_end, period)
@@ -101,6 +101,10 @@ def fetch_discovery_coverage(
     count. `period` must be one of COVERAGE_PERIODS and is passed to
     date_trunc as a parameter.
     """
+    if period not in COVERAGE_PERIODS:
+        raise ValueError(
+            f"period must be one of {COVERAGE_PERIODS}, got {period!r}."
+        )
     upper_bound = window_end + dt.timedelta(days=1)
     with get_db().get_cursor() as cur:
         cur.execute(MATCH_DATE_BOUNDS_QUERY)

--- a/tests/storage/test_discovery_coverage.py
+++ b/tests/storage/test_discovery_coverage.py
@@ -1,0 +1,150 @@
+"""Tests for the discovery-coverage queries and gap detection (#125).
+
+fetch_discovery_coverage runs three read-only queries on one cursor, so
+a sequenced fake returns one canned result per fetch call;
+compute_gap_ranges and align_period_start are pure and tested directly.
+"""
+
+import datetime as dt
+
+import cs2_analytics.storage.discovery_coverage as coverage_module
+from cs2_analytics.storage.discovery_coverage import (
+    align_period_start,
+    compute_gap_ranges,
+    fetch_discovery_coverage,
+)
+
+
+class _SequencedCursor:
+    def __init__(self, results: list[object]) -> None:
+        self.results = list(results)
+        self.executed: list[tuple[str, tuple | None]] = []
+
+    def __enter__(self) -> "_SequencedCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple | None = None) -> None:
+        self.executed.append((query, params))
+
+    def fetchone(self) -> object:
+        return self.results.pop(0)
+
+    def fetchall(self) -> object:
+        return self.results.pop(0)
+
+
+class _FakeDatabase:
+    def __init__(self, cursor: _SequencedCursor) -> None:
+        self.cursor = cursor
+
+    def get_cursor(self) -> _SequencedCursor:
+        return self.cursor
+
+
+def test_align_period_start_day_is_identity() -> None:
+    day = dt.date(2026, 8, 27)
+
+    assert align_period_start(day, "day") == day
+
+
+def test_align_period_start_week_aligns_to_monday() -> None:
+    thursday = dt.date(2026, 8, 27)
+
+    assert align_period_start(thursday, "week") == dt.date(2026, 8, 24)
+    assert align_period_start(dt.date(2026, 8, 24), "week") == dt.date(2026, 8, 24)
+
+
+def test_compute_gap_ranges_merges_consecutive_missing_days() -> None:
+    window_start = dt.date(2026, 8, 1)
+    window_end = dt.date(2026, 8, 7)
+    counts = [
+        (dt.date(2026, 8, 1), 5),
+        (dt.date(2026, 8, 4), 2),
+        (dt.date(2026, 8, 7), 1),
+    ]
+
+    gaps = compute_gap_ranges(window_start, window_end, "day", counts)
+
+    assert gaps == [
+        (dt.date(2026, 8, 2), dt.date(2026, 8, 3)),
+        (dt.date(2026, 8, 5), dt.date(2026, 8, 6)),
+    ]
+
+
+def test_compute_gap_ranges_reports_trailing_gap() -> None:
+    window_start = dt.date(2026, 8, 1)
+    window_end = dt.date(2026, 8, 4)
+    counts = [(dt.date(2026, 8, 1), 3)]
+
+    gaps = compute_gap_ranges(window_start, window_end, "day", counts)
+
+    assert gaps == [(dt.date(2026, 8, 2), dt.date(2026, 8, 4))]
+
+
+def test_compute_gap_ranges_empty_window_counts_is_one_gap() -> None:
+    window_start = dt.date(2026, 8, 1)
+    window_end = dt.date(2026, 8, 3)
+
+    gaps = compute_gap_ranges(window_start, window_end, "day", [])
+
+    assert gaps == [(dt.date(2026, 8, 1), dt.date(2026, 8, 3))]
+
+
+def test_compute_gap_ranges_full_coverage_has_no_gaps() -> None:
+    window_start = dt.date(2026, 8, 1)
+    window_end = dt.date(2026, 8, 2)
+    counts = [(dt.date(2026, 8, 1), 1), (dt.date(2026, 8, 2), 1)]
+
+    assert compute_gap_ranges(window_start, window_end, "day", counts) == []
+
+
+def test_compute_gap_ranges_week_buckets_align_with_sql_truncation() -> None:
+    # Window opens mid-week; the first bucket is that week's Monday, so a
+    # count landing on the Monday bucket covers the opening partial week.
+    window_start = dt.date(2026, 8, 27)  # Thursday
+    window_end = dt.date(2026, 9, 9)  # Wednesday two weeks on
+    counts = [(dt.date(2026, 8, 24), 4)]
+
+    gaps = compute_gap_ranges(window_start, window_end, "week", counts)
+
+    assert gaps == [(dt.date(2026, 8, 31), dt.date(2026, 9, 7))]
+
+
+def test_fetch_discovery_coverage_combines_three_queries(monkeypatch) -> None:
+    earliest = dt.datetime(2025, 10, 2, 12, 0)
+    latest = dt.datetime(2026, 8, 30, 20, 0)
+    cursor = _SequencedCursor(
+        [
+            (earliest, latest, 700),
+            [(dt.date(2026, 8, 24), 40), (dt.date(2026, 8, 31), 5)],
+            [("discovered", 561), ("failed", 2)],
+        ]
+    )
+    monkeypatch.setattr(coverage_module, "get_db", lambda: _FakeDatabase(cursor))
+
+    report = fetch_discovery_coverage(
+        dt.date(2025, 10, 1), dt.date(2026, 8, 31), "week"
+    )
+
+    assert report["earliest_match"] == earliest
+    assert report["latest_match"] == latest
+    assert report["total_matches"] == 700
+    assert report["window_matches"] == 45
+    assert report["period_counts"] == [
+        (dt.date(2026, 8, 24), 40),
+        (dt.date(2026, 8, 31), 5),
+    ]
+    assert report["pending_by_status"] == {"discovered": 561, "failed": 2}
+    bounds_query, bounds_params = cursor.executed[0]
+    period_query, period_params = cursor.executed[1]
+    pending_query, _ = cursor.executed[2]
+    assert "FROM matches" in bounds_query
+    assert bounds_params is None
+    assert "date_trunc" in period_query
+    # Upper bound is exclusive one day past the window end.
+    assert period_params == ("week", dt.date(2025, 10, 1), dt.date(2026, 9, 1))
+    assert "FROM match_ingestion_state" in pending_query
+    assert "!= 'processed'" in pending_query

--- a/tests/storage/test_discovery_coverage.py
+++ b/tests/storage/test_discovery_coverage.py
@@ -113,6 +113,35 @@ def test_compute_gap_ranges_week_buckets_align_with_sql_truncation() -> None:
     assert gaps == [(dt.date(2026, 8, 31), dt.date(2026, 9, 7))]
 
 
+def test_compute_gap_ranges_treats_explicit_zero_counts_as_gaps() -> None:
+    window_start = dt.date(2026, 8, 1)
+    window_end = dt.date(2026, 8, 3)
+    counts = [
+        (dt.date(2026, 8, 1), 3),
+        (dt.date(2026, 8, 2), 0),
+        (dt.date(2026, 8, 3), 1),
+    ]
+
+    gaps = compute_gap_ranges(window_start, window_end, "day", counts)
+
+    assert gaps == [(dt.date(2026, 8, 2), dt.date(2026, 8, 2))]
+
+
+def test_fetch_discovery_coverage_rejects_unknown_period(monkeypatch) -> None:
+    monkeypatch.setattr(
+        coverage_module,
+        "get_db",
+        lambda: (_ for _ in ()).throw(AssertionError("must not touch the db")),
+    )
+
+    try:
+        fetch_discovery_coverage(dt.date(2025, 10, 1), dt.date(2026, 8, 31), "month")
+    except ValueError as exc:
+        assert "period must be one of" in str(exc)
+    else:
+        raise AssertionError("Expected an unknown period to be rejected")
+
+
 def test_fetch_discovery_coverage_combines_three_queries(monkeypatch) -> None:
     earliest = dt.datetime(2025, 10, 2, 12, 0)
     latest = dt.datetime(2026, 8, 30, 20, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,104 @@ def test_discover_rejects_nonpositive_max_matches(monkeypatch) -> None:
     assert calls == []
 
 
+def _patch_coverage(monkeypatch, report):
+    """Replace the coverage fetch with a canned report in its module."""
+    import cs2_analytics.storage.discovery_coverage as coverage_module
+
+    calls: list[tuple] = []
+
+    def _fetch(window_start, window_end, period):
+        calls.append((window_start, window_end, period))
+        return report
+
+    monkeypatch.setattr(coverage_module, "fetch_discovery_coverage", _fetch)
+    return calls
+
+
+def test_ingest_coverage_reports_window_gaps_and_backlog(monkeypatch) -> None:
+    import datetime as dt
+
+    calls = _patch_coverage(
+        monkeypatch,
+        {
+            "earliest_match": dt.datetime(2025, 10, 2, 12, 0),
+            "latest_match": dt.datetime(2026, 8, 30, 20, 0),
+            "total_matches": 700,
+            "window_matches": 45,
+            "period_counts": [(dt.date(2026, 8, 24), 45)],
+            "pending_by_status": {"discovered": 561, "failed": 2},
+        },
+    )
+
+    result = runner.invoke(app, ["ingest", "coverage"])
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    window_start, window_end, period = calls[0]
+    assert window_start == dt.date(2025, 10, 1)
+    assert window_end == dt.date.today()
+    assert period == "week"
+    assert "Discovery window: 2025-10-01" in result.stdout
+    assert "(per week)" in result.stdout
+    assert "Earliest match: 2025-10-02 12:00:00" in result.stdout
+    assert "Matches in window: 45 (total in database: 700)" in result.stdout
+    assert "Gaps (no matches, per week):" in result.stdout
+    assert "Pending (discovered but not processed):" in result.stdout
+    assert "discovered   561" in result.stdout
+    assert "Note: gaps may reflect pending backlog" in result.stdout
+
+
+def test_ingest_coverage_day_period_and_quiet_when_no_backlog(monkeypatch) -> None:
+    import datetime as dt
+
+    today = dt.date.today()
+    calls = _patch_coverage(
+        monkeypatch,
+        {
+            "earliest_match": None,
+            "latest_match": None,
+            "total_matches": 0,
+            "window_matches": 0,
+            "period_counts": [(day, 1) for day in _all_days_since_start(today)],
+            "pending_by_status": {},
+        },
+    )
+
+    result = runner.invoke(app, ["ingest", "coverage", "--period", "day"])
+
+    assert result.exit_code == 0
+    assert calls[0][2] == "day"
+    assert "Earliest match: -" in result.stdout
+    assert "gap ranges: 0" in result.stdout
+    assert "Gaps" not in result.stdout
+    assert "Pending" not in result.stdout
+    assert "Note:" not in result.stdout
+
+
+def _all_days_since_start(today):
+    import datetime as dt
+
+    start = dt.date(2025, 10, 1)
+    return [start + dt.timedelta(days=i) for i in range((today - start).days + 1)]
+
+
+def test_ingest_coverage_exits_nonzero_when_database_is_unavailable(
+    monkeypatch,
+) -> None:
+    import cs2_analytics.storage.discovery_coverage as coverage_module
+    from cs2_analytics.exceptions import DatabaseConnectionError
+
+    def _raise(window_start, window_end, period):
+        raise DatabaseConnectionError("no pool")
+
+    monkeypatch.setattr(coverage_module, "fetch_discovery_coverage", _raise)
+
+    result = runner.invoke(app, ["ingest", "coverage"])
+
+    assert result.exit_code == 1
+    assert "Database unavailable" in result.stderr
+
+
 def test_process_rejects_nonpositive_batch(monkeypatch) -> None:
     calls: list[tuple[str, dict]] = []
     _patch_controller(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,9 +162,9 @@ def test_ingest_coverage_reports_window_gaps_and_backlog(monkeypatch) -> None:
     assert "Earliest match: 2025-10-02 12:00:00" in result.stdout
     assert "Matches in window: 45 (total in database: 700)" in result.stdout
     assert "Gaps (no matches, per week):" in result.stdout
-    assert "Pending (discovered but not processed):" in result.stdout
+    assert "Not yet processed (by status):" in result.stdout
     assert "discovered   561" in result.stdout
-    assert "Note: gaps may reflect pending backlog" in result.stdout
+    assert "Note: gaps may reflect unprocessed backlog" in result.stdout
 
 
 def test_ingest_coverage_day_period_and_quiet_when_no_backlog(monkeypatch) -> None:
@@ -190,7 +190,7 @@ def test_ingest_coverage_day_period_and_quiet_when_no_backlog(monkeypatch) -> No
     assert "Earliest match: -" in result.stdout
     assert "gap ranges: 0" in result.stdout
     assert "Gaps" not in result.stdout
-    assert "Pending" not in result.stdout
+    assert "Not yet processed" not in result.stdout
     assert "Note:" not in result.stdout
 
 


### PR DESCRIPTION
## Summary

Adds a read-only `cs2a ingest coverage` command that turns "is the backfill done?" into a query: it compares the configured discovery window (`START_DATE` through today) against the match dates actually present in `matches`, merges zero-match periods into contiguous gap ranges, and shows the discovered-but-unprocessed backlog so "not discovered" is distinguishable from "not yet processed".

## Related Issue

Closes #125

## Scope

- `cs2_analytics/storage/discovery_coverage.py` (new): `fetch_discovery_coverage` runs three read-only queries - overall min/max/count of match dates, per-period counts inside the window via `date_trunc` (period, bounds parametrized), and the non-`processed` `match_ingestion_state` backlog by status - returning a `CoverageReport` TypedDict. `compute_gap_ranges` / `align_period_start` are pure helpers merging zero-match periods into contiguous ranges, with week buckets aligned to Monday to match Postgres `date_trunc` semantics.
- `cs2_analytics/cli.py`: `cs2a ingest coverage [--period week|day]` (default week) printing the window, earliest/latest ingested match dates, window vs total counts, covered-period and gap-range counts, the gap ranges, and the pending backlog with a note that gaps may reflect backlog rather than undiscovered dates. Database-unavailable exits 1, matching the other read commands.
- `tests/storage/test_discovery_coverage.py` (new): pure gap logic (merging, trailing gap, empty window, full coverage, mid-week alignment) and query composition/parametrization.
- `tests/test_cli.py`: report rendering, `--period day`, quiet paths (no gaps, no backlog), database-unavailable exit.
- `README.md`: example and usage paragraph alongside the other operational commands.

## Out of Scope

- No changes to discovery behavior and no gap-healing or automatic re-discovery - the command only reports (#121 owns strategy).
- Backfill cursor state is deliberately absent until #121 defines it, per the issue's split provision; the command docstring and README note where it will join the report.
- The pending backlog is aggregate-only on purpose: unprocessed state rows carry no match date yet, so they cannot be attributed to calendar periods.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Read-only SELECT queries behind a new CLI subcommand plus pure date arithmetic; no controller, stage-service, scraper, or storage-write involvement, and no changes to existing command behavior.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README documents the new command in the CLI section. No architecture docs needed - a new focused read-only storage module following the established summary pattern.

Backlog: Update not needed

Reason: The operational CLI commands (#123-#125) are not roadmap checklist items in docs/backlog.md; no phase, checklist, or sequencing status changes.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check` / `uv run mypy` (CI invocations)
- Read-only against the deployed database: `cs2a ingest coverage` (week) and `--period day`
- Cross-checked a reported gap with direct SQL counts

Results:

- pytest: 255 passed, 2 skipped; total coverage 82.28% (CI floor 80%)
- ruff and mypy clean
- Live report: 745 matches spanning 2026-05-25 .. 2026-07-06, head gap back to the 2025-10-01 window floor (backfill has never run), one mid-window gap, and a trailing gap correctly paired with the 462-row pending backlog and the backlog note
- Direct SQL cross-check: the reported mid-window gap (2026-05-29 .. 2026-06-04) contains 0 matches, with 32 on the edge day immediately before it

## Review Notes

- Definition of "covered" (the issue's review note): a calendar period is covered when `matches` has at least one row with `date` in that period. This is the definition #121's cursor design should build on; the head gap to the window floor in the live output is exactly the backfill target it will consume.
- Week buckets align to Monday (`date_trunc` semantics), so a window opening mid-week reports its opening partial week under that Monday's bucket - the alignment test pins this.
- The SQL window upper bound is exclusive at `window_end + 1 day` so the end date's matches count.
