### PR TITLE
Strip run-parameter and dead constants from config; callers pass scraping parameters (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ aggregates rows by error message so dominant failure modes - transient
 scraper noise versus a structural break like a page layout change - are
 obvious before running `cs2a retry`.
 
-`cs2a ingest coverage` reports discovery date coverage: the configured
-window (`START_DATE` through today), earliest/latest ingested match
+`cs2a ingest coverage` reports discovery date coverage: the discovery
+window (the CLI-owned window floor through today), earliest/latest ingested match
 dates, how many periods (`--period week` default, or `day`) contain
 matches, contiguous zero-match gap ranges, and the not-yet-processed
 backlog (every non-processed lifecycle status) so "not discovered" is

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -6,6 +6,7 @@ imports live inside the command bodies so `cs2a --help` and `cs2a status`
 do not pay the scraper-stack import cost.
 """
 
+import datetime as dt
 from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated
 
@@ -49,6 +50,12 @@ DISCOVER_MODE_MAX_MATCHES = {
     DiscoverMode.BACKFILL: 1000,
 }
 
+# Discovery window floor. Run parameters live with the invoker, not in
+# config (ADR-0015); the pipeline imports these same defaults so both
+# entry points stay aligned. The end of the window is always computed at
+# run time. #121 turns the floor into a real backfill cursor target.
+DISCOVERY_WINDOW_START = dt.date(2025, 10, 1)
+
 
 @ingest_app.command("discover")
 def discover(
@@ -65,7 +72,11 @@ def discover(
     from cs2_analytics.controllers.results_controller import ResultsController
 
     cap = max_matches if max_matches is not None else DISCOVER_MODE_MAX_MATCHES[mode]
-    ResultsController().run(max_matches=cap)
+    ResultsController().run(
+        max_matches=cap,
+        start_date=DISCOVERY_WINDOW_START,
+        end_date=dt.date.today(),
+    )
 
 
 class CoveragePeriod(StrEnum):
@@ -84,22 +95,19 @@ def coverage(
 ) -> None:
     """Report discovery date coverage of the target window.
 
-    Read-only: compares the configured window (START_DATE through today)
-    against match dates present in `matches`, lists zero-match periods as
-    gaps, and shows the not-yet-processed backlog (every non-processed
-    lifecycle status) so "not discovered" is distinguishable from "not
-    yet processed". Backfill cursor state joins this report once the
-    backfill strategy (#121) lands.
+    Read-only: compares the discovery window (DISCOVERY_WINDOW_START
+    through today) against match dates present in `matches`, lists
+    zero-match periods as gaps, and shows the not-yet-processed backlog
+    (every non-processed lifecycle status) so "not discovered" is
+    distinguishable from "not yet processed". Backfill cursor state
+    joins this report once the backfill strategy (#121) lands.
     """
-    import datetime as dt
-
-    from cs2_analytics.config.config import START_DATE
     from cs2_analytics.storage.discovery_coverage import (
         compute_gap_ranges,
         fetch_discovery_coverage,
     )
 
-    window_start = dt.date.fromisoformat(START_DATE)
+    window_start = DISCOVERY_WINDOW_START
     window_end = dt.date.today()
     try:
         report = fetch_discovery_coverage(window_start, window_end, period.value)

--- a/cs2_analytics/config/__init__.py
+++ b/cs2_analytics/config/__init__.py
@@ -16,15 +16,9 @@ from .config import (
     DB_PORT,
     DB_USER,
     DEBUG_MODE,
-    ENABLE_ANALYTICS,
-    ENABLE_DATA_STORAGE,
-    END_DATE,
     ENVIRONMENT,
-    LOG_FILE,
     LOG_LEVEL,
-    MAX_MATCHES,
     SOURCE_URL,
-    START_DATE,
 )
 
 __all__ = [
@@ -38,13 +32,7 @@ __all__ = [
     "DB_PASS",
     "DB_PORT",
     "DB_USER",
-    "ENABLE_ANALYTICS",
-    "ENABLE_DATA_STORAGE",
-    "END_DATE",
     "ENVIRONMENT",
-    "LOG_FILE",
     "LOG_LEVEL",
-    "MAX_MATCHES",
     "SOURCE_URL",
-    "START_DATE",
 ]

--- a/cs2_analytics/config/config.py
+++ b/cs2_analytics/config/config.py
@@ -1,6 +1,11 @@
-"""Environment-backed runtime configuration for CS2 Analytics."""
+"""Environment-backed runtime configuration for CS2 Analytics.
 
-import datetime as dt
+Holds environment facts only (database, API, source URL, environment and
+debug flags, log level). Scraping run parameters - discovery window,
+match caps, batch sizes - are explicit arguments supplied by the invoker
+(the CLI today, an orchestrator later); see ADR-0015.
+"""
+
 import logging
 import os
 
@@ -106,7 +111,6 @@ DB_USER = os.getenv("DB_USER", default="postgres")
 DB_PASS = os.getenv("DB_PASS", default="password")
 DB_HOST = os.getenv("DB_HOST", default="localhost")
 DB_PORT = _read_int("DB_PORT", default=5432)
-BATCH_SIZE = 1000
 
 # API Configuration
 API_HOST = os.getenv("API_HOST", default="127.0.0.1")
@@ -122,21 +126,13 @@ API_CORS_ORIGINS = _read_csv(
     ],
 )
 
-# Feature Toggles
-ENABLE_DATA_STORAGE = True
-ENABLE_ANALYTICS = False
-
 # Scraping Config
 SOURCE_URL = os.getenv("SOURCE_URL", default="https://www.hltv.org/results")
-START_DATE = "2025-10-01"
-END_DATE = str(dt.datetime.today().date())
-MAX_MATCHES = 10
 
 # Logging Config
 LOG_LEVEL = logging.INFO
 if DEBUG_MODE:
     LOG_LEVEL = logging.DEBUG
-LOG_FILE = os.path.join(os.getcwd(), "logs", "app.log")
 
 _validate_production_environment(
     environment=ENVIRONMENT,

--- a/cs2_analytics/controllers/results_controller.py
+++ b/cs2_analytics/controllers/results_controller.py
@@ -1,5 +1,6 @@
 """Controller for scraping and recording match result links."""
 
+import datetime as dt
 import time
 from dataclasses import dataclass
 
@@ -37,13 +38,25 @@ class ResultsController:
         self.match_state = MatchIngestionState()
         self.stage_service = ResultsStageService(match_state=self.match_state)
 
-    def run(self, max_matches: int = 50) -> None:
-        """Scrapes result pages and records match URLs for downstream stages."""
-        logger.info("Running ResultsController with max_matches=%d", max_matches)
+    def run(
+        self, max_matches: int, start_date: dt.date, end_date: dt.date
+    ) -> None:
+        """Scrapes result pages and records match URLs for downstream stages.
+
+        Run parameters are explicit (ADR-0015): the invoker owns the
+        discovery window and cap, and the controller passes them through
+        to the scraper unchanged.
+        """
+        logger.info(
+            "Running ResultsController with max_matches=%d window=%s..%s",
+            max_matches,
+            start_date,
+            end_date,
+        )
 
         run_state = _ResultsRunState(scraper=self.scraper)
         try:
-            self._run_attempts(max_matches, run_state)
+            self._run_attempts(max_matches, start_date, end_date, run_state)
         finally:
             self._close_scraper(run_state)
             logger.info(
@@ -54,11 +67,19 @@ class ResultsController:
                 max_matches,
             )
 
-    def _run_attempts(self, max_matches: int, run_state: _ResultsRunState) -> None:
+    def _run_attempts(
+        self,
+        max_matches: int,
+        start_date: dt.date,
+        end_date: dt.date,
+        run_state: _ResultsRunState,
+    ) -> None:
         """Attempts the results stage until it succeeds or retries are exhausted."""
         for attempt in range(1, MAX_ATTEMPTS + 1):
             try:
-                recorded = self._record_discovered_batches(max_matches, run_state)
+                recorded = self._record_discovered_batches(
+                    max_matches, start_date, end_date, run_state
+                )
                 run_state.status = "succeeded"
                 logger.info("ResultsController complete. recorded=%d", recorded)
                 return
@@ -66,11 +87,17 @@ class ResultsController:
                 self._handle_attempt_failure(e, attempt, run_state)
 
     def _record_discovered_batches(
-        self, max_matches: int, run_state: _ResultsRunState
+        self,
+        max_matches: int,
+        start_date: dt.date,
+        end_date: dt.date,
+        run_state: _ResultsRunState,
     ) -> int:
         """Streams result pages and records each discovered match batch."""
         recorded = 0
-        for batch in run_state.scraper.iter_match_batches(max_matches=max_matches):
+        for batch in run_state.scraper.iter_match_batches(
+            max_matches=max_matches, start_date=start_date, end_date=end_date
+        ):
             recorded += self.stage_service.record_batch(batch)
         return recorded
 

--- a/cs2_analytics/pipeline/cs2_pipeline.py
+++ b/cs2_analytics/pipeline/cs2_pipeline.py
@@ -1,3 +1,10 @@
+import datetime as dt
+
+from cs2_analytics.cli import (
+    DISCOVER_MODE_MAX_MATCHES,
+    DISCOVERY_WINDOW_START,
+    DiscoverMode,
+)
 from cs2_analytics.controllers.map_controller import MapController
 from cs2_analytics.controllers.match_controller import MatchController
 from cs2_analytics.controllers.results_controller import ResultsController
@@ -16,9 +23,15 @@ class CS2AnalyticsPipeline:
     def run(self) -> None:
         self.logger.info("🚀 CS2 Analytics Pipeline started.")
 
-        # Step 1: Scrape results and record match links
+        # Step 1: Scrape results and record match links. Run parameters
+        # are explicit (ADR-0015); the pipeline uses the CLI's
+        # incremental-mode defaults so both entry points behave the same.
         self.logger.info("🔍 Scraping match results page...")
-        self.results_controller.run()
+        self.results_controller.run(
+            max_matches=DISCOVER_MODE_MAX_MATCHES[DiscoverMode.INCREMENTAL],
+            start_date=DISCOVERY_WINDOW_START,
+            end_date=dt.date.today(),
+        )
 
         # Step 2: Process pending matches from match_ingestion_state
         self.logger.info("🎯 Processing matches...")

--- a/cs2_analytics/scrapers/results_scraper.py
+++ b/cs2_analytics/scrapers/results_scraper.py
@@ -14,7 +14,7 @@ from collections.abc import Iterator
 from bs4 import BeautifulSoup
 from seleniumbase import Driver
 
-from cs2_analytics.config.config import END_DATE, MAX_MATCHES, SOURCE_URL, START_DATE
+from cs2_analytics.config.config import SOURCE_URL
 from cs2_analytics.exceptions import ResultsScrapeError, SessionScrapeError
 from cs2_analytics.utils.log_manager import get_logger
 
@@ -29,11 +29,9 @@ class ResultsScraper:
     """
 
     def __init__(self) -> None:
-        """Initializes the scraper with a SeleniumBase driver and config params."""
+        """Initializes the scraper with a SeleniumBase driver."""
         self.driver = Driver(uc=True, headless=True)
         self.base_url = SOURCE_URL
-        self.start_date = dt.datetime.strptime(START_DATE, "%Y-%m-%d").date()
-        self.end_date = dt.datetime.strptime(END_DATE, "%Y-%m-%d").date()
 
     def __enter__(self) -> "ResultsScraper":
         """Enables use as a context manager."""
@@ -44,17 +42,24 @@ class ResultsScraper:
         self.close()
 
     def iter_match_batches(
-        self, max_matches: int = MAX_MATCHES
+        self, max_matches: int, start_date: dt.date, end_date: dt.date
     ) -> Iterator[list[tuple[int, str]]]:
         """
-        Scrapes HLTV results pages and yields discovered matches per page.
+        Scrapes results pages and yields discovered matches per page.
+
+        Run parameters are explicit per call (ADR-0015): the caller owns
+        the discovery window and cap; the scraper holds no run defaults.
 
         Args:
             max_matches (int): Maximum number of matches to discover.
+            start_date (dt.date): Window floor; discovery stops at older dates.
+            end_date (dt.date): Window ceiling; newer dates are skipped.
 
         Yields:
             One list of (match_id, match_url) tuples per results page.
         """
+        self.start_date = start_date
+        self.end_date = end_date
         offset = 0
         total_discovered = 0
 

--- a/docs/architecture/decision_log.md
+++ b/docs/architecture/decision_log.md
@@ -402,3 +402,42 @@ Consequences:
 - The demo stage boundary is now preserved by the ingestion-state tables and
   discovery flow rather than a placeholder `DemoStageService`, superseding
   that consequence of ADR-0005.
+
+## ADR-0015: Config Holds Environment Facts; Run Parameters Flow From The Invoker
+
+Status:
+Accepted
+
+Date:
+Phase 4.5
+
+Context:
+`cs2_analytics/config/config.py` mixed environment configuration with
+scraping run parameters and dead entries. `BATCH_SIZE`,
+`ENABLE_DATA_STORAGE`, `ENABLE_ANALYTICS`, and config's `LOG_FILE` were
+consumed by no code (the logger defines its own path). `MAX_MATCHES`
+looked like the discovery cap but only applied to a bare scraper call -
+the CLI passed its own caps. `START_DATE`/`END_DATE` were hardcoded run
+parameters, and `END_DATE` was evaluated once at import time, so a
+long-lived process would scrape against a stale "today" (#126).
+
+Decision:
+Config holds environment facts only: database, API, source URL,
+environment/debug flags, log level. Run parameters flow from the
+invoker. `ResultsScraper.iter_match_batches` takes the match cap and
+date window as required per-call arguments; `ResultsController.run`
+passes them through unchanged. Defaults are owned by the CLI
+(`DISCOVERY_WINDOW_START`, per-mode caps, end date computed at run
+time), and the pipeline imports those same defaults so both entry
+points behave identically. The dead constants were deleted outright.
+
+Consequences:
+- A long-lived process computes its discovery window per run; the
+  import-time `END_DATE` staleness is gone.
+- The orchestrator that later replaces the CLI supplies run parameters
+  explicitly instead of editing config, which is the interface #121's
+  backfill cursor will use (the window floor becomes a cursor target).
+- The scraper stays fetch-only and gains no config coupling; tests pass
+  windows explicitly instead of mutating module constants.
+- Removing public config names is a breaking change for external
+  scripts, accepted because a repo-wide grep showed no consumers.

--- a/tests/controllers/test_results_controller.py
+++ b/tests/controllers/test_results_controller.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import pytest
 
 from cs2_analytics.controllers import results_controller as results_module
@@ -18,7 +20,7 @@ class _RetryThenSucceedScraper:
         self.run_calls = 0
         self.close_calls = 0
 
-    def iter_match_batches(self, max_matches: int = 50):
+    def iter_match_batches(self, max_matches: int, start_date=None, end_date=None):
         self.run_calls += 1
         if self.run_calls == 1:
             raise SessionScrapeError("Session dropped while fetching results page.")
@@ -34,7 +36,7 @@ class _AlwaysFailingRetryableScraper:
         self.run_calls = 0
         self.close_calls = 0
 
-    def iter_match_batches(self, max_matches: int = 50):
+    def iter_match_batches(self, max_matches: int, start_date=None, end_date=None):
         self.run_calls += 1
         raise SessionScrapeError("Session dropped while fetching results page.")
         yield  # pragma: no cover - makes this a generator like the real scraper
@@ -48,7 +50,7 @@ class _NonRetryableFailingScraper:
         self.run_calls = 0
         self.close_calls = 0
 
-    def iter_match_batches(self, max_matches: int = 50):
+    def iter_match_batches(self, max_matches: int, start_date=None, end_date=None):
         self.run_calls += 1
         raise RuntimeError("Unexpected parse failure")
         yield  # pragma: no cover - makes this a generator like the real scraper
@@ -78,7 +80,11 @@ def test_results_controller_retries_retryable_scrape_error(
         lambda scraper: reset_calls.append(scraper) or scraper,
     )
 
-    controller.run(max_matches=25)
+    controller.run(
+        max_matches=25,
+        start_date=dt.date(2025, 10, 1),
+        end_date=dt.date(2026, 8, 31),
+    )
 
     assert controller.scraper.run_calls == 2
     assert len(reset_calls) == 1
@@ -135,7 +141,11 @@ def test_results_controller_raises_pipeline_error_after_exhausting_retries(
         PipelineError,
         match=r"Results stage failed after exhausting retries \(3/3 attempts\)\.",
     ) as exc_info:
-        controller.run(max_matches=25)
+        controller.run(
+            max_matches=25,
+            start_date=dt.date(2025, 10, 1),
+            end_date=dt.date(2026, 8, 31),
+        )
 
     assert isinstance(exc_info.value.__cause__, SessionScrapeError)
     assert controller.scraper.run_calls == 3
@@ -209,7 +219,11 @@ def test_results_controller_raises_pipeline_error_for_non_retryable_failure(
         PipelineError,
         match=r"Results stage failed on non-retryable error at attempt 1/3\.",
     ) as exc_info:
-        controller.run(max_matches=25)
+        controller.run(
+            max_matches=25,
+            start_date=dt.date(2025, 10, 1),
+            end_date=dt.date(2026, 8, 31),
+        )
 
     assert isinstance(exc_info.value.__cause__, RuntimeError)
     assert controller.scraper.run_calls == 1

--- a/tests/scrapers/test_results_scraper.py
+++ b/tests/scrapers/test_results_scraper.py
@@ -42,6 +42,10 @@ def _page(urls: list[str], stop: bool) -> tuple[list[str], bool]:
     return urls, stop
 
 
+# Explicit run-parameter window for iter_match_batches calls (ADR-0015).
+_WINDOW = {"start_date": dt.date(2025, 1, 1), "end_date": dt.date(2026, 12, 31)}
+
+
 def test_iter_match_batches_yields_page_batches_with_ids(
     scraper: ResultsScraper, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -60,7 +64,7 @@ def test_iter_match_batches_yields_page_batches_with_ids(
     )
     monkeypatch.setattr(scraper, "_extract_matches_from_page", lambda _url: next(pages))
 
-    batches = list(scraper.iter_match_batches(max_matches=50))
+    batches = list(scraper.iter_match_batches(max_matches=50, **_WINDOW))
 
     assert batches == [
         [
@@ -83,7 +87,7 @@ def test_iter_match_batches_stops_at_max_matches(
 
     monkeypatch.setattr(scraper, "_extract_matches_from_page", fake_extract)
 
-    batches = list(scraper.iter_match_batches(max_matches=2))
+    batches = list(scraper.iter_match_batches(max_matches=2, **_WINDOW))
 
     assert len(batches) == 2
     assert calls == 2
@@ -102,7 +106,7 @@ def test_iter_match_batches_caps_within_a_page(
 
     monkeypatch.setattr(scraper, "_extract_matches_from_page", fake_extract)
 
-    batches = list(scraper.iter_match_batches(max_matches=2))
+    batches = list(scraper.iter_match_batches(max_matches=2, **_WINDOW))
 
     assert batches == [
         [
@@ -118,7 +122,24 @@ def test_iter_match_batches_stops_on_empty_page(
 ) -> None:
     monkeypatch.setattr(scraper, "_extract_matches_from_page", lambda _url: ([], False))
 
-    assert list(scraper.iter_match_batches(max_matches=10)) == []
+    assert list(scraper.iter_match_batches(max_matches=10, **_WINDOW)) == []
+
+
+def test_iter_match_batches_applies_window_parameters(
+    scraper: ResultsScraper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(scraper, "_extract_matches_from_page", lambda _url: ([], False))
+
+    list(
+        scraper.iter_match_batches(
+            max_matches=1,
+            start_date=dt.date(2025, 3, 1),
+            end_date=dt.date(2025, 4, 1),
+        )
+    )
+
+    assert scraper.start_date == dt.date(2025, 3, 1)
+    assert scraper.end_date == dt.date(2025, 4, 1)
 
 
 def test_extract_match_id(scraper: ResultsScraper) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,21 @@ def test_help_lists_all_commands() -> None:
         assert command in result.stdout
 
 
+def _assert_discover_call(calls, max_matches, before, after) -> None:
+    """Assert one discover run with the CLI-owned window defaults.
+
+    end_date is computed at run time, so it is bounded between dates
+    captured before and after the invocation instead of compared to a
+    fresh today(), which would flake across midnight.
+    """
+    assert len(calls) == 1
+    name, kwargs = calls[0]
+    assert name == "results"
+    assert kwargs["max_matches"] == max_matches
+    assert kwargs["start_date"] == dt.date(2025, 10, 1)
+    assert before <= kwargs["end_date"] <= after
+
+
 def test_discover_defaults_to_incremental_cap(monkeypatch) -> None:
     calls: list[tuple[str, dict]] = []
     _patch_controller(
@@ -66,10 +81,12 @@ def test_discover_defaults_to_incremental_cap(monkeypatch) -> None:
         calls,
     )
 
+    before = dt.date.today()
     result = runner.invoke(app, ["ingest", "discover"])
+    after = dt.date.today()
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 50, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
+    _assert_discover_call(calls, 50, before, after)
 
 
 def test_discover_backfill_raises_the_cap(monkeypatch) -> None:
@@ -82,10 +99,12 @@ def test_discover_backfill_raises_the_cap(monkeypatch) -> None:
         calls,
     )
 
+    before = dt.date.today()
     result = runner.invoke(app, ["ingest", "discover", "--mode", "backfill"])
+    after = dt.date.today()
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 1000, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
+    _assert_discover_call(calls, 1000, before, after)
 
 
 def test_discover_max_matches_overrides_mode(monkeypatch) -> None:
@@ -98,12 +117,14 @@ def test_discover_max_matches_overrides_mode(monkeypatch) -> None:
         calls,
     )
 
+    before = dt.date.today()
     result = runner.invoke(
         app, ["ingest", "discover", "--mode", "backfill", "--max-matches", "7"]
     )
+    after = dt.date.today()
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 7, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
+    _assert_discover_call(calls, 7, before, after)
 
 
 def test_discover_rejects_nonpositive_max_matches(monkeypatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ replaced in their source modules because the CLI imports them lazily
 inside command bodies.
 """
 
+import datetime as dt
+
 from typer.testing import CliRunner
 
 from cs2_analytics.cli import app
@@ -67,7 +69,7 @@ def test_discover_defaults_to_incremental_cap(monkeypatch) -> None:
     result = runner.invoke(app, ["ingest", "discover"])
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 50})]
+    assert calls == [("results", {"max_matches": 50, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
 
 
 def test_discover_backfill_raises_the_cap(monkeypatch) -> None:
@@ -83,7 +85,7 @@ def test_discover_backfill_raises_the_cap(monkeypatch) -> None:
     result = runner.invoke(app, ["ingest", "discover", "--mode", "backfill"])
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 1000})]
+    assert calls == [("results", {"max_matches": 1000, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
 
 
 def test_discover_max_matches_overrides_mode(monkeypatch) -> None:
@@ -101,7 +103,7 @@ def test_discover_max_matches_overrides_mode(monkeypatch) -> None:
     )
 
     assert result.exit_code == 0
-    assert calls == [("results", {"max_matches": 7})]
+    assert calls == [("results", {"max_matches": 7, "start_date": dt.date(2025, 10, 1), "end_date": dt.date.today()})]
 
 
 def test_discover_rejects_nonpositive_max_matches(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Strips run-parameter and dead constants from `cs2_analytics/config/config.py` so the module holds environment facts only. Scraping run parameters (discovery window, match cap) become explicit arguments supplied by the invoker - the CLI today, the orchestrator later - which also fixes the import-time `END_DATE` staleness. The principle is recorded as ADR-0015.

## Related Issue

Closes #126

## Scope

- `cs2_analytics/config/config.py` / `config/__init__.py`: deleted `BATCH_SIZE`, `ENABLE_DATA_STORAGE`, `ENABLE_ANALYTICS`, `LOG_FILE` (all dead - the logger defines its own path), and `MAX_MATCHES`, `START_DATE`, `END_DATE` (run parameters), plus their re-exports. Kept `SOURCE_URL`, `DB_*`, `API_*`, `ENVIRONMENT`, `DEBUG_MODE`, `LOG_LEVEL`. Module docstring states the principle.
- `cs2_analytics/scrapers/results_scraper.py`: `iter_match_batches(max_matches, start_date, end_date)` - required per-call parameters; `__init__` no longer parses dates (which also keeps `reset_scraper`'s no-argument factory working). Scraper stays fetch-only, now with zero run-parameter config coupling.
- `cs2_analytics/controllers/results_controller.py`: `run(max_matches, start_date, end_date)` passes parameters through unchanged and logs the window.
- `cs2_analytics/cli.py`: owns the defaults - `DISCOVERY_WINDOW_START = 2025-10-01`, per-mode caps unchanged, end date computed at run time. `ingest coverage` reads the same constant instead of config's `START_DATE`.
- `cs2_analytics/pipeline/cs2_pipeline.py`: supplies the CLI's incremental-mode defaults (imported from the CLI module, single source of truth) so `main.py` behaves identically to `cs2a ingest discover`.
- `docs/architecture/decision_log.md`: ADR-0015 - config holds environment facts; run parameters flow from the invoker.
- `README.md`: coverage paragraph no longer references `START_DATE`.
- Tests: scraper iter tests pass explicit windows (new test pins that window parameters reach the date filter); controller fakes and `run` calls updated; CLI discover assertions include the window kwargs.

## Out of Scope

- No change to discovery stop semantics or cursor work - that is #121; the explicit window parameter is its groundwork.
- No new environment variables and no changes to DB/API configuration or production validation.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: Touches the scraper and controller signatures and removes public config names. Mitigated by: repo-wide grep for the removed names is clean, behavior-preserving defaults are pinned by tests, and a live discovery run confirmed identical windowing and cap behavior. Flagging Medium because architecture-boundary-adjacent signatures changed and human review is required for that class of change.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: ADR-0015 added to the decision log; config module docstring states the environment-facts-only principle; README's coverage paragraph updated to drop the removed constant.

Backlog: Update not needed

Reason: Maintenance cleanup, not roadmap work - no phase, checklist, or sequencing status changes in docs/backlog.md.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check` / `uv run mypy` (CI invocations)
- Repo-wide grep for `BATCH_SIZE|ENABLE_DATA_STORAGE|ENABLE_ANALYTICS|MAX_MATCHES|START_DATE|END_DATE|LOG_FILE`
- Live: `cs2a ingest discover --max-matches 5` and `cs2a ingest coverage`

Results:

- pytest: 258 passed, 2 skipped; total coverage 82.16% (CI floor 80%)
- ruff and mypy clean
- Grep: no remaining references to any removed constant
- Live discover: controller logged the explicit window (2025-10-01..2026-08-31, end date computed at run time), respected the cap, recorded 5 matches, closed cleanly - behavior unchanged
- Live coverage: reports the identical window as before the change

## Review Notes

- The window/cap became per-call parameters on `iter_match_batches` rather than constructor parameters so `reset_scraper`'s no-argument factory keeps working during retry recovery - no retry-flow changes needed.
- The pipeline imports `DISCOVERY_WINDOW_START` / `DISCOVER_MODE_MAX_MATCHES` from the CLI module as the single source of run-parameter defaults ("defaults owned by the CLI" per the issue). The CLI's controller imports stay lazy, so no import cycle.
- Removing public config names is breaking for external consumers; the grep found none in the repo, and no deployment references them (they were never environment variables).
