### PR TITLE
Add --stage to cs2a process to run only matches, maps, or demos (#195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ cs2a ingest discover --mode backfill   # resume the backward walk toward the win
 cs2a ingest discover --mode backfill --since 2023-09-27   # extend the floor (full CS2 era)
 cs2a ingest coverage            # discovery date coverage: frontier, swept/unswept, gaps
 cs2a process --batch 50         # process pending matches, then maps
+cs2a process --stage map --batch 200   # drain only the map backlog
+cs2a process --stage map --stage match # explicit subset; runs match, then map
 cs2a status                     # ingestion-state row counts by status
 cs2a failures --stage match     # recent failed rows with error details
 cs2a failures --stage map --group   # aggregate failures by error message
@@ -302,6 +304,15 @@ cs2a retry --stage match        # requeue failed matches for reprocessing
 cs2a retry --stage map --dry-run
 cs2a retry --stage map --status processing --dry-run   # inspect rows stuck by an interrupted run
 ```
+
+`cs2a process` runs the match stage and then the map stage with one
+`--batch` size. `--stage` (repeatable: `match`, `map`, `demo`) restricts a
+run to a subset so one backlog can be drained without touching the
+other - each processed match discovers several maps, so the map backlog
+outgrows the match backlog under combined runs. Selected stages always
+run in the canonical order match, map, demo regardless of argument
+order. `demo` is accepted by the parser but rejected with a clear error
+until a demo controller exists; nothing runs and nothing is written.
 
 `cs2a failures` is read-only diagnostics for deciding whether to requeue:
 it lists recent `failed` rows (or `dead`/`partial` via `--status`) with

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -151,11 +151,10 @@ def coverage(
     joins this report once the backfill strategy (#121) lands.
     """
     from cs2_analytics.storage.discovery_coverage import (
+        align_period_start,
         compute_gap_ranges,
         fetch_discovery_coverage,
     )
-
-    from cs2_analytics.storage.discovery_coverage import align_period_start
 
     window_start = since.date() if since is not None else DISCOVERY_WINDOW_START
     window_end = dt.date.today()
@@ -219,19 +218,62 @@ def coverage(
         )
 
 
+class ProcessStage(StrEnum):
+    """Processing stage selectable on `cs2a process`, in canonical run order.
+
+    Separate from IngestionStage, which names state tables for retry and
+    failures commands: demo has no state-table command surface yet, and
+    its presence here is an interface placeholder until a demo controller
+    exists.
+    """
+
+    MATCH = "match"
+    MAP = "map"
+    DEMO = "demo"
+
+
+IMPLEMENTED_PROCESS_STAGES = frozenset({ProcessStage.MATCH, ProcessStage.MAP})
+
+
 @app.command()
 def process(
     batch: Annotated[
         int,
         typer.Option(min=1, help="Items to process per stage batch."),
     ] = 50,
+    stage: Annotated[
+        list[ProcessStage] | None,
+        typer.Option(
+            help=(
+                "Stage to run; repeatable. Selected stages always run in the"
+                " canonical order match, map, demo regardless of argument"
+                " order. Default: every implemented stage (match, then map)."
+            )
+        ),
+    ] = None,
 ) -> None:
-    """Process pending matches, then pending maps."""
+    """Process pending matches, then pending maps.
+
+    `--stage` restricts the run to a subset so one backlog can be drained
+    without touching the others (the map backlog grows faster than the
+    match backlog because each match discovers several maps). Stage
+    selection is rejected before any controller is imported, so an
+    unimplemented stage never reaches the database.
+    """
+    selected = frozenset(stage) if stage else IMPLEMENTED_PROCESS_STAGES
+    if ProcessStage.DEMO in selected:
+        raise typer.BadParameter(
+            "the demo stage is not implemented; choose match and/or map.",
+            param_hint="--stage",
+        )
+
     from cs2_analytics.controllers.map_controller import MapController
     from cs2_analytics.controllers.match_controller import MatchController
 
-    MatchController().run(batch_size=batch)
-    MapController().run(batch_size=batch)
+    controllers = {ProcessStage.MATCH: MatchController, ProcessStage.MAP: MapController}
+    for process_stage in ProcessStage:
+        if process_stage in selected:
+            controllers[process_stage]().run(batch_size=batch)
 
 
 class IngestionStage(StrEnum):

--- a/cs2_analytics/cli.py
+++ b/cs2_analytics/cli.py
@@ -270,7 +270,10 @@ def process(
     from cs2_analytics.controllers.map_controller import MapController
     from cs2_analytics.controllers.match_controller import MatchController
 
-    controllers = {ProcessStage.MATCH: MatchController, ProcessStage.MAP: MapController}
+    controllers: dict[ProcessStage, type[MatchController] | type[MapController]] = {
+        ProcessStage.MATCH: MatchController,
+        ProcessStage.MAP: MapController,
+    }
     for process_stage in ProcessStage:
         if process_stage in selected:
             controllers[process_stage]().run(batch_size=batch)

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -870,6 +870,11 @@ item track record.
       package, and update the docs that reference `python main.py`
 - [ ] (#182) README "Design decisions and tradeoffs" section distilled from the
       decision log (last v1.0 polish item)
+- [x] (#195) `cs2a process --stage` (repeatable: match, map, demo) so a
+      single backlog can be drained without running the other stage;
+      selected stages run in the canonical order regardless of argument
+      order, demo is rejected until a demo controller exists, and the
+      default remains match then map
 
 ---
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,6 +319,70 @@ def test_process_runs_matches_then_maps_with_batch(monkeypatch) -> None:
     ]
 
 
+def _patch_process_controllers(monkeypatch, calls):
+    """Replace both process-stage controllers with recording fakes."""
+    _patch_controller(
+        monkeypatch,
+        "cs2_analytics.controllers.match_controller",
+        "MatchController",
+        "match",
+        calls,
+    )
+    _patch_controller(
+        monkeypatch,
+        "cs2_analytics.controllers.map_controller",
+        "MapController",
+        "map",
+        calls,
+    )
+
+
+def test_process_single_stage_runs_only_that_controller(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+    _patch_process_controllers(monkeypatch, calls)
+
+    result = runner.invoke(app, ["process", "--stage", "map", "--batch", "10"])
+
+    assert result.exit_code == 0
+    assert calls == [("map", {"batch_size": 10})]
+
+
+def test_process_multiple_stages_run_in_canonical_order(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+    _patch_process_controllers(monkeypatch, calls)
+
+    result = runner.invoke(
+        app, ["process", "--stage", "map", "--stage", "match", "--batch", "10"]
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        ("match", {"batch_size": 10}),
+        ("map", {"batch_size": 10}),
+    ]
+
+
+def test_process_rejects_demo_stage_without_running_anything(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+    _patch_process_controllers(monkeypatch, calls)
+
+    result = runner.invoke(app, ["process", "--stage", "match", "--stage", "demo"])
+
+    assert result.exit_code != 0
+    assert "demo stage is not implemented" in result.output
+    assert calls == []
+
+
+def test_process_rejects_unknown_stage(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+    _patch_process_controllers(monkeypatch, calls)
+
+    result = runner.invoke(app, ["process", "--stage", "results"])
+
+    assert result.exit_code != 0
+    assert calls == []
+
+
 class _FakeRetryState:
     """Ingestion-state stand-in recording fetch/requeue calls per stage."""
 


### PR DESCRIPTION
## Summary

Adds a repeatable `--stage` option (`match`, `map`, `demo`) to `cs2a process` so one backlog can be drained without running the other stage. Selected stages always run in the canonical order match, map, demo regardless of argument order; with no `--stage` the command is unchanged (match, then map). `demo` is accepted by the parser but rejected with a usage error before any controller is imported, so it exits non-zero and writes nothing until a demo controller exists.

Motivation: each processed match discovers several maps, so the map backlog outgrows the match backlog under combined runs (roughly four to one as of 2026-09-08) and draining maps alone was not expressible.

## Related Issue

Closes #195

## Scope

- `cs2_analytics/cli.py`: new `ProcessStage` enum and `--stage` option on `process`; canonical-order execution; demo rejection ahead of controller imports. One pre-existing import-sort finding in the same file's `coverage` command folded in.
- `tests/test_cli.py`: five wiring tests (single stage, out-of-order arguments, demo rejection with another stage present, unknown stage, shared controller-patching helper). The existing default-behaviour test is unchanged.
- `README.md`: two usage lines and a paragraph on the option.
- `docs/backlog.md`: #195 recorded in the Phase 5 list.

## Out of Scope

- Per-stage batch sizes.
- Implementing the demo controller or any demo download/parse work.
- Controller selection, claim, retry, or rotation semantics.
- Letting `--stage` reorder stages.
- `cs2_analytics/pipeline/cs2_pipeline.py` is untouched; the pipeline entry point still runs all implemented stages.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: CLI-only wiring change. Controllers, stage services, scrapers, parsers, storage, and schema are untouched, and the default invocation is covered by an unchanged test.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README `cs2a process` usage block and a paragraph describing `--stage`, the canonical order, and the demo rejection. The issue also named `docs/workflow.md` for operational notes, but that file has no operational section and does not mention the CLI; the CLI is documented in the README, so the notes live there.

Backlog: Updated

Reason: #195 added to the Phase 5 list in `docs/backlog.md` as completed by this branch.

## Verification

Commands run:

- `uv run pytest --cov`
- `uv run ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501` (CI-equivalent lint)
- `uv run cs2a process --help`, `uv run cs2a process --stage demo`
- Manual on the desktop: `uv run cs2a process --stage map --batch 50` and `uv run cs2a process --batch 5`

Results:

- 274 passed, 2 skipped; total coverage 82.54% (floor 80).
- Lint clean.
- Help lists `--stage [match|map|demo]`; `--stage demo` exits 2 with "Invalid value for --stage: the demo stage is not implemented; choose match and/or map."
- Map-only run printed only the map summary; the default run's output was unchanged.

## Review Notes

- `ProcessStage` is a separate enum rather than an extension of `IngestionStage`: that enum also drives `cs2a retry` and `cs2a failures`, where a demo value would silently resolve to the map state table.
- Demo is accepted-and-rejected (the issue's proposed default) so the interface is stable before the demo controller exists.
- Local full-ruleset ruff and `ruff format --check` flag pre-existing lines in both touched files (unused-argument test stubs, formatter drift). None are enforced by CI and none are from this change; left alone to keep the diff focused.
