### PR TITLE
Pin the test environment to a local database and gate DB-backed tests on it (#174)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,13 @@
+# Test environment. tests/conftest.py loads this file OVER the process
+# environment before any project module is imported, so a pytest run can
+# only ever see these values, never the ones in .env or in a shell export.
+# The matching compose container is defined literally in
+# docker-compose.test.yml; nothing outside pytest reads this file.
+# Local defaults only; nothing here is secret.
+ENVIRONMENT=development
+DEBUG_MODE=false
+DB_NAME=cs2_db
+DB_USER=postgres
+DB_PASS=change_me
+DB_HOST=127.0.0.1
+DB_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       DB_PASS: change_me
       DB_HOST: 127.0.0.1
       DB_PORT: "5432"
-      # Opt the DB-backed storage tests in; they run only against a local
-      # host (the service container here) and delete their own rows.
-      CS2_ALLOW_DB_TESTS: "true"
 
     steps:
       - name: Check out repository

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ logs/*
 .env
 .env.*
 .env.local
+# Committed test environment: local compose defaults only, no secrets.
+!.env.test
 
 # Downloaded files & data
 demos/

--- a/README.md
+++ b/README.md
@@ -379,20 +379,25 @@ Then open the host and port configured by `API_HOST` and `API_PORT`, such as
 ### 9. Run Tests
 
 ```sh
-python -m pytest
+uv run pytest --cov
 ```
 
-The DB-backed storage integration tests (`tests/storage/test_database.py`)
-write and delete real rows, so they are skipped unless you opt in with
-`CS2_ALLOW_DB_TESTS=true` *and* `DB_HOST` is a local database
-(`localhost`, `127.0.0.1`, or the compose `db` service); they never run
-against a remote database. CI opts in against its disposable service
-container. To run them locally, point `DB_*` at the compose database:
+Tests never touch the database named in `.env`. `tests/conftest.py` loads
+the committed `.env.test` over the process environment (a shell export
+loses too) before any project module is imported, and refuses to start
+unless `DB_HOST` is a local host (`localhost`, `127.0.0.1`, or the compose
+`db` service). DB-backed tests (the storage integration tests and the
+atomic-transaction acceptance test) take the `test_database` fixture,
+which migrates the local database on first use and skips when it is not
+running; CI runs them against its disposable service container.
+
+To run them locally, start the compose database with the test override,
+which pins the container to literal local values so no environment
+variable can repoint it. No migration step is needed.
 
 ```sh
-docker compose --env-file .env.example up -d db
-env CS2_ALLOW_DB_TESTS=true DB_HOST=127.0.0.1 DB_USER=postgres \
-  DB_PASS=change_me DB_NAME=cs2_db python -m pytest tests/storage/test_database.py
+docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db
+uv run pytest --cov
 ```
 
 ### 10. Run dbt (analytics transformations)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,13 @@
+# Test database override. The base file interpolates the db service from
+# DB_* variables, which a shell export can silently repoint at a deployed
+# database; this file pins the container to literal local values instead.
+# Always pair it with the base file:
+#   docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db
+# These values match .env.test, which tests/conftest.py loads before any
+# project module is imported.
+services:
+  db:
+    environment:
+      POSTGRES_DB: cs2_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: change_me

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Pytest bootstrap: pin the test environment before any project code loads.
+
+Every test run, local or CI, targets the disposable local database and
+never the deployment one. This module loads `.env.test` into the process
+environment with override on, so it beats both the application `.env`
+(read later by the config module, which never overrides variables that are
+already set) and any stray shell export. It then refuses to start unless
+the resulting DB_HOST is a local database host. pytest imports the root
+conftest before collecting any test module, so this runs before the config
+module can be imported anywhere; the guard at the top makes that
+assumption explicit rather than silent.
+
+DB-backed tests take the `test_database` fixture, which connects to that
+local database or skips when it is not running. See README, Run Tests.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+# tests.support imports only cs2_analytics.exceptions, which never touches
+# config, so importing it here cannot pre-empt the environment pin below.
+from tests.support import LOCAL_DB_HOSTS
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEST_ENV_FILE = PROJECT_ROOT / ".env.test"
+CONFIG_MODULE = "cs2_analytics.config.config"
+
+
+def _pin_test_environment() -> None:
+    """Load .env.test with override and refuse any non-local database host."""
+    if CONFIG_MODULE in sys.modules:
+        raise RuntimeError(
+            f"{CONFIG_MODULE} was imported before tests/conftest.py loaded "
+            f"{TEST_ENV_FILE.name}; the test environment cannot be guaranteed."
+        )
+    if not TEST_ENV_FILE.is_file():
+        raise RuntimeError(f"{TEST_ENV_FILE} is missing; tests refuse to run without it.")
+    load_dotenv(TEST_ENV_FILE, override=True)
+    host = os.environ.get("DB_HOST", "")
+    if host not in LOCAL_DB_HOSTS:
+        raise RuntimeError(
+            f"DB_HOST={host!r} after loading {TEST_ENV_FILE.name} is not one of "
+            f"{LOCAL_DB_HOSTS}; refusing to run tests against a non-local database."
+        )
+
+
+_pin_test_environment()
+
+
+@pytest.fixture(scope="session")
+def test_database():
+    """Shared connection to the local test database; skips when it is down."""
+    from tests.support import NO_TEST_DB_REASON, open_test_database
+
+    database = open_test_database()
+    if database is None:
+        pytest.skip(NO_TEST_DB_REASON)
+    yield database
+    database.close_db_pool()

--- a/tests/stage_services/test_atomic_transactions.py
+++ b/tests/stage_services/test_atomic_transactions.py
@@ -117,13 +117,8 @@ class TestAtomicRollbackIntegration:
     MAP_ID = 990001
 
     @pytest.fixture()
-    def db(self):
-        from cs2_analytics.storage.db_instance import get_db
-
-        try:
-            database = get_db()
-        except Exception:
-            pytest.skip("PostgreSQL is not available for integration tests")
+    def db(self, test_database):
+        database = test_database
 
         with database.get_cursor() as cur:
             cur.execute(

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -2,13 +2,12 @@
 
 These tests write real rows through the storage modules, which commit on
 their own connections, so no rollback can undo them. They therefore run
-only when explicitly opted in (CS2_ALLOW_DB_TESTS) and only against a
-local database host, and they delete their fixed-ID rows before and after
-each test. CI opts in against its service container; a local run with the
-application .env skips.
+only against the local test database pinned by tests/conftest.py via
+.env.test (never the application .env), skip when that database is not
+running, and delete their fixed-ID rows before and after each test. CI
+runs them against its disposable service container.
 """
 
-import os
 import sys
 import unittest
 from datetime import UTC, datetime
@@ -16,28 +15,14 @@ from datetime import UTC, datetime
 from cs2_analytics.models.map import Map
 from cs2_analytics.models.match import Match
 from cs2_analytics.models.player import Player
-from cs2_analytics.storage.database import Database
 from cs2_analytics.storage.map_storage import store_maps
 from cs2_analytics.storage.match_storage import store_matches
 from cs2_analytics.storage.player_storage import store_players
+from tests.support import NO_TEST_DB_REASON, open_test_database
 
-OPT_IN_ENV = "CS2_ALLOW_DB_TESTS"
-LOCAL_DB_HOSTS = ("localhost", "127.0.0.1", "db")
 TEST_MATCH_IDS = (999998, 999999)
 TEST_MAP_ID = 999999
 TEST_PLAYER_ID = 888888
-
-
-def db_tests_enabled() -> bool:
-    """True only when opted in and DB_HOST is a local database."""
-    opted_in = os.getenv(OPT_IN_ENV, "").strip().lower() in {"1", "true", "yes"}
-    return opted_in and os.getenv("DB_HOST", "") in LOCAL_DB_HOSTS
-
-
-SKIP_REASON = (
-    f"DB-backed storage tests run only with {OPT_IN_ENV} set and DB_HOST "
-    f"in {LOCAL_DB_HOSTS}; they write and delete real rows."
-)
 
 
 def delete_test_rows(cur) -> None:
@@ -58,16 +43,18 @@ class TestDatabase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Enforce the opt-in guard, then open the database connection.
+        """Open the local test database connection, or skip.
 
-        The guard lives here rather than in a pytest marker so it also
-        applies under `python -m unittest` and this file's own entry point.
+        open_test_database enforces the local-host guard itself, so the
+        guard also applies under `python -m unittest` and this file's own
+        entry point, where tests/conftest.py does not run.
         """
-        if not db_tests_enabled():
-            raise unittest.SkipTest(SKIP_REASON)
+        database = open_test_database()
+        if database is None:
+            raise unittest.SkipTest(NO_TEST_DB_REASON)
         print("\n🚀 Setting up database connection for tests...")
         sys.stdout.flush()
-        cls.db = Database()
+        cls.db = database
         cls.conn = cls.db.get_connection()
         cls.conn.autocommit = True
         cls.cur = cls.conn.cursor()

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -2,10 +2,14 @@
 
 These tests write real rows through the storage modules, which commit on
 their own connections, so no rollback can undo them. They therefore run
-only against the local test database pinned by tests/conftest.py via
-.env.test (never the application .env), skip when that database is not
-running, and delete their fixed-ID rows before and after each test. CI
-runs them against its disposable service container.
+only against a local database and delete their fixed-ID rows before and
+after each test. Under pytest that is the database pinned by
+tests/conftest.py via .env.test, never the application .env. Under the
+`python -m unittest` entry point conftest does not run, config resolves
+from the application .env, and open_test_database refuses to connect
+unless that host is local. Either way the tests skip when the local
+database is not reachable. CI runs them against its disposable service
+container.
 """
 
 import sys

--- a/tests/support.py
+++ b/tests/support.py
@@ -43,7 +43,8 @@ class FakeTransactionDb:
 LOCAL_DB_HOSTS = ("localhost", "127.0.0.1", "db")
 
 NO_TEST_DB_REASON = (
-    "the local test database is not running; start it with `docker compose "
+    "the local test database is not reachable (not running, or its credentials "
+    "or database name differ from .env.test); start it with `docker compose "
     "-f docker-compose.yml -f docker-compose.test.yml up -d db` (README: Run Tests)"
 )
 
@@ -53,9 +54,11 @@ def open_test_database():
 
     Returns a Database, or None when the local Postgres is not reachable
     so callers can skip. Refuses outright if the configured host is not
-    local: conftest already guarantees this under pytest, and this check
-    extends the same guarantee to the unittest entry point of
-    tests/storage/test_database.py, which conftest does not cover. A
+    local. Under pytest, conftest has already pinned the host; under the
+    unittest entry point of tests/storage/test_database.py, conftest does
+    not run and config resolves from the application .env, so this check
+    is what stops that entry point from ever opening a non-local
+    connection (it errors rather than skips: that is a setup mistake). A
     reachable but unmigrated database is migrated here, on first use:
     the host has passed the local-only guard twice by this point, so the
     migration cannot reach anything but the disposable test database,

--- a/tests/support.py
+++ b/tests/support.py
@@ -38,3 +38,59 @@ class FakeTransactionDb:
                 raise self.fail_on_exit
         except Exception as e:
             raise DatabaseOperationError("Failed during database transaction.") from e
+
+
+LOCAL_DB_HOSTS = ("localhost", "127.0.0.1", "db")
+
+NO_TEST_DB_REASON = (
+    "the local test database is not running; start it with `docker compose "
+    "-f docker-compose.yml -f docker-compose.test.yml up -d db` (README: Run Tests)"
+)
+
+
+def open_test_database():
+    """Connect to the local test database pinned by tests/conftest.py.
+
+    Returns a Database, or None when the local Postgres is not reachable
+    so callers can skip. Refuses outright if the configured host is not
+    local: conftest already guarantees this under pytest, and this check
+    extends the same guarantee to the unittest entry point of
+    tests/storage/test_database.py, which conftest does not cover. A
+    reachable but unmigrated database is migrated here, on first use:
+    the host has passed the local-only guard twice by this point, so the
+    migration cannot reach anything but the disposable test database,
+    and no manual migration command needs to exist for it.
+    """
+    from cs2_analytics.config.config import DB_HOST
+    from cs2_analytics.exceptions import DatabaseConnectionError
+    from cs2_analytics.storage.database import Database
+
+    if DB_HOST not in LOCAL_DB_HOSTS:
+        raise RuntimeError(
+            f"DB_HOST={DB_HOST!r} is not a local database host {LOCAL_DB_HOSTS};"
+            " refusing to open a test database connection."
+        )
+    try:
+        database = Database()
+    except DatabaseConnectionError:
+        return None
+    _ensure_migrated_schema(database)
+    return database
+
+
+def _schema_present(database) -> bool:
+    with database.get_cursor() as cur:
+        cur.execute("SELECT to_regclass('public.alembic_version');")
+        (present,) = cur.fetchone()
+    return present is not None
+
+
+def _ensure_migrated_schema(database) -> None:
+    """Run the Alembic migrations against the (local-only) test database."""
+    from cs2_analytics.storage.initialize_db import run_migrations
+
+    if _schema_present(database):
+        return
+    run_migrations()
+    if not _schema_present(database):
+        raise RuntimeError("migrating the local test database left no schema behind.")


### PR DESCRIPTION
## Summary

Makes it structurally impossible for a pytest run to reach the database named in `.env`. `tests/conftest.py` loads the committed `.env.test` over the process environment with override on, before any project module is imported, and refuses to start unless `DB_HOST` is a local host. DB-backed tests take a session `test_database` fixture that connects to that local database, migrates the schema on first use, and skips with a pointer to the compose command when it is not running. A `docker-compose.test.yml` override pins the local container to literal values so an environment variable cannot repoint it either.

Why override, and why literal compose values: both `uv run --env-file` and `docker compose --env-file` yield to variables that are already exported, so any shell that carries deployment settings silently defeats an env file loaded without override. The design here does not depend on the shell being clean.

This is the first of two PRs for #174. It changes no test coverage of the lifecycle itself; the integration tests follow in the second PR, which closes the issue.

## Related Issue

Refs #174 (first of two PRs; the lifecycle tests in the second close it)

## Scope

- `tests/conftest.py` (new): environment pin with override, config-import guard, local-host refusal, session `test_database` fixture.
- `tests/support.py`: `open_test_database` (host re-check, connect-or-None, migrate on first use) and the shared skip reason.
- `tests/storage/test_database.py`: uses the shared helper; the module-local opt-in variable and guard are removed.
- `tests/stage_services/test_atomic_transactions.py`: the acceptance test takes the fixture instead of probing the shared connection.
- `.env.test` (new, committed) and a `.gitignore` re-allow for it; local compose defaults, no secrets.
- `docker-compose.test.yml` (new): literal `POSTGRES_*` values for the db service.
- `.github/workflows/ci.yml`: the `CS2_ALLOW_DB_TESTS` line and its comment removed; nothing else changes.
- `README.md`: Run Tests section rewritten around the two-command recipe.

## Out of Scope

- The lifecycle integration tests themselves (second PR for #174).
- Any change to lifecycle semantics, schema, controllers, or the production `Database` class and its pool.
- A remote-host refusal on `cs2a db upgrade` / `downgrade` (proposed as a follow-up issue).

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Medium

Reason: Touches the CI workflow (one env line removed) and changes how every test run resolves its configuration. No runtime code changes; the production `Database`, config, and state modules are untouched.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: README Run Tests section now describes the environment pin, the fixture, and the local compose recipe; the old opt-in instructions are gone.

Backlog: Update not needed

Reason: #174 stays open until the second PR lands the lifecycle tests. That PR checks the Phase 5 item and adjusts its wording (the gate is an environment pin rather than a separate URL variable).

## Verification

Commands run:

- `uv run pytest --cov` with the compose test database up (fresh, unmigrated container; fixture migrated it on first use), then again with the schema present
- `uv run pytest --cov` with the container stopped
- Probe test run under hostile exports (`DB_HOST=<remote> ENVIRONMENT=production uv run pytest <probe>`), then removed
- `uv run ruff check ... --select E,F --ignore E501` and the CI mypy command
- Manual: `docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db` from a shell whose environment carried deployment `DB_*` exports; container inspected as `POSTGRES_USER=postgres`, `POSTGRES_DB=cs2_db`

Results:

- Database up: 276 passed, 0 skipped, total coverage 82.80% (floor 80). The atomic-rollback test now runs here instead of against the `.env` database.
- Database down: 273 passed, 3 skipped, each skip naming the compose command.
- Probe: config reported `127.0.0.1` / `development` despite the exports.
- Lint and mypy clean.
- Container pinned to the literal values despite the exports.

## Review Notes

- The config-import guard in conftest is deliberate: the design assumes the root conftest runs before any module imports config, and the guard turns that assumption into a hard failure instead of a silent leak.
- `open_test_database` re-checks the host on its own so the `python -m unittest` entry point of the storage tests is covered without conftest.
- Migrating inside the fixture was chosen over a documented manual command because the manual command is exactly the step an export can redirect; the fixture path is behind two local-only checks.
- Follow-up proposed: `cs2a db upgrade` / `downgrade` refuse non-local hosts without an explicit acknowledgement flag.
