### PR TITLE
Omit non-unit-testable modules from coverage and raise the floor to 85 (#177)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -867,9 +867,15 @@ item track record.
       migration needs the production settings, the flag, and the
       confirmation prompt together (follow-up from #199, where an env
       file lost to exported variables and the CLI targeted production)
-- [ ] (#177) Coverage hygiene: omit Alembic migrations and the thin pipeline
+- [x] (#177) Coverage hygiene: omit Alembic migrations and the thin pipeline
       entrypoint from coverage, add parser fallback-branch fixtures, and
-      raise the coverage floor to 85
+      raise the coverage floor to 85 - `[tool.coverage.run] omit` now
+      excludes `cs2_analytics/alembic/*` and `cs2_analytics/pipeline/*`
+      (the latter pending its removal in #181), the fixture tests in
+      `tests/parsers/test_map_parser_fallbacks.py` and
+      `tests/parsers/test_match_parser_fallbacks.py` cover the parser
+      fallback and secondary-stat branches (map parser 100%, match parser
+      99%), and `fail_under = 85` at a measured 94.04% total
 - [ ] (#178) dbt singular tests for business invariants: SCD2 validity (no
       overlapping intervals, exactly one current row per player) and
       score consistency (map winner has the higher score, match winner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,12 +160,19 @@ omit = [
     "*/tests/*",
     "*/test_*.py",
     "*/__init__.py",
+    # Not unit-testable: Alembic env/migrations run only against a live
+    # database, and the legacy pipeline entrypoint is slated for removal
+    # in favor of the cs2a CLI (#177, #181).
+    "*/cs2_analytics/alembic/*",
+    "*/cs2_analytics/pipeline/*",
 ]
 
 [tool.coverage.report]
-# Honest floor; raised from 75 at a measured 80.36% (#128). Raise as
-# coverage improves.
-fail_under = 80
+# Honest floor; raised from 75 at a measured 80.36% (#128), then from 80
+# at a measured 94.04% once non-unit-testable modules were omitted and
+# the parser fallback branches got fixtures (#177). Raise as coverage
+# improves.
+fail_under = 85
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/tests/parsers/test_map_parser_fallbacks.py
+++ b/tests/parsers/test_map_parser_fallbacks.py
@@ -1,0 +1,418 @@
+"""Fixture tests for map parser fallback and secondary-stat branches.
+
+The map stats page is rendered from small building blocks (info box,
+stats tables, player rows) so each test varies exactly the markup that
+drives the branch under test.
+"""
+
+from typing import Any, cast
+from unittest import mock
+
+import pytest
+from bs4 import BeautifulSoup
+
+from cs2_analytics.exceptions import MapParseError
+from cs2_analytics.models.player import Player
+from cs2_analytics.parsers import map_parser as map_parser_module
+from cs2_analytics.parsers.map_parser import MapParser
+
+MAP_ID = 222
+MAP_URL = f"https://www.hltv.org/stats/matches/mapstatsid/{MAP_ID}/team-a-vs-team-b"
+UNIX_2024_01_01 = "1704067200000"
+
+DEFAULT_INFO_BOX = """
+<div class="match-info-box">
+  <div class="date">2025-08-05 14:30</div>
+  <div class="small-text">Map</div>
+  Inferno
+  <a href="/team/1/team-a">Team A</a>
+  <div>13</div>
+  <a href="/team/2/team-b">Team B</a>
+  <div>9</div>
+  <div>Breakdown</div>
+</div>
+"""
+
+DEFAULT_HEADERS = (
+    "<th>Op. K-D</th><th>MKs</th><th>KAST</th><th>1vsX</th><th>K (hs)</th>"
+    "<th>A (f)</th><th>D (t)</th><th>ADR</th><th>Swing</th><th>Rating 3.0</th>"
+)
+
+
+def _player_row(
+    *,
+    player_id: int = 1234,
+    name: str = "TestPlayer",
+    opkd: str = "5 : 2",
+    mks: str = "3",
+    kast: str = "70.0%",
+    clutches: str = "1",
+    kills: str = "20 (12)",
+    assists: str = "6 (2)",
+    deaths: str = "15 (3)",
+    adr: str = "95.2",
+    swing: str = "+3.00%",
+    rating: str = "1.24",
+) -> str:
+    return f"""
+    <tr>
+      <td class="st-player"><a href="/player/{player_id}/x">{name}</a></td>
+      <td class="st-opkd">{opkd}</td>
+      <td class="st-mks">{mks}</td>
+      <td class="st-kast">{kast}</td>
+      <td class="st-clutches">{clutches}</td>
+      <td class="st-kills">{kills}</td>
+      <td class="st-assists">{assists}</td>
+      <td class="st-deaths">{deaths}</td>
+      <td class="st-adr">{adr}</td>
+      <td class="st-roundSwing">{swing}</td>
+      <td class="st-rating">{rating}</td>
+    </tr>
+    """
+
+
+def _stats_table(
+    *,
+    team: str = "Team A",
+    rows: str | None = None,
+    headers: str = DEFAULT_HEADERS,
+    table_class: str = "stats-table totalstats",
+    with_tbody: bool = True,
+) -> str:
+    body_rows = rows if rows is not None else _player_row()
+    tbody = f"<tbody>{body_rows}</tbody>" if with_tbody else ""
+    return (
+        f'<table class="{table_class}">'
+        f'<thead><tr><th class="st-teamname">{team}</th>{headers}</tr></thead>'
+        f"{tbody}</table>"
+    )
+
+
+def _two_team_tables() -> str:
+    return _stats_table(team="Team A") + _stats_table(
+        team="Team B", rows=_player_row(player_id=5678, name="OtherPlayer")
+    )
+
+
+def _map_soup(
+    *, info_box: str = DEFAULT_INFO_BOX, tables: str = "", extra: str = ""
+) -> BeautifulSoup:
+    html = f"<html><body>{info_box}{tables}{extra}</body></html>"
+    return BeautifulSoup(html, "html.parser")
+
+
+def _parse_players(soup: BeautifulSoup) -> list[Player]:
+    return MapParser().parse_map(soup, map_url=MAP_URL, map_id=MAP_ID)
+
+
+def _parse_details(
+    soup: BeautifulSoup,
+    *,
+    map_id: int = MAP_ID,
+    match_id: int | None = 1001,
+    map_order: int | None = 1,
+) -> Any:
+    return MapParser().parse_map_details(
+        soup,
+        map_url=MAP_URL,
+        map_id=map_id,
+        match_id=match_id,
+        map_order=map_order,
+    )
+
+
+def test_parse_map_wraps_unexpected_errors_as_parse_error() -> None:
+    with pytest.raises(
+        MapParseError, match="Failed to parse map stats page"
+    ) as exc_info:
+        MapParser().parse_map(None, map_url=MAP_URL, map_id=MAP_ID)
+
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+
+
+def test_parse_map_details_wraps_unexpected_errors_as_parse_error() -> None:
+    with pytest.raises(
+        MapParseError, match="Failed to parse map stats page"
+    ) as exc_info:
+        MapParser().parse_map_details(
+            None, map_url=MAP_URL, map_id=MAP_ID, match_id=1001, map_order=1
+        )
+
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+
+
+def test_parse_map_details_requires_parent_match_id() -> None:
+    soup = _map_soup(tables=_two_team_tables())
+
+    with pytest.raises(
+        MapParseError, match="Missing parent match id for map persistence."
+    ):
+        _parse_details(soup, match_id=None)
+
+
+def test_parse_map_raises_when_page_has_no_stats_tables() -> None:
+    with pytest.raises(
+        MapParseError, match="No player stats tables found on map page."
+    ):
+        _parse_players(_map_soup())
+
+
+def test_parse_map_falls_back_to_plain_stats_tables_and_skips_hidden() -> None:
+    tables = _stats_table(
+        table_class="stats-table hidden",
+        rows=_player_row(player_id=1, name="HiddenPlayer"),
+    ) + _stats_table(table_class="stats-table")
+
+    players = _parse_players(_map_soup(tables=tables))
+
+    assert [player.player_name for player in players] == ["TestPlayer"]
+
+
+def test_parse_map_skips_table_without_tbody_and_warns() -> None:
+    tables = _stats_table(team="Team B", with_tbody=False) + _stats_table()
+
+    with mock.patch.object(map_parser_module.logger, "warning") as warning_mock:
+        players = _parse_players(_map_soup(tables=tables))
+
+    assert [player.player_name for player in players] == ["TestPlayer"]
+    warning_mock.assert_called_once_with(
+        "Skipping table without tbody in %s", MAP_URL
+    )
+
+
+def test_parse_map_skips_rows_without_cells() -> None:
+    tables = _stats_table(rows="<tr></tr>" + _player_row())
+
+    players = _parse_players(_map_soup(tables=tables))
+
+    assert [player.player_name for player in players] == ["TestPlayer"]
+
+
+def test_map_name_requires_small_text_label() -> None:
+    soup = _map_soup(info_box='<div class="match-info-box">Inferno</div>')
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map name from map stats page."
+    ):
+        _parse_players(soup)
+
+
+def test_map_name_requires_text_after_label() -> None:
+    soup = _map_soup(
+        info_box='<div class="match-info-box"><div class="small-text">Map</div></div>'
+    )
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map name from map stats page."
+    ):
+        _parse_players(soup)
+
+
+def test_map_date_prefers_data_unix_attribute() -> None:
+    info_box = DEFAULT_INFO_BOX.replace(
+        '<div class="date">2025-08-05 14:30</div>',
+        f'<div class="date" data-unix="{UNIX_2024_01_01}"></div>',
+    )
+
+    parsed = _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+    assert parsed.map.date == "2024-01-01 00:00:00"
+
+
+def test_map_date_rejects_unparseable_data_unix() -> None:
+    info_box = DEFAULT_INFO_BOX.replace(
+        '<div class="date">2025-08-05 14:30</div>',
+        '<div class="date" data-unix="not-a-number"></div>',
+    )
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map date from map stats page."
+    ) as exc_info:
+        _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_map_date_accepts_date_without_time() -> None:
+    info_box = DEFAULT_INFO_BOX.replace("2025-08-05 14:30", "2025-08-05")
+
+    parsed = _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+    assert parsed.map.date == "2025-08-05"
+
+
+def test_map_date_missing_raises() -> None:
+    info_box = DEFAULT_INFO_BOX.replace(
+        '<div class="date">2025-08-05 14:30</div>', ""
+    )
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map date from map stats page."
+    ):
+        _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+
+def test_team_scores_require_info_box() -> None:
+    parser = cast(Any, MapParser())
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map scores from map stats page."
+    ):
+        parser._extract_map_team_scores(_map_soup(info_box=""))
+
+
+def test_team_scores_require_two_distinct_teams() -> None:
+    with pytest.raises(
+        MapParseError, match="Failed to extract map teams from map stats page."
+    ):
+        _parse_details(_map_soup(tables=_stats_table(team="Team A")))
+
+
+def test_team_scores_require_team_name_in_info_box() -> None:
+    info_box = DEFAULT_INFO_BOX.replace("Team B</a>", "Someone Else</a>")
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map scores from map stats page."
+    ) as exc_info:
+        _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_team_scores_stop_scanning_at_breakdown_marker() -> None:
+    info_box = """
+    <div class="match-info-box">
+      <div class="small-text">Map</div>
+      Inferno
+      <a href="/team/1/team-a">Team A</a>
+      <div>Breakdown</div>
+      <div>13</div>
+      <a href="/team/2/team-b">Team B</a>
+      <div>9</div>
+    </div>
+    """
+
+    with pytest.raises(
+        MapParseError, match="Failed to extract map scores from map stats page."
+    ):
+        _parse_details(_map_soup(info_box=info_box, tables=_two_team_tables()))
+
+
+def test_map_order_is_inferred_from_map_stats_links() -> None:
+    links = (
+        '<a href="/stats/matches/mapstatsid/111/map-one">1</a>'
+        '<a href="/stats/matches/mapstatsid/222/map-two">2</a>'
+        '<a href="/stats/matches/mapstatsid/222/map-two">2 again</a>'
+        '<a href="/stats/matches/mapstatsid/">no id</a>'
+    )
+
+    parsed = _parse_details(
+        _map_soup(tables=_two_team_tables(), extra=links), map_order=None
+    )
+
+    assert parsed.map.map_order == 2
+
+
+def test_map_order_falls_back_to_map_id_in_url() -> None:
+    links = (
+        '<a href="/stats/matches/mapstatsid/111/map-one">1</a>'
+        '<a href="/stats/matches/mapstatsid/222/map-two">2</a>'
+    )
+
+    parsed = _parse_details(
+        _map_soup(tables=_two_team_tables(), extra=links),
+        map_id=0,
+        map_order=None,
+    )
+
+    assert parsed.map.map_order == 2
+
+
+def test_map_order_missing_raises() -> None:
+    with pytest.raises(
+        MapParseError, match="Failed to extract map order from map stats page."
+    ):
+        _parse_details(_map_soup(tables=_two_team_tables()), map_order=None)
+
+
+def test_column_map_skips_blank_headers_and_defaults_missing_columns() -> None:
+    headers = DEFAULT_HEADERS.replace("<th>Swing</th>", "<th></th>")
+
+    players = _parse_players(_map_soup(tables=_stats_table(headers=headers)))
+
+    assert len(players) == 1
+    assert players[0].round_swing == 0.03
+
+
+def test_sparse_row_falls_back_to_empty_text_for_out_of_range_columns() -> None:
+    row = """
+    <tr>
+      <td class="st-player"><a href="/player/1234/x">TestPlayer</a></td>
+      <td>filler</td>
+      <td class="st-kills">20 (12)</td>
+      <td class="st-assists">6 (2)</td>
+      <td class="st-deaths">15 (3)</td>
+      <td class="st-kast">70.0%</td>
+      <td class="st-adr">95.2</td>
+      <td class="st-rating">1.24</td>
+    </tr>
+    """
+
+    with mock.patch.object(map_parser_module.logger, "warning"):
+        players = _parse_players(_map_soup(tables=_stats_table(rows=row)))
+
+    assert len(players) == 1
+    assert players[0].round_swing == 0.0
+
+
+def test_metric_text_uses_hidden_cell_when_no_visible_cell_exists() -> None:
+    row = _player_row().replace(
+        '<td class="st-opkd">5 : 2</td>',
+        '<td class="st-opkd eco-adjusted-data hidden">9 : 4</td>',
+    )
+
+    players = _parse_players(_map_soup(tables=_stats_table(rows=row)))
+
+    assert (players[0].opening_kills, players[0].opening_deaths) == (9, 4)
+
+
+def test_metric_text_prefer_hidden_picks_hidden_then_visible() -> None:
+    parser = cast(Any, MapParser())
+    both = BeautifulSoup(
+        '<tr><td class="st-opkd">5 : 2</td>'
+        '<td class="st-opkd eco-adjusted-data hidden">9 : 4</td></tr>',
+        "html.parser",
+    ).find_all("td")
+    visible_only = BeautifulSoup(
+        '<tr><td class="st-opkd">5 : 2</td></tr>', "html.parser"
+    ).find_all("td")
+
+    assert parser._extract_metric_text(both, 0, ["st-opkd"], prefer_hidden=True) == (
+        "9 : 4"
+    )
+    assert parser._extract_metric_text(
+        visible_only, 0, ["st-opkd"], prefer_hidden=True
+    ) == "5 : 2"
+
+
+def test_pair_metric_without_parenthesized_part_defaults_second_value() -> None:
+    players = _parse_players(_map_soup(tables=_stats_table(rows=_player_row(kills="20"))))
+
+    assert (players[0].kills, players[0].headshots) == (20, 0)
+
+
+def test_secondary_stats_default_to_zero_with_warning_when_unparseable() -> None:
+    row = _player_row(opkd="-", mks="-")
+
+    with mock.patch.object(map_parser_module.logger, "warning") as warning_mock:
+        players = _parse_players(_map_soup(tables=_stats_table(rows=row)))
+
+    player = players[0]
+    assert (player.opening_kills, player.opening_deaths) == (0, 0)
+    assert player.multi_kills == 0
+    warning_mock.assert_any_call(
+        "Could not parse %s from %r; defaulting to 0", "opening duels", "-"
+    )
+    warning_mock.assert_any_call(
+        "Could not parse %s from %r; defaulting to 0", "multi-kills", "-"
+    )

--- a/tests/parsers/test_match_parser_fallbacks.py
+++ b/tests/parsers/test_match_parser_fallbacks.py
@@ -1,0 +1,173 @@
+"""Fixture tests for match parser fallback and error branches.
+
+Each test renders a minimal match page with one field varied so the
+branch under test is the only thing that differs from the happy path.
+"""
+
+from typing import Any, cast
+
+import pytest
+from bs4 import BeautifulSoup
+
+from cs2_analytics.exceptions import MatchParseError
+from cs2_analytics.parsers.match_parser import MatchParser
+
+MATCH_URL = "https://www.hltv.org/matches/123456/test-match"
+
+
+def _match_soup(
+    *,
+    team1: str = "Team One",
+    team2: str = "Team Two",
+    match_type: str = "Best of 3",
+    map_name: str = "Inferno",
+    results_href: str = "/stats/matches/mapstatsid/2/test-map",
+    extra: str = "",
+) -> BeautifulSoup:
+    html = f"""
+    <html>
+      <body>
+        <div class="teamName">{team1}</div>
+        <div class="teamName">{team2}</div>
+        <div class="team1-gradient">
+          <a href="/team/1/team-one">{team1}</a>
+          <div>16</div>
+        </div>
+        <div class="team2-gradient">
+          <a href="/team/2/team-two">{team2}</a>
+          <div>10</div>
+        </div>
+        <div class="event text-ellipsis">Test Event</div>
+        <div class="padding preformatted-text">{match_type}</div>
+        <div class="mapname">{map_name}</div>
+        <div class="date" data-unix="1704067200000"></div>
+        <a class="results-stats" href="{results_href}"></a>
+        {extra}
+      </body>
+    </html>
+    """
+    return BeautifulSoup(html, "html.parser")
+
+
+class _BrokenSoup:
+    """Stands in for a soup whose tree walking blows up mid-extraction."""
+
+    def find(self, *args: Any, **kwargs: Any) -> None:
+        raise AttributeError("broken markup")
+
+    def find_all(self, *args: Any, **kwargs: Any) -> None:
+        raise AttributeError("broken markup")
+
+
+def test_parse_match_wraps_unexpected_errors_as_parse_error() -> None:
+    parser = MatchParser()
+
+    with pytest.raises(
+        MatchParseError, match="Failed to parse match page"
+    ) as exc_info:
+        parser.parse_match(None, MATCH_URL)
+
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+
+
+def test_parse_match_rejects_blank_team_names() -> None:
+    parser = MatchParser()
+
+    with pytest.raises(MatchParseError, match="Missing team names on match page."):
+        parser.parse_match(_match_soup(team1="", team2="Team Two"), MATCH_URL)
+
+
+def test_parse_match_extracts_demo_link_from_stream_box() -> None:
+    parser = MatchParser()
+    soup = _match_soup(
+        extra='<a class="stream-box" data-demo-link="/download/demo/98765"></a>'
+    )
+
+    _, _, demo_links = parser.parse_match(soup, MATCH_URL)
+
+    assert demo_links == [("98765", "https://www.hltv.org/download/demo/98765")]
+
+
+def test_demo_link_extraction_wraps_broken_markup() -> None:
+    parser = cast(Any, MatchParser())
+
+    with pytest.raises(
+        MatchParseError, match="Invalid demo link markup on match page."
+    ) as exc_info:
+        parser._extract_demo_links(_BrokenSoup())
+
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+
+
+def test_map_link_extraction_wraps_broken_markup() -> None:
+    parser = cast(Any, MatchParser())
+
+    with pytest.raises(
+        MatchParseError, match="Invalid map link markup on match page."
+    ) as exc_info:
+        parser._extract_map_stats_links(_BrokenSoup())
+
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+
+
+def test_extract_id_returns_url_when_it_has_no_digits() -> None:
+    parser = cast(Any, MatchParser())
+
+    assert parser._extract_id("https://www.hltv.org/download/demo/pending") == (
+        "https://www.hltv.org/download/demo/pending"
+    )
+
+
+def test_parse_match_rejects_map_link_without_numeric_id() -> None:
+    parser = MatchParser()
+    soup = _match_soup(results_href="/stats/matches/mapstatsid/pending/test-map")
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract numeric id from URL."
+    ):
+        parser.parse_match(soup, MATCH_URL)
+
+
+def test_parse_match_rejects_blank_match_type() -> None:
+    parser = MatchParser()
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match type from match page."
+    ):
+        parser.parse_match(_match_soup(match_type=""), MATCH_URL)
+
+
+@pytest.mark.parametrize(
+    ("match_type_text", "expected"),
+    [
+        ("Best of 5", "bo5"),
+        ("Best of 1", "bo1"),
+        ("Best of 3", "bo3"),
+    ],
+)
+def test_parse_match_normalizes_best_of_variants(
+    match_type_text: str, expected: str
+) -> None:
+    parser = MatchParser()
+
+    match, _, _ = parser.parse_match(_match_soup(match_type=match_type_text), MATCH_URL)
+
+    assert match.match_type == expected
+
+
+def test_parse_match_rejects_unknown_best_of_text() -> None:
+    parser = MatchParser()
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract match type from match page."
+    ):
+        parser.parse_match(_match_soup(match_type="Best of 7"), MATCH_URL)
+
+
+def test_parse_match_rejects_blank_map_name_for_forfeit_status() -> None:
+    parser = MatchParser()
+
+    with pytest.raises(
+        MatchParseError, match="Failed to extract forfeit status from match page."
+    ):
+        parser.parse_match(_match_soup(map_name=""), MATCH_URL)


### PR DESCRIPTION
## Summary

Makes the coverage number honest and raises the enforced floor to 85. The previous total averaged in 143 statements that no unit test can reach (Alembic env and migrations, the legacy pipeline entrypoint), which hid the real gaps in parser fallback branches. Those branches now have fixture tests, and the non-unit-testable modules are omitted from measurement.

## Related Issue

Closes #177

## Scope

- `pyproject.toml`: `[tool.coverage.run] omit` adds `*/cs2_analytics/alembic/*` and `*/cs2_analytics/pipeline/*` (the latter tied to its removal in #181); `fail_under` raised from 80 to 85 with the measured total recorded in the comment.
- `tests/parsers/test_map_parser_fallbacks.py` (26 tests): generic exception wrap, missing parent match id, no stats tables, plain `stats-table` fallback with hidden tables skipped, tables without tbody, rows without cells, both map-name failure paths, data-unix date path and its failure, date without time, missing date, all score/team failure paths including the Breakdown marker, map-order inference from mapstats links plus the URL fallback and the missing case, blank headers and default column indexes, out-of-range index fallback, hidden-cell fallback, prefer-hidden ordering, single-number pairs, unparseable secondary stats defaulting to zero with a warning.
- `tests/parsers/test_match_parser_fallbacks.py` (13 tests): generic exception wrap, blank team names, demo link extraction, broken demo and map link markup, non-numeric id handling, blank match type, bo1/bo3/bo5 normalization, unknown best-of text, blank map name for forfeit status.
- `docs/backlog.md`: #177 Phase 5 item marked done with implementation notes.

## Out of Scope

- No scraper or DB-backed test work (other Phase 5 issues).
- No driver/connection branches that need a live browser.
- No parser behavior changes; the dash-placeholder ADR bug in #202 is untouched.
- Removing `main.py` and `cs2_analytics/pipeline/` (#181).

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: Test and tooling only. No runtime code changes. The only behavioral effect is on CI, which now fails below 85% instead of 80%, and the measured total is well above the new floor.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Update not needed

Reason: No architecture, setup, config, schema, API, pipeline, or workflow rule changed. `docs/workflow.md` already describes the gate generically as "the coverage floor set by `fail_under` in `pyproject.toml`", so it stays accurate. The README carries only the coverage badge, which reads the measured value from the badges branch.

Backlog: Updated

Reason: This branch completes the #177 Phase 5 checklist item; `docs/backlog.md` flips it to done and records what was omitted, which tests were added, and the measured total behind the new floor.

## Verification

Commands run:

- `docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db`
- `uv run pytest --cov`
- `uv run ruff check cs2_analytics api main.py run_api.py manage_db.py --select E,F --ignore E501`
- `uv run mypy cs2_analytics api/main.py api/routes api/schemas api/services main.py run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip`

Results:

- pytest: 350 passed, 0 skipped (DB-backed tests ran against the local compose database). Total coverage 94.04% at the new `fail_under = 85`. Without the DB-backed tests the total is 90.68%, still above the floor.
- map_parser 100%, match_parser 99% (remaining line is a regex guard that cannot fail).
- ruff: all checks passed. mypy: no issues in 61 source files.

## Review Notes

- The pipeline omit is deliberately temporary: drop it along with the package in #181.
- Fixture tests build pages from small helpers (`_player_row`, `_stats_table`, `_map_soup`, `_match_soup`) so each test varies exactly one thing. Two tests call private helpers directly (`_extract_map_team_scores` without an info box, `_extract_metric_text` with `prefer_hidden=True`) because no public path reaches those branches; that matches the existing `cast(Any, MapParser())` pattern in the regression tests.
