### PR TITLE
Parse the ADR dash placeholder as a missing value instead of rejecting the map (#202)

### DIFF
--- a/cs2_analytics/models/player.py
+++ b/cs2_analytics/models/player.py
@@ -26,7 +26,7 @@ class Player:
     clutches_won: int
     kast: float
     kd_diff: int
-    adr: float
+    adr: float | None
     fk_diff: int
     round_swing: float
     rating: float
@@ -35,7 +35,7 @@ class Player:
     last_updated_at: datetime
     data_complete: bool
 
-    def to_dict(self) -> dict[str, int | str | bool | float | datetime]:
+    def to_dict(self) -> dict[str, int | str | bool | float | datetime | None]:
         """Converts the Player object to a dictionary."""
         return {
             "map_id": self.map_id,

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import re
 from dataclasses import dataclass
+from typing import TypedDict
 
 from cs2_analytics.exceptions import MapParseError
 from cs2_analytics.models.map import Map
@@ -10,6 +11,28 @@ from cs2_analytics.models.player import Player
 from cs2_analytics.utils.log_manager import get_logger
 
 logger = get_logger(__name__)
+
+# Cell text the source renders when it has no figure for a metric.
+MISSING_METRIC_PLACEHOLDERS = frozenset({"-", "\u2013", "\u2014"})
+
+
+class _PlayerStats(TypedDict):
+    """Per-row metrics parsed from a stats table; only adr is optional."""
+
+    kills: int
+    headshots: int
+    assists: int
+    flash_assists: int
+    deaths: int
+    traded_deaths: int
+    opening_kills: int
+    opening_deaths: int
+    multi_kills: int
+    clutches_won: int
+    round_swing: float
+    kast: float
+    adr: float | None
+    rating: float
 
 
 @dataclass(frozen=True)
@@ -247,7 +270,7 @@ class MapParser:
 
     def _extract_player_stats(
         self, cols, column_indexes: dict[str, int]
-    ) -> dict[str, int | float]:
+    ) -> _PlayerStats:
         """Extracts parsed combat and utility stats from a player row."""
         kills, headshots = self._extract_kills(cols, column_indexes["kills"])
         assists, flash_assists = self._extract_assists(cols, column_indexes["assists"])
@@ -333,14 +356,22 @@ class MapParser:
         except ValueError as e:
             raise MapParseError(f"Failed to parse KAST value: {kast_text!r}") from e
 
-    def _extract_adr(self, cols, adr_idx: int) -> float:
-        """Extracts ADR as a float value."""
+    def _extract_adr(self, cols, adr_idx: int) -> float | None:
+        """Extracts ADR as a float, or None for the source's dash placeholder.
+
+        The source renders a dash instead of a damage figure when it has
+        none for a player (observed for a player substituted out early on
+        map 221392, #202). That is a missing value, not a parse failure;
+        any other non-numeric text still raises.
+        """
         adr_text = self._extract_metric_text(
             cols,
             adr_idx,
             ["st-adr"],
             prefer_hidden=False,
         )
+        if adr_text.strip() in MISSING_METRIC_PLACEHOLDERS:
+            return None
         try:
             return float(adr_text)
         except ValueError as e:
@@ -369,7 +400,7 @@ class MapParser:
         player_url: str,
         map_name: str,
         team_name: str,
-        stats: dict[str, int | float],
+        stats: _PlayerStats,
     ) -> Player:
         """Builds a Player model from a parsed row."""
         now = dt.datetime.now(dt.UTC)
@@ -397,7 +428,7 @@ class MapParser:
             clutches_won=int(stats["clutches_won"]),
             kast=float(stats["kast"]),
             kd_diff=kills - deaths,
-            adr=float(stats["adr"]),
+            adr=stats["adr"],
             fk_diff=opening_kills - opening_deaths,
             round_swing=float(stats["round_swing"]),
             rating=float(stats["rating"]),

--- a/cs2_analytics/parsers/map_parser.py
+++ b/cs2_analytics/parsers/map_parser.py
@@ -17,7 +17,10 @@ MISSING_METRIC_PLACEHOLDERS = frozenset({"-", "\u2013", "\u2014"})
 
 
 class _PlayerStats(TypedDict):
-    """Per-row metrics parsed from a stats table; only adr is optional."""
+    """Per-row metrics parsed from a stats table.
+
+    Every key is always present; only the adr value may be None (#202).
+    """
 
     kills: int
     headshots: int

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -21,6 +21,11 @@ Current implementation note:
 - No lifecycle-state transitions
 - No storage writes
 - Raise typed parse exceptions with specific helper-level messages
+- Treat the source's dash placeholder as a missing value, not a parse
+  failure, for metrics the source can leave blank: ADR parses to `None`
+  (stored as NULL) when a player was substituted mid-map and has no damage
+  figure (#202). Any other non-numeric text still raises. KAST and rating
+  stay strict until a placeholder is observed in those columns
 
 ## Stage Services
 

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -47,7 +47,10 @@ current codebase.
 
 #### `players`
 
-Grain: one row per player per map.
+Grain: one row per player per map. A map can carry more than ten rows
+when a player is substituted mid-map (both players appear), so consumers
+must count players rather than assume five per team. `adr` is NULL when
+the source shows a dash placeholder for that player (#202).
 
 - `map_id`, `player_id` (composite PK)
 - `player_name`, `player_url`, `map_name`, `team_name`

--- a/tests/parsers/test_map_parser_fallbacks.py
+++ b/tests/parsers/test_map_parser_fallbacks.py
@@ -416,3 +416,33 @@ def test_secondary_stats_default_to_zero_with_warning_when_unparseable() -> None
     warning_mock.assert_any_call(
         "Could not parse %s from %r; defaulting to 0", "multi-kills", "-"
     )
+
+
+@pytest.mark.parametrize("placeholder", ["-", "–", "—"])
+def test_adr_dash_placeholder_parses_as_missing_and_keeps_the_row(
+    placeholder: str,
+) -> None:
+    rows = _player_row() + _player_row(
+        player_id=5678, name="SubbedOut", adr=placeholder, kills="0 (0)", deaths="3 (0)"
+    )
+
+    players = _parse_players(_map_soup(tables=_stats_table(rows=rows)))
+
+    assert [player.player_name for player in players] == ["TestPlayer", "SubbedOut"]
+    assert players[0].adr == 95.2
+    assert players[1].adr is None
+    assert (players[1].kills, players[1].deaths, players[1].rating) == (0, 3, 1.24)
+
+
+def test_adr_non_numeric_text_other_than_the_placeholder_still_raises() -> None:
+    row = _player_row(adr="N/A")
+
+    with pytest.raises(MapParseError, match="Failed to parse ADR value: 'N/A'"):
+        _parse_players(_map_soup(tables=_stats_table(rows=row)))
+
+
+def test_adr_missing_cell_still_raises() -> None:
+    row = _player_row().replace('<td class="st-adr">95.2</td>', '<td class="st-adr"></td>')
+
+    with pytest.raises(MapParseError, match="Failed to parse ADR value: ''"):
+        _parse_players(_map_soup(tables=_stats_table(rows=row)))

--- a/tests/storage/test_player_storage.py
+++ b/tests/storage/test_player_storage.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -136,3 +137,17 @@ def test_store_players_wraps_database_factory_failures(
 
     with pytest.raises(PlayerStorageError, match="Failed to store player records."):
         player_storage_module.store_players([_player()])
+
+
+def test_store_players_binds_null_for_missing_adr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _RecordingCursor()
+    monkeypatch.setattr(player_storage_module, "get_db", lambda: _FakeDb(cursor))
+    player = replace(_player(), adr=None)
+
+    player_storage_module.store_players([player])
+
+    _query, values = cursor.executed[0]
+    assert values[0]["adr"] is None
+    assert player.to_dict()["adr"] is None


### PR DESCRIPTION
## Summary

A dash in a player's ADR cell now parses as a missing value (`None`, stored as NULL) instead of raising `MapParseError` and rejecting the whole map. The source shows the dash when it has no damage figure for a player, observed on map 221392 (match 2391079) where a player was substituted out early. Before this change the map record and all eleven player rows were dropped and the map sat in `failed`.

## Related Issue

Closes #202

## Scope

- `cs2_analytics/parsers/map_parser.py`: `_extract_adr` returns `float | None`; hyphen, en dash, and em dash (`MISSING_METRIC_PLACEHOLDERS`) map to `None`; any other non-numeric text, including an empty cell, still raises. The parsed row is a `_PlayerStats` TypedDict so `adr` can be optional while every other metric stays required under mypy. `_build_player` passes `adr` through unchanged.
- `cs2_analytics/models/player.py`: `Player.adr` is `float | None`; `to_dict` admits `None`.
- `tests/parsers/test_map_parser_fallbacks.py`: the three dash forms each yield a stored row with `adr is None` and the other metrics intact next to a normal row; `N/A` still raises; an empty cell still raises.
- `tests/storage/test_player_storage.py`: a player with `adr=None` binds NULL in the upsert parameters and `to_dict` passes `None` through.
- `docs/conventions.md`: parsers treat the placeholder as a missing value for ADR; other text still raises; KAST and rating stay strict until a placeholder is observed.
- `docs/database_schema.md`: a map can carry more than ten player rows after a substitution, so consumers must count players rather than assume five per team; `adr` is NULL on the placeholder.

## Out of Scope

- Retry policy and which exceptions are retryable are unchanged.
- KAST and rating stay strict. No placeholder has been observed in those columns; the row that triggered this bug had both populated.
- Other player metrics stay required.
- Storage and SQL are unchanged: `players.adr` was already nullable in `schema.sql` and the initial migration, and the row mapping already binds the attribute directly.
- dbt is unchanged: there is no `not_null` on `adr`, the mart's `accepted_range` warning skips nulls (`not NULL >= 0` is NULL in the installed `dbt_utils` macro), and every model passes the column through untouched.
- The production reprocessing of map 221392 (`cs2a retry`) is a production write and is left for after merge.

## Risk Level

Select exactly one: `Low`, `Medium`, or `High`.

Risk level: Low

Reason: The only behavior change is that a specific placeholder string in one column produces NULL instead of a parse failure. Every other input takes the same path as before, the column was already nullable end to end, and the change is covered by parser and storage tests.

## Architecture And Roadmap Check

- [x] Controllers still own batch coordination, retry policy, scraper reset/rotation, summaries, and retry exhaustion.
- [x] Stage services still own per-item fetch, parse, persist, and lifecycle outcomes.
- [x] Scrapers fetch only.
- [x] Parsers parse only.
- [x] Storage modules centralize relational writes.
- [x] Pipelines remain thin.
- [x] No ingestion responsibilities moved into dbt.
- [x] No dbt, Airflow, CT/T splits, eco-adjusted stats, or demo expansion added unless explicitly requested.
- [x] Schema changes, if any, follow the current schema ownership rule for this phase.

## Documentation Check

Select exactly one: `Updated` or `Update not needed`.

Documentation: Updated

Reason: The parser now has a documented rule for a placeholder value, and downstream consumers need to know `adr` can be NULL and that a map can have more than ten player rows. `docs/conventions.md` and `docs/database_schema.md` carry both notes.

Backlog: Update not needed

Reason: #202 is a bug filed after the Phase 5 list was committed and has no backlog entry; it does not change phase status, checklist status, or branch sequencing.

## Verification

Commands run:

- `docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db` then `uv run pytest --cov`, then `down`
- `uv run pytest --cov` without the database
- `uv run ruff check cs2_analytics api run_api.py manage_db.py tests --select E,F --ignore E501`
- `uv run mypy cs2_analytics api/main.py api/routes api/schemas api/services run_api.py manage_db.py --ignore-missing-imports --follow-imports=skip`
- `uv run mypy tests/parsers/test_map_parser_fallbacks.py tests/storage/test_player_storage.py --ignore-missing-imports`

Results:

- pytest with the local test DB: 356 passed, 0 skipped. Total coverage 94.09% at `fail_under = 85`.
- pytest without the DB: 318 passed, 38 skipped, 90.81%.
- ruff: all checks passed. mypy: no issues in 58 source files; the touched tests are clean with imports followed.
- Not run: `dbt build`, since no dbt model or test changed (see Out of Scope for why NULL is tolerated).

## Review Notes

- The TypedDict is the smallest change that keeps mypy strict about the required metrics while allowing one optional field; the alternative of widening the dict value type to include `None` would have required a guard on every `int()` cast.
- After merge, the remaining acceptance step is `cs2a retry` on map 221392 against production and confirming eleven player rows with one NULL ADR. That is a deliberate production write and should be run on its own.
